### PR TITLE
feature: Include postfix unary operations for uint64 and biguint

### DIFF
--- a/src/puya/awst/function_traverser.py
+++ b/src/puya/awst/function_traverser.py
@@ -289,3 +289,13 @@ class FunctionTraverser(
 
     def visit_box_value_expression(self, expr: awst_nodes.BoxValueExpression) -> None:
         expr.key.accept(self)
+
+    def visit_biguint_postfix_unary_operation(
+        self, expr: awst_nodes.BigUIntPostfixUnaryOperation
+    ) -> None:
+        expr.target.accept(self)
+
+    def visit_uint64_postfix_unary_operation(
+        self, expr: awst_nodes.UInt64PostfixUnaryOperation
+    ) -> None:
+        expr.target.accept(self)

--- a/src/puya/awst/nodes.py
+++ b/src/puya/awst/nodes.py
@@ -1089,6 +1089,12 @@ class UInt64UnaryOperator(enum.StrEnum):
     bit_invert = "~"
 
 
+@enum.unique
+class UInt64PostfixUnaryOperator(enum.StrEnum):
+    increment = "++"
+    decrement = "--"
+
+
 @attrs.frozen
 class UInt64UnaryOperation(Expression):
     op: UInt64UnaryOperator
@@ -1097,6 +1103,32 @@ class UInt64UnaryOperation(Expression):
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_uint64_unary_operation(self)
+
+
+@attrs.frozen
+class UInt64PostfixUnaryOperation(Expression):
+    op: UInt64PostfixUnaryOperator
+    target: Lvalue = attrs.field(validator=[wtype_is_uint64])
+    wtype: WType = attrs.field(default=wtypes.uint64_wtype, init=False)
+
+    def accept(self, visitor: ExpressionVisitor[T]) -> T:
+        return visitor.visit_uint64_postfix_unary_operation(self)
+
+
+@enum.unique
+class BigUIntPostfixUnaryOperator(enum.StrEnum):
+    increment = "++"
+    decrement = "--"
+
+
+@attrs.frozen
+class BigUIntPostfixUnaryOperation(Expression):
+    op: BigUIntPostfixUnaryOperator
+    target: Expression = attrs.field(validator=[wtype_is_biguint])
+    wtype: WType = attrs.field(default=wtypes.biguint_wtype, init=False)
+
+    def accept(self, visitor: ExpressionVisitor[T]) -> T:
+        return visitor.visit_biguint_postfix_unary_operation(self)
 
 
 @attrs.frozen

--- a/src/puya/awst/to_code_visitor.py
+++ b/src/puya/awst/to_code_visitor.py
@@ -600,6 +600,14 @@ class ToCodeVisitor(
     def visit_template_var(self, expr: nodes.TemplateVar) -> str:
         return f"TemplateVar[{expr.wtype}]({expr.name})"
 
+    def visit_biguint_postfix_unary_operation(
+        self, expr: nodes.BigUIntPostfixUnaryOperation
+    ) -> str:
+        return f"{expr.target.accept(self)}{expr.op}"
+
+    def visit_uint64_postfix_unary_operation(self, expr: nodes.UInt64PostfixUnaryOperation) -> str:
+        return f"{expr.target.accept(self)}{expr.op}"
+
 
 def _indent(lines: t.Iterable[str], indent_size: str = "  ") -> t.Iterator[str]:
     yield from (f"{indent_size}{line}" for line in lines)

--- a/src/puya/awst/visitors.py
+++ b/src/puya/awst/visitors.py
@@ -263,3 +263,13 @@ class ExpressionVisitor(t.Generic[T], ABC):
 
     @abstractmethod
     def visit_box_value_expression(self, expr: puya.awst.nodes.BoxValueExpression) -> T: ...
+
+    @abstractmethod
+    def visit_uint64_postfix_unary_operation(
+        self, expr: puya.awst.nodes.UInt64PostfixUnaryOperation
+    ) -> T: ...
+
+    @abstractmethod
+    def visit_biguint_postfix_unary_operation(
+        self, expr: puya.awst.nodes.BigUIntPostfixUnaryOperation
+    ) -> T: ...

--- a/src/puya/ir/builder/main.py
+++ b/src/puya/ir/builder/main.py
@@ -238,6 +238,52 @@ class FunctionIRBuilder(
         else:
             return ValueTuple(expr.source_location, list(result))
 
+    def visit_biguint_postfix_unary_operation(
+        self, expr: awst_nodes.BigUIntPostfixUnaryOperation
+    ) -> TExpression:
+        target_value = self.visit_and_materialise_single(expr.target)
+        rhs = BigUIntConstant(value=1, source_location=expr.source_location)
+        match expr.op:
+            case awst_nodes.BigUIntPostfixUnaryOperator.increment:
+                binary_op = awst_nodes.BigUIntBinaryOperator.add
+            case awst_nodes.BigUIntPostfixUnaryOperator.decrement:
+                binary_op = awst_nodes.BigUIntBinaryOperator.sub
+            case never:
+                typing.assert_never(never)
+
+        new_value = create_biguint_binary_op(binary_op, target_value, rhs, expr.source_location)
+
+        handle_assignment(
+            self.context,
+            target=expr.target,
+            value=new_value,
+            assignment_location=expr.source_location,
+        )
+        return target_value
+
+    def visit_uint64_postfix_unary_operation(
+        self, expr: awst_nodes.UInt64PostfixUnaryOperation
+    ) -> TExpression:
+        target_value = self.visit_and_materialise_single(expr.target)
+        rhs = UInt64Constant(value=1, source_location=expr.source_location)
+        match expr.op:
+            case awst_nodes.UInt64PostfixUnaryOperator.increment:
+                binary_op = awst_nodes.UInt64BinaryOperator.add
+            case awst_nodes.UInt64PostfixUnaryOperator.decrement:
+                binary_op = awst_nodes.UInt64BinaryOperator.sub
+            case never:
+                typing.assert_never(never)
+
+        new_value = create_uint64_binary_op(binary_op, target_value, rhs, expr.source_location)
+
+        handle_assignment(
+            self.context,
+            target=expr.target,
+            value=new_value,
+            assignment_location=expr.source_location,
+        )
+        return target_value
+
     def visit_uint64_binary_operation(self, expr: awst_nodes.UInt64BinaryOperation) -> TExpression:
         left = self.visit_and_materialise_single(expr.left)
         right = self.visit_and_materialise_single(expr.right)


### PR DESCRIPTION
## Proposed Changes

- Adds support for `i++` and `i--` expressions on uint64 and biguint types