### PR TITLE
fix: resolves some bugs with match statements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "puya"
-version = "0.1.2"
+version = "0.1.3"
 description = "An optimising Python to TEAL compiler"
 authors = ["Algorand Foundation <contact@algorand.foundation>"]
 readme = "README.md"

--- a/src/puya/ir/models.py
+++ b/src/puya/ir/models.py
@@ -438,7 +438,7 @@ class Switch(ControlOp):
 
     @cases.validator
     def _check_cases(self, _attribute: object, cases: dict[Value, BasicBlock]) -> None:
-        if any(case.atype != self.value.atype for case in cases):
+        if not all(case.atype & self.value.atype for case in cases):
             raise CodeError(
                 "Switch cases types mismatch with value to match", self.source_location
             )

--- a/src/puya/ir/optimize/constant_propagation.py
+++ b/src/puya/ir/optimize/constant_propagation.py
@@ -8,6 +8,7 @@ from puya.ir.avm_ops import AVMOp
 from puya.ir.models import Assignment, Intrinsic
 from puya.ir.ssa import TrivialPhiRemover
 from puya.ir.visitor_mutator import IRMutator
+from puya.utils import unique
 
 logger: structlog.typing.FilteringBoundLogger = structlog.get_logger(__name__)
 
@@ -180,7 +181,7 @@ def simplify_conditional_branches(_context: CompileContext, subroutine: models.S
                 block.terminator = models.Goto(
                     source_location=terminator.source_location, target=goto
                 )
-                for target in terminator.targets():
+                for target in unique(terminator.targets()):
                     if target is not goto:
                         remove_target(block, target)
             # TODO: do these belong in constant_propagation?

--- a/src/puyapy-stubs/_primitives.pyi
+++ b/src/puyapy-stubs/_primitives.pyi
@@ -69,7 +69,6 @@ class UInt64:
     def __ior__(self, other: UInt64 | int) -> UInt64: ...
     # ~
     def __invert__(self) -> UInt64: ...
-    # used to turn this into an index e.g. to a list
 
 class Bytes(t.Iterable[Bytes]):
     @t.overload


### PR DESCRIPTION
- fix bug in constant propagation with duplicate target blocks
- fix bug in IR validation of switch, where atype was compared with == instead of &
- remove floating dead comment
- manually bump version number