### PR TITLE
fix: change total_num_byte_slice return type to UInt64

### DIFF
--- a/stubs/algopy-stubs/_reference.pyi
+++ b/stubs/algopy-stubs/_reference.pyi
@@ -63,7 +63,7 @@ class Account(BytesBacked):
         """
 
     @property
-    def total_num_byte_slice(self) -> Bytes:
+    def total_num_byte_slice(self) -> UInt64:
         """The total number of byte array values allocated by this account in Global and Local States.
 
         ```{note}


### PR DESCRIPTION
## Proposed Changes

- Minor typo in return type of total_num_byte_slice on Account stub 