### PR TITLE
feature: Allow teal output annotations to be specified in a command line parameter `--annotations 31`

### DIFF
--- a/examples/amm/puya.log
+++ b/examples/amm/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['amm'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['amm'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/examples/auction/puya.log
+++ b/examples/auction/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['auction'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['auction'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/examples/calculator/puya.log
+++ b/examples/calculator/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['calculator'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['calculator'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/examples/global_state/puya.log
+++ b/examples/global_state/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['global_state'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['global_state'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/examples/hello_world/puya.log
+++ b/examples/hello_world/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['hello_world'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['hello_world'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/examples/local_state/puya.log
+++ b/examples/local_state/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['local_state'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['local_state'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/examples/voting/puya.log
+++ b/examples/voting/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['voting'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['voting'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/src/puya/__main__.py
+++ b/src/puya/__main__.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from puya.compile import compile_to_teal
 from puya.logging_config import LogLevel, configure_logging
-from puya.options import PuyaOptions
+from puya.options import PuyaOptions, TealAnnotatorOption
 
 
 def main() -> None:
@@ -88,6 +88,12 @@ def main() -> None:
         "--log-level",
         type=LogLevel.from_string,
         choices=list(LogLevel),
+    )
+    parser.add_argument(
+        "--annotations",
+        type=TealAnnotatorOption.from_string,
+        help="combine multiple options as bit flags",
+        default=False,
     )
 
     parser.add_argument("paths", type=Path, nargs="+", metavar="PATH")

--- a/src/puya/options.py
+++ b/src/puya/options.py
@@ -1,9 +1,22 @@
 from collections.abc import Sequence
+from enum import IntFlag
 from pathlib import Path
 
 import attrs
 
 from puya.logging_config import LogLevel
+
+
+class TealAnnotatorOption(IntFlag):
+    op_description = (1 << 0,)
+    stack = (1 << 1,)
+    vla = (1 << 2,)
+    x_stack = (1 << 3,)
+    source_info = 1 << 4
+
+    @staticmethod
+    def from_string(s: str) -> "TealAnnotatorOption":
+        return TealAnnotatorOption(int(s))
 
 
 @attrs.define(kw_only=True)
@@ -22,3 +35,4 @@ class PuyaOptions:
     debug_level: int = 0
     optimization_level: int = 0
     log_level: LogLevel = LogLevel.info
+    annotations: TealAnnotatorOption | None = None

--- a/test_cases/abi_routing/puya.log
+++ b/test_cases/abi_routing/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['abi_routing'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['abi_routing'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/address_constant.puya.log
+++ b/test_cases/address_constant.puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['address_constant.py'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['address_constant.py'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/application/puya.log
+++ b/test_cases/application/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['application'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['application'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/arc4_types/puya.log
+++ b/test_cases/arc4_types/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['arc4_types'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['arc4_types'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 arc4_types/array.py:71:9 warning: expression result is ignored
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13

--- a/test_cases/asset/puya.log
+++ b/test_cases/asset/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['asset'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['asset'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/augmented_assignment/puya.log
+++ b/test_cases/augmented_assignment/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['augmented_assignment'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['augmented_assignment'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/avm_types_in_abi/puya.log
+++ b/test_cases/avm_types_in_abi/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['avm_types_in_abi'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['avm_types_in_abi'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/biguint_binary_ops/puya.log
+++ b/test_cases/biguint_binary_ops/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['biguint_binary_ops'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['biguint_binary_ops'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/boolean_binary_ops/puya.log
+++ b/test_cases/boolean_binary_ops/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['boolean_binary_ops'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['boolean_binary_ops'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/byte_constants.puya.log
+++ b/test_cases/byte_constants.puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['byte_constants.py'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['byte_constants.py'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/bytes_ops/puya.log
+++ b/test_cases/bytes_ops/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['bytes_ops'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['bytes_ops'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/callsub/puya.log
+++ b/test_cases/callsub/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['callsub'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['callsub'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/chained_assignment/puya.log
+++ b/test_cases/chained_assignment/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['chained_assignment'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['chained_assignment'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/conditional_execution/puya.log
+++ b/test_cases/conditional_execution/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['conditional_execution'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['conditional_execution'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 conditional_execution/contract.py:11:9 warning: expression result is ignored
 conditional_execution/contract.py:17:9 warning: expression result is ignored
 conditional_execution/contract.py:23:9 warning: expression result is ignored

--- a/test_cases/conditional_expressions/puya.log
+++ b/test_cases/conditional_expressions/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['conditional_expressions'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['conditional_expressions'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/contains/puya.log
+++ b/test_cases/contains/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['contains'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['contains'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/edverify/puya.log
+++ b/test_cases/edverify/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['edverify'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['edverify'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/enumeration/puya.log
+++ b/test_cases/enumeration/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['enumeration'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['enumeration'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/everything/puya.log
+++ b/test_cases/everything/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['everything'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['everything'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/koopman/puya.log
+++ b/test_cases/koopman/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['koopman'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['koopman'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/less_simple/puya.log
+++ b/test_cases/less_simple/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['less_simple'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['less_simple'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/match/puya.log
+++ b/test_cases/match/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['match'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['match'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/module_consts/puya.log
+++ b/test_cases/module_consts/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['module_consts'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['module_consts'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/mylib/puya.log
+++ b/test_cases/mylib/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['mylib'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['mylib'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/nested_loops/puya.log
+++ b/test_cases/nested_loops/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['nested_loops'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['nested_loops'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/non_utf8.puya.log
+++ b/test_cases/non_utf8.puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['non_utf8.py'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['non_utf8.py'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/scratch_slots/puya.log
+++ b/test_cases/scratch_slots/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['scratch_slots'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['scratch_slots'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/simple/puya.log
+++ b/test_cases/simple/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['simple'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['simple'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/simplish/puya.log
+++ b/test_cases/simplish/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['simplish'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['simplish'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/ssa/puya.log
+++ b/test_cases/ssa/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['ssa'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['ssa'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/ssa2/puya.log
+++ b/test_cases/ssa2/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['ssa2'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['ssa2'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/string_ops/puya.log
+++ b/test_cases/string_ops/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['string_ops'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['string_ops'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/stubs/puya.log
+++ b/test_cases/stubs/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['stubs'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['stubs'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/transaction/puya.log
+++ b/test_cases/transaction/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['transaction'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['transaction'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/tuple_support.puya.log
+++ b/test_cases/tuple_support.puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['tuple_support.py'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['tuple_support.py'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/unary/puya.log
+++ b/test_cases/unary/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['unary'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['unary'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/undefined_phi_args/puya.log
+++ b/test_cases/undefined_phi_args/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['undefined_phi_args'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['undefined_phi_args'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13
 debug: Looking for 'required_budget_with_buffer' in an unsealed block creating an incomplete Phi: block@1: // while_top_L20

--- a/test_cases/unssa/puya.log
+++ b/test_cases/unssa/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['unssa'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['unssa'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 unssa/contract.py:6:9 warning: expression result is ignored
 unssa/contract.py:13:9 warning: expression result is ignored
 unssa/contract.py:15:9 warning: expression result is ignored

--- a/test_cases/with_reentrancy/puya.log
+++ b/test_cases/with_reentrancy/puya.log
@@ -1,4 +1,4 @@
-debug: PuyaOptions(paths=['with_reentrancy'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>)
+debug: PuyaOptions(paths=['with_reentrancy'], output_teal=True, output_arc32=True, output_awst=False, output_ssa_ir=True, output_optimization_ir=True, output_cssa_ir=True, output_post_ssa_ir=True, output_parallel_copies_ir=True, output_final_ir=True, debug_level=1, optimization_level=1, log_level=<LogLevel.debug: 10>, annotations=None)
 with_reentrancy/contract.py:9:9 warning: expression result is ignored
 debug: Sealing block@0: // L13
 debug: Terminated block@0: // L13


### PR DESCRIPTION
Most developers will only be interested in the source line annotations, as such this PR allows a developer to specify which annotations should be used. 

Currently annotations will apply to all outputted teal. It's possible that we might want to only output annotations in the `*.debug.teal` files