### PR TITLE
Feature/add comment to intrinsic

### DIFF
--- a/src/puya/awst/function_traverser.py
+++ b/src/puya/awst/function_traverser.py
@@ -222,9 +222,6 @@ class FunctionTraverser(
     def visit_expression_statement(self, statement: awst_nodes.ExpressionStatement) -> None:
         statement.expr.accept(self)
 
-    def visit_assert_statement(self, statement: awst_nodes.AssertStatement) -> None:
-        statement.condition.accept(self)
-
     def visit_template_var(self, statement: awst_nodes.TemplateVar) -> None:
         pass
 

--- a/src/puya/awst/nodes.py
+++ b/src/puya/awst/nodes.py
@@ -471,6 +471,7 @@ class IntrinsicCall(Expression):
     op_code: str
     immediates: Sequence[str | int] = attrs.field(default=(), converter=tuple[str | int, ...])
     stack_args: Sequence[Expression] = attrs.field(default=(), converter=tuple[Expression, ...])
+    comment: str | None = attrs.field(default=None)
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_intrinsic_call(self)

--- a/src/puya/awst/nodes.py
+++ b/src/puya/awst/nodes.py
@@ -205,15 +205,6 @@ class ContinueStatement(Statement):
 
 
 @attrs.frozen
-class AssertStatement(Statement):
-    condition: Expression = attrs.field(validator=[wtype_is_bool])
-    comment: str | None
-
-    def accept(self, visitor: StatementVisitor[T]) -> T:
-        return visitor.visit_assert_statement(self)
-
-
-@attrs.frozen
 class ReturnStatement(Statement):
     value: Expression | None
 

--- a/src/puya/awst/to_code_visitor.py
+++ b/src/puya/awst/to_code_visitor.py
@@ -395,6 +395,8 @@ class ToCodeVisitor(
         result += "("
         if expr.stack_args:
             result += ", ".join([stack_arg.accept(self) for stack_arg in expr.stack_args])
+        if expr.comment:
+            result += f', comment="{expr.comment}"'
         result += ")"
         return result
 

--- a/src/puya/awst/to_code_visitor.py
+++ b/src/puya/awst/to_code_visitor.py
@@ -533,13 +533,6 @@ class ToCodeVisitor(
             statement.expr.accept(self),
         ]
 
-    def visit_assert_statement(self, statement: nodes.AssertStatement) -> list[str]:
-        condition = statement.condition.accept(self)
-        if statement.comment is None:
-            return [f"assert({condition})"]
-        else:
-            return [f'assert({condition}, comment="{statement.comment}")']
-
     def visit_uint64_augmented_assignment(
         self, statement: nodes.UInt64AugmentedAssignment
     ) -> list[str]:

--- a/src/puya/awst/visitors.py
+++ b/src/puya/awst/visitors.py
@@ -35,9 +35,6 @@ class StatementVisitor(t.Generic[T], ABC):
     def visit_expression_statement(self, statement: puya.awst.nodes.ExpressionStatement) -> T: ...
 
     @abstractmethod
-    def visit_assert_statement(self, statement: puya.awst.nodes.AssertStatement) -> T: ...
-
-    @abstractmethod
     def visit_uint64_augmented_assignment(
         self, statement: puya.awst.nodes.UInt64AugmentedAssignment
     ) -> T: ...

--- a/src/puya/awst_build/intrinsic_factory.py
+++ b/src/puya/awst_build/intrinsic_factory.py
@@ -136,3 +136,15 @@ def zero_address(
         immediates=["ZeroAddress"],
         source_location=loc,
     )
+
+
+def assert_(
+    *, condition: Expression, comment: str | None, source_location: SourceLocation
+) -> IntrinsicCall:
+    return IntrinsicCall(
+        wtype=wtypes.void_wtype,
+        stack_args=[condition],
+        op_code="assert",
+        source_location=source_location,
+        comment=comment,
+    )

--- a/src/puya/ir/arc4_router.py
+++ b/src/puya/ir/arc4_router.py
@@ -110,10 +110,12 @@ def has_app_args(location: SourceLocation) -> awst_nodes.Expression:
 
 
 def reject(location: SourceLocation) -> awst_nodes.Statement:
-    return awst_nodes.AssertStatement(
-        source_location=location,
-        condition=awst_nodes.BoolConstant(source_location=location, value=False),
-        comment="reject transaction",
+    return awst_nodes.ExpressionStatement(
+        expr=intrinsic_factory.assert_(
+            source_location=location,
+            condition=awst_nodes.BoolConstant(source_location=location, value=False),
+            comment="reject transaction",
+        )
     )
 
 
@@ -234,7 +236,7 @@ def log_arc4_result(
 
 def assert_create_state(
     config: ARC4MethodConfig, location: SourceLocation
-) -> Sequence[awst_nodes.AssertStatement]:
+) -> Sequence[awst_nodes.Statement]:
     existing_app = has_app_id(location)
     match config.create:
         case ARC4CreateOption.allow:
@@ -249,10 +251,12 @@ def assert_create_state(
         case invalid:
             typing.assert_never(invalid)
     return [
-        awst_nodes.AssertStatement(
-            condition=condition,
-            comment=comment,
-            source_location=location,
+        awst_nodes.ExpressionStatement(
+            expr=intrinsic_factory.assert_(
+                condition=condition,
+                comment=comment,
+                source_location=location,
+            )
         )
     ]
 
@@ -357,10 +361,12 @@ def check_allowed_oca(
     if len(allowed_ocas) > 1:
         oca_desc = f"one of {oca_desc}"
     return (
-        awst_nodes.AssertStatement(
-            condition=condition,
-            comment=f"OnCompletion is {oca_desc}",
-            source_location=location,
+        awst_nodes.ExpressionStatement(
+            expr=intrinsic_factory.assert_(
+                condition=condition,
+                comment=f"OnCompletion is {oca_desc}",
+                source_location=location,
+            )
         ),
     )
 

--- a/src/puya/ir/builder/main.py
+++ b/src/puya/ir/builder/main.py
@@ -377,6 +377,7 @@ class FunctionIRBuilder(
                     args=args,
                     immediates=list(call.immediates),
                     types=wtype_to_ir_types(call.wtype),
+                    comment=call.comment,
                 )
 
     def visit_create_inner_transaction(self, call: awst_nodes.CreateInnerTransaction) -> None:


### PR DESCRIPTION
## Proposed Changes

- Adds `comment` property to `IntrinsicCall` node at the awst level so that assertion comments can be passed in
- Removes `AssertStatement` node in favour of using the `IntrinsicCall` node directly as not all front end languages will treat assertions as statements
