### PR TITLE
feature: Refactor awst node for switch blocks to support multiple clauses per block

### DIFF
--- a/src/puya/awst/function_traverser.py
+++ b/src/puya/awst/function_traverser.py
@@ -199,9 +199,10 @@ class FunctionTraverser(
 
     def visit_switch(self, statement: awst_nodes.Switch) -> None:
         statement.value.accept(self)
-        for case, block in statement.cases.items():
-            case.accept(self)
-            block.accept(self)
+        for case_block in statement.cases:
+            for clause in case_block.clauses:
+                clause.accept(self)
+            case_block.block.accept(self)
         if statement.default_case:
             statement.default_case.accept(self)
 

--- a/src/puya/awst/nodes.py
+++ b/src/puya/awst/nodes.py
@@ -173,10 +173,26 @@ class IfElse(Statement):
         return visitor.visit_if_else(self)
 
 
+@attrs.frozen(init=False)
+class SwitchCaseBlock(Node):
+    clauses: Sequence[Expression]
+    block: Block
+
+    def __init__(self, clauses: Sequence[Expression], block: Block):
+        location = block.source_location
+        for c in clauses:
+            location += c.source_location
+
+        if len(clauses) == 0:
+            raise ValueError("SwitchCaseBlock must have at least one clause")
+
+        self.__attrs_init__(clauses=clauses, block=block, source_location=location)
+
+
 @attrs.frozen
 class Switch(Statement):
     value: Expression
-    cases: Mapping[Expression, Block] = attrs.field(converter=immutabledict)
+    cases: Sequence[SwitchCaseBlock] = attrs.field(converter=tuple[SwitchCaseBlock, ...])
     default_case: Block | None
 
     def accept(self, visitor: StatementVisitor[T]) -> T:

--- a/src/puya/awst/to_code_visitor.py
+++ b/src/puya/awst/to_code_visitor.py
@@ -480,13 +480,17 @@ class ToCodeVisitor(
 
     def visit_switch(self, statement: nodes.Switch) -> list[str]:
         match_block = [f"switch ({statement.value.accept(self)}) {{"]
-        for case_value, case_block in statement.cases.items():
-            value = case_value.accept(self)
-            block = case_block.accept(self)
+        for case_block in statement.cases:
+            block = case_block.block.accept(self)
+
+            clauses = [f"case {c.accept(self)}:" for c in case_block.clauses]
+
+            clauses[-1] += " {"
+
             match_block.extend(
                 _indent(
                     [
-                        f"case {value}: {{",
+                        *clauses,
                         *_indent(block),
                         "}",
                     ]

--- a/src/puya/awst_build/subroutine.py
+++ b/src/puya/awst_build/subroutine.py
@@ -35,6 +35,7 @@ from puya.awst.nodes import (
     Subroutine,
     SubroutineArgument,
     Switch,
+    SwitchCaseBlock,
     UInt64Constant,
     VarExpression,
     WhileLoop,
@@ -515,7 +516,7 @@ class FunctionASTConverter(BaseMyPyVisitor[Statement | Sequence[Statement] | Non
         subject_eb = require_instance_builder(stmt.subject.accept(self))
         subject_typ = subject_eb.pytype
         subject = subject_eb.single_eval().resolve()
-        case_block_map = dict[Expression, Block]()
+        case_blocks = list[SwitchCaseBlock]()
         default_block: Block | None = None
         for pattern, guard, block in zip(stmt.patterns, stmt.guards, stmt.bodies, strict=True):
             match pattern, guard:
@@ -523,13 +524,23 @@ class FunctionASTConverter(BaseMyPyVisitor[Statement | Sequence[Statement] | Non
                     case_value_builder_or_literal = case_expr.accept(self)
                     case_value = require_instance_builder(case_value_builder_or_literal).resolve()
                     case_block = self.visit_block(block)
-                    case_block_map[case_value] = case_block
+                    case_blocks.append(
+                        SwitchCaseBlock(
+                            clauses=(case_value,),
+                            block=case_block,
+                        )
+                    )
                 case mypy.patterns.SingletonPattern(value=bool() as bool_literal), None:
                     case_value = BoolConstant(
                         value=bool_literal, source_location=self._location(pattern)
                     )
                     case_block = self.visit_block(block)
-                    case_block_map[case_value] = case_block
+                    case_blocks.append(
+                        SwitchCaseBlock(
+                            clauses=(case_value,),
+                            block=case_block,
+                        )
+                    )
                 case (
                     mypy.patterns.ClassPattern(
                         positionals=[mypy.patterns.ValuePattern(expr=inner_literal_expr)],
@@ -550,7 +561,12 @@ class FunctionASTConverter(BaseMyPyVisitor[Statement | Sequence[Statement] | Non
                         case_value_builder_or_literal, subject_typ
                     ).resolve()
                     case_block = self.visit_block(block)
-                    case_block_map[case_value] = case_block
+                    case_blocks.append(
+                        SwitchCaseBlock(
+                            clauses=(case_value,),
+                            block=case_block,
+                        )
+                    )
                 case mypy.patterns.AsPattern(name=None, pattern=None), None:
                     default_block = self.visit_block(block)
                 case _:
@@ -573,7 +589,7 @@ class FunctionASTConverter(BaseMyPyVisitor[Statement | Sequence[Statement] | Non
             return Switch(
                 source_location=loc,
                 value=subject,
-                cases=case_block_map,
+                cases=case_blocks,
                 default_case=default_block,
             )
         return None

--- a/src/puya/ir/arc4_router.py
+++ b/src/puya/ir/arc4_router.py
@@ -138,11 +138,14 @@ def create_oca_switch(
     return awst_nodes.Switch(
         source_location=location,
         value=on_completion(location),
-        cases={
-            awst_nodes.UInt64Constant(value=oca.value, source_location=location): block
+        cases=[
+            awst_nodes.SwitchCaseBlock(
+                clauses=(awst_nodes.UInt64Constant(value=oca.value, source_location=location),),
+                block=block,
+            )
             for oca, block in block_mapping.items()
             if block is not default_case
-        },
+        ],
         default_case=default_case,
     )
 
@@ -505,7 +508,7 @@ def route_abi_methods(
 ) -> awst_nodes.Block:
     if not methods:
         return create_block(location, "reject_abi_methods", reject(location))
-    method_routing_cases = dict[awst_nodes.Expression, awst_nodes.Block]()
+    method_routing_cases = list[awst_nodes.SwitchCaseBlock]()
     seen_signatures = set[str]()
     for method, config in methods.items():
         abi_loc = config.source_location or location
@@ -539,7 +542,12 @@ def route_abi_methods(
         method_selector_value = awst_nodes.MethodConstant(
             source_location=location, value=arc4_signature
         )
-        method_routing_cases[method_selector_value] = method_routing_block
+        method_routing_cases.append(
+            awst_nodes.SwitchCaseBlock(
+                clauses=(method_selector_value,),
+                block=method_routing_block,
+            )
+        )
     return create_block(
         location,
         "abi_routing",

--- a/src/puya/ir/builder/flow_control.py
+++ b/src/puya/ir/builder/flow_control.py
@@ -66,16 +66,17 @@ def handle_if_else(context: IRFunctionBuildContext, stmt: awst_nodes.IfElse) -> 
 def handle_switch(context: IRFunctionBuildContext, statement: awst_nodes.Switch) -> None:
     case_blocks = dict[Value, BasicBlock]()
     ir_blocks = dict[awst_nodes.Block, BasicBlock]()
-    for value, block in statement.cases.items():
-        ir_value = context.visitor.visit_and_materialise_single(value)
-        case_blocks[ir_value] = lazy_setdefault(
-            ir_blocks,
-            block,
-            lambda b: BasicBlock(
-                source_location=b.source_location,
-                comment=b.description or f"switch_case_{len(ir_blocks)}",
-            ),
-        )
+    for case_block in statement.cases:
+        for clause in case_block.clauses:
+            ir_value = context.visitor.visit_and_materialise_single(clause)
+            case_blocks[ir_value] = lazy_setdefault(
+                ir_blocks,
+                case_block.block,
+                lambda b: BasicBlock(
+                    source_location=b.source_location,
+                    comment=b.description or f"switch_case_{len(ir_blocks)}",
+                ),
+            )
     default_block, next_block = mkblocks(
         statement.source_location,
         (statement.default_case and statement.default_case.description) or "switch_case_default",

--- a/src/puya/ir/models.py
+++ b/src/puya/ir/models.py
@@ -669,7 +669,7 @@ class Switch(ControlOp):
         )
 
     def targets(self) -> Sequence[BasicBlock]:
-        return [*self.cases.values(), *self.default.targets()]
+        return [*unique(self.cases.values()), *self.default.targets()]
 
     @property
     def can_exit(self) -> bool:


### PR DESCRIPTION
## Proposed Changes

JavaScript/TypeScript (and several other languages) allow multiple cases per case block. They also support case fall through. The latter is [discouraged](https://eslint.org/docs/latest/rules/no-fallthrough) as it can often be undesired behaviour leading to a bug. The former however is highly desirable as it leads to terser code.

eg.

```ts
switch(someValue) {
  case 'value1':
  case 'value2':
     return doSomething()
  case 'value3':
     return doSomethingElse()
  default:
     return defaultValue()
```

This PR replaces the `Mapping[Expression, Block]` of the awst `Switch` node with a sequence of `SwitchCaseBlock` nodes which support several clauses to be listed per block in a `Sequence[Expression]`. 

At the IR build level these are mapped out to individual cases which `goto` the same `BasicBlock`. 

A small tweak was required for the IR `Switch` model to return only distinct blocks from its `targets` property.

---

The changes here result in no changes to the output for existing python contracts and I have done some basic testing of multiple clauses by manipulating the awst in the awst_build step but otherwise it's hard to get additional test coverage without hooking up another language front end. 
