### PR TITLE
fix: relax docstring-parser version constraint for now

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2665,4 +2665,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "35f0b89e91f176f1f714477f384fb071e7b64f5f2a50c9b05dfeea8b5e020136"
+content-hash = "fbe7d856c4a8277dfab4783f6f7569f7554b613f93e779d53e4b5dfbfedc6c4b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ typing-extensions = "^4.8.0"
 attrs = "^23.1.0"
 structlog = "^23.2.0"
 networkx = "^3.1"
-docstring-parser = "^0.15"
+docstring-parser = ">=0.14.1"
 pycryptodomex = ">=3.6.0,<4"
 immutabledict = "^4.0.0"
 # vendored mypy dependencies


### PR DESCRIPTION
This allows PyTEAL and Puya to be installed in the same venv for now, for those looking to test it out that way in their existing projects.