### PR TITLE
fix: Flip the arc4 copy logc so we look for specific nodes rather than exclude an ever growing list of 'safe' nodes

### DIFF
--- a/src/puya/awst_build/subroutine.py
+++ b/src/puya/awst_build/subroutine.py
@@ -719,9 +719,9 @@ class FunctionASTConverter(
             mypy.nodes.GDEF: "global",
             None: "unknown",
         }.get(expr.kind)
-        raise InternalError(
-            f'Unable to resolve reference to "{fullname}" with scope "{scope}"'
-            f" (node = {expr.node})",
+        # this can happen in otherwise well-formed code that is just missing a reference
+        raise CodeError(
+            f"Unable to resolve reference to {fullname or expr.name!r}, {scope=}",
             expr_loc,
         )
 

--- a/src/puya/awst_build/validation/arc4_copy.py
+++ b/src/puya/awst_build/validation/arc4_copy.py
@@ -18,74 +18,13 @@ class ARC4CopyValidator(AWSTTraverser):
             module_statement.accept(validator)
 
     def visit_assignment_statement(self, statement: awst_nodes.AssignmentStatement) -> None:
-        self._check_for_arc4_tuple_destructure(statement.target, statement.value)
+        _check_assignment(statement.target, statement.value)
         statement.value.accept(self)
-        self._check_for_arc4_copy(statement.value, "being assigned to another variable")
 
     def visit_tuple_expression(self, expr: awst_nodes.TupleExpression) -> None:
         super().visit_tuple_expression(expr)
         for item in expr.items:
-            self._check_for_arc4_copy(item, "being passed to a tuple expression")
-
-    @staticmethod
-    def _is_referable_expression(expr: awst_nodes.Expression) -> bool:
-        """
-        Returns True if expr represents something that can be referenced multiple times.
-        """
-        match expr:
-            case (
-                awst_nodes.VarExpression()
-                | awst_nodes.AppStateExpression()
-                | awst_nodes.AppAccountStateExpression()
-            ):
-                return True
-            case (
-                awst_nodes.IndexExpression(base=base_expr)
-                | awst_nodes.TupleItemExpression(base=base_expr)
-            ):
-                return ARC4CopyValidator._is_referable_expression(base_expr)
-        return False
-
-    @staticmethod
-    def _is_arc4_mutable(wtype: wtypes.WType) -> bool:
-        """
-        Returns True if expr represents an arc4 type that is mutable
-        """
-        match wtype:
-            case wtypes.ARC4Type(immutable=False):
-                return True
-        return False
-
-    def _check_for_arc4_tuple_destructure(
-        self, target: awst_nodes.Expression, value: awst_nodes.Expression
-    ) -> None:
-        if not isinstance(target, awst_nodes.TupleExpression):
-            return
-        match value.wtype:
-            case wtypes.WTuple(types=item_types):
-                if self._is_referable_expression(value):
-                    problem_type = next((i for i in item_types if self._is_arc4_mutable(i)), None)
-                    if problem_type:
-                        logger.error(
-                            f"Tuple cannot be destructured as it contains an item of type"
-                            f" {problem_type} which requires copying. Use index access instead",
-                            location=value.source_location,
-                        )
-
-    def _check_for_arc4_copy(self, expr: awst_nodes.Expression, context_desc: str) -> None:
-        if self._is_arc4_mutable(expr.wtype) and self._is_referable_expression(expr):
-            logger.error(
-                f"{expr.wtype} must be copied using .copy() when {context_desc}",
-                location=expr.source_location,
-            )
-
-    @staticmethod
-    def _expand_tuple_items(expr: awst_nodes.Expression) -> Iterator[awst_nodes.Expression]:
-        match expr:
-            case awst_nodes.TupleExpression(items=items):
-                yield from items
-            case _:
-                yield expr
+            _check_for_arc4_copy(item, "being passed to a tuple expression")
 
     def visit_for_in_loop(self, statement: awst_nodes.ForInLoop) -> None:
         if not isinstance(statement.sequence, awst_nodes.Range):
@@ -93,10 +32,8 @@ class ARC4CopyValidator(AWSTTraverser):
         statement.loop_body.accept(self)
 
     def visit_assignment_expression(self, expr: awst_nodes.AssignmentExpression) -> None:
-        self._check_for_arc4_tuple_destructure(expr.target, expr.value)
-
+        _check_assignment(expr.target, expr.value)
         expr.value.accept(self)
-        self._check_for_arc4_copy(expr.value, "being assigned to another variable")
 
     def visit_subroutine_call_expression(self, expr: awst_nodes.SubroutineCallExpression) -> None:
         super().visit_subroutine_call_expression(expr)
@@ -110,15 +47,78 @@ class ARC4CopyValidator(AWSTTraverser):
                     message = "being passed to a subroutine from state"
                 case _:
                     message = "being passed to a subroutine"
-            self._check_for_arc4_copy(arg.value, message)
+            _check_for_arc4_copy(arg.value, message)
 
     def visit_arc4_array_encode(self, expr: awst_nodes.ARC4ArrayEncode) -> None:
         super().visit_arc4_array_encode(expr)
         for v in expr.values:
-            self._check_for_arc4_copy(v, "being passed to an array constructor")
+            _check_for_arc4_copy(v, "being passed to an array constructor")
 
     def visit_arc4_encode(self, expr: awst_nodes.ARC4Encode) -> None:
         super().visit_arc4_encode(expr)
 
-        for item in self._expand_tuple_items(expr.value):
-            self._check_for_arc4_copy(item, "being passed to a constructor")
+        for item in _expand_tuple_items(expr.value):
+            _check_for_arc4_copy(item, "being passed to a constructor")
+
+
+def _is_referable_expression(expr: awst_nodes.Expression) -> bool:
+    """
+    Returns True if expr represents something that can be referenced multiple times.
+    """
+    match expr:
+        case (
+            awst_nodes.VarExpression()
+            | awst_nodes.AppStateExpression()
+            | awst_nodes.AppAccountStateExpression()
+        ):
+            return True
+        case (
+            awst_nodes.IndexExpression(base=base_expr)
+            | awst_nodes.TupleItemExpression(base=base_expr)
+        ):
+            return _is_referable_expression(base_expr)
+    return False
+
+
+def _check_assignment(target: awst_nodes.Expression, value: awst_nodes.Expression) -> None:
+    if not isinstance(target, awst_nodes.TupleExpression):
+        _check_for_arc4_copy(value, "being assigned to another variable")
+    else:
+        match value.wtype:
+            case wtypes.WTuple(types=item_types):
+                if _is_referable_expression(value):
+                    problem_type = next((i for i in item_types if _is_arc4_mutable(i)), None)
+                    if problem_type:
+                        logger.error(
+                            f"Tuple cannot be destructured as it contains an item of type"
+                            f" {problem_type} which requires copying. Use index access instead",
+                            location=value.source_location,
+                        )
+
+
+def _check_for_arc4_copy(expr: awst_nodes.Expression, context_desc: str) -> None:
+    if _is_arc4_mutable(expr.wtype) and _is_referable_expression(expr):
+        logger.error(
+            f"{expr.wtype} must be copied using .copy() when {context_desc}",
+            location=expr.source_location,
+        )
+
+
+def _expand_tuple_items(expr: awst_nodes.Expression) -> Iterator[awst_nodes.Expression]:
+    match expr:
+        case awst_nodes.TupleExpression(items=items):
+            yield from items
+        case _:
+            yield expr
+
+
+def _is_arc4_mutable(wtype: wtypes.WType) -> bool:
+    """
+    Returns True if expr represents an arc4 type that is mutable
+    """
+    match wtype:
+        case wtypes.ARC4Type(immutable=False):
+            return True
+        case wtypes.WTuple(types=types):
+            return any(_is_arc4_mutable(t) for t in types)
+    return False

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1376,3 +1376,18 @@ def test_arc4_tuple_element_mutation(harness: _TestHarness) -> None:
                 return True
 
     harness.deploy_from_closure(test)
+
+
+def test_arc4_copy_in_state(harness: _TestHarness) -> None:
+    def test() -> None:
+        from algopy import GlobalState, arc4
+
+        class MyContract(arc4.ARC4Contract):
+            def __init__(self) -> None:
+                self.g = GlobalState(arc4.Address())
+
+            @arc4.abimethod
+            def okay(self) -> None:
+                pass
+
+    harness.deploy_from_closure(test)

--- a/tests/test_expected_output/arc4.test
+++ b/tests/test_expected_output/arc4.test
@@ -119,7 +119,7 @@ class NotOkay(arc4.ARC4Contract):
 ## case: arc4_copy
 
 import typing
-from algopy import arc4, GlobalState, subroutine
+from algopy import GlobalState, LocalState, Txn, arc4, subroutine
 
 IntArray: typing.TypeAlias = arc4.DynamicArray[arc4.UInt64]
 
@@ -128,6 +128,7 @@ class Arc4CopyContract(arc4.ARC4Contract):
     def __init__(self) -> None:
         self.global_a = IntArray()
         self.global_b = GlobalState(IntArray())
+        self.local = LocalState(IntArray)
 
     @subroutine
     def method_a(self, a: IntArray) -> None:
@@ -136,23 +137,48 @@ class Arc4CopyContract(arc4.ARC4Contract):
     @arc4.abimethod
     def test(self) -> None:
         # Local does not need copy
+
         local_array = IntArray()
         self.method_a(local_array)
+
+        # Require copy when reassigning
+
+        copy1 = local_array ## E: algopy.arc4.DynamicArray[algopy.arc4.UInt64] must be copied using .copy() when being assigned to another variable
+        assert (copy2 := local_array).length, "this isn't ok" ## E: algopy.arc4.DynamicArray[algopy.arc4.UInt64] must be copied using .copy() when being assigned to another variable
+        valid_tuple = (local_array.copy(),)
+        copy3 = valid_tuple[0] ## E: algopy.arc4.DynamicArray[algopy.arc4.UInt64] must be copied using .copy() when being assigned to another variable
+        copy4 = self.global_a ## E: algopy.arc4.DynamicArray[algopy.arc4.UInt64] must be copied using .copy() when being assigned to another variable
+        copy5 = self.global_b.value ## E: algopy.arc4.DynamicArray[algopy.arc4.UInt64] must be copied using .copy() when being assigned to another variable
+
+        # Require copy when building a collection
+
+        my_tuple = (local_array, local_array) ## E: algopy.arc4.DynamicArray[algopy.arc4.UInt64] must be copied using .copy() when being passed to a tuple expression
+        copy_in_tuple = arc4.Tuple(valid_tuple) ## E: tuple[algopy.arc4.DynamicArray[algopy.arc4.UInt64]] must be copied using .copy() when being passed to a constructor
+        copy_in_array1 = arc4.DynamicArray(local_array) ## E: algopy.arc4.DynamicArray[algopy.arc4.UInt64] must be copied using .copy() when being passed to an array constructor
+        copy_in_array2 = arc4.StaticArray(local_array) ## E: algopy.arc4.DynamicArray[algopy.arc4.UInt64] must be copied using .copy() when being passed to an array constructor
 
         # State vars should require copy
 
         self.method_a(self.global_a) ## E: algopy.arc4.DynamicArray[algopy.arc4.UInt64] must be copied using .copy() when being passed to a subroutine from state
         self.method_a(self.global_b.value) ## E: algopy.arc4.DynamicArray[algopy.arc4.UInt64] must be copied using .copy() when being passed to a subroutine from state
+        self.method_a(self.local[Txn.sender]) ## E: algopy.arc4.DynamicArray[algopy.arc4.UInt64] must be copied using .copy() when being passed to a subroutine from state
 
-        # Require copy when building a tuple
+        # Tuple items require a copy when passing
 
-        my_tuple = (local_array, local_array) ## E: algopy.arc4.DynamicArray[algopy.arc4.UInt64] must be copied using .copy() when being passed to a tuple expression
+        self.method_a(valid_tuple[0]) ## E: algopy.arc4.DynamicArray[algopy.arc4.UInt64] must be copied using .copy() when being passed to a subroutine
 
-        # Don't allow destructuring of arc4 containers from tuples
+        # Require copy when reassigning tuple elements
 
         destructured_a, destructured_b = my_tuple ## E: Tuple cannot be destructured as it contains an item of type algopy.arc4.DynamicArray[algopy.arc4.UInt64] which requires copying. Use index access instead
         destructured_a = my_tuple[0] ## E: algopy.arc4.DynamicArray[algopy.arc4.UInt64] must be copied using .copy() when being assigned to another variable
         destructured_b = my_tuple[1] ## E: algopy.arc4.DynamicArray[algopy.arc4.UInt64] must be copied using .copy() when being assigned to another variable
+
+        # Can't create copies by iterating
+        valid_array_of_arrays = arc4.DynamicArray(local_array.copy())
+
+        for an_array in valid_array_of_arrays: ## E: Cannot directly iterate an ARC4 array of mutable objects, construct a for-loop over the indexes via urange(<array>.length) instead
+            assert an_array.length
+
 
 ## case: abi_decorator_not_arc4_contract
 

--- a/tests/test_expected_output/data.py
+++ b/tests/test_expected_output/data.py
@@ -512,7 +512,7 @@ class TestFile(pytest.File):
         # however a ParseError in a single case will effect all cases which is not ideal
         try:
             compile_and_update_cases(self.cases)
-        except PuyaError as ex:
+        except (PuyaError, SystemExit) as ex:
             pytest.fail(f"Unhandled compiler error: {ex}", pytrace=False)
         except BaseException as ex:
             # unexpected error, fail immediately


### PR DESCRIPTION
fixes #179 