### PR TITLE
refactor: Change StateDelete node to be an expression

### DIFF
--- a/src/puya/awst/nodes.py
+++ b/src/puya/awst/nodes.py
@@ -1441,10 +1441,11 @@ class StateExists(Expression):
 
 
 @attrs.frozen
-class StateDelete(Statement):
+class StateDelete(Expression):
     field: StorageExpression
+    wtype: WType = attrs.field(default=wtypes.void_wtype, init=False)
 
-    def accept(self, visitor: StatementVisitor[T]) -> T:
+    def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_state_delete(self)
 
 

--- a/src/puya/awst/to_code_visitor.py
+++ b/src/puya/awst/to_code_visitor.py
@@ -594,8 +594,8 @@ class ToCodeVisitor(
     def visit_state_get_ex(self, expr: nodes.StateGetEx) -> str:
         return f"STATE_GET_EX({expr.field.accept(self)})"
 
-    def visit_state_delete(self, statement: nodes.StateDelete) -> list[str]:
-        return [f"STATE_DELETE({statement.field.accept(self)})"]
+    def visit_state_delete(self, statement: nodes.StateDelete) -> str:
+        return f"STATE_DELETE({statement.field.accept(self)})"
 
     def visit_state_get(self, expr: nodes.StateGet) -> str:
         return f"STATE_GET({expr.field.accept(self)}, default={expr.default.accept(self)})"

--- a/src/puya/awst/visitors.py
+++ b/src/puya/awst/visitors.py
@@ -56,9 +56,6 @@ class StatementVisitor(t.Generic[T], ABC):
     def visit_assignment_statement(self, statement: puya.awst.nodes.AssignmentStatement) -> T: ...
 
     @abstractmethod
-    def visit_state_delete(self, statement: puya.awst.nodes.StateDelete) -> T: ...
-
-    @abstractmethod
     def visit_goto(self, statement: puya.awst.nodes.Goto) -> T: ...
 
 
@@ -83,6 +80,9 @@ class ModuleStatementVisitor(t.Generic[T], ABC):
 
 
 class ExpressionVisitor(t.Generic[T], ABC):
+    @abstractmethod
+    def visit_state_delete(self, expr: puya.awst.nodes.StateDelete) -> T: ...
+
     @abstractmethod
     def visit_assignment_expression(self, expr: puya.awst.nodes.AssignmentExpression) -> T: ...
 

--- a/src/puya/awst_build/eb/storage/_common.py
+++ b/src/puya/awst_build/eb/storage/_common.py
@@ -6,6 +6,7 @@ import mypy.nodes
 
 from puya.awst.nodes import (
     BoxValueExpression,
+    ExpressionStatement,
     StateDelete,
     StateGet,
     StateGetEx,
@@ -76,7 +77,9 @@ class BoxValueExpressionBuilder(ValueProxyExpressionBuilder[pytypes.PyType, BoxV
 
     @typing.override
     def delete(self, location: SourceLocation) -> Statement:
-        return StateDelete(field=self.resolve(), source_location=location)
+        return ExpressionStatement(
+            expr=StateDelete(field=self.resolve(), source_location=location)
+        )
 
     @typing.override
     def member_access(self, name: str, location: SourceLocation) -> NodeBuilder:

--- a/src/puya/awst_build/eb/storage/global_state.py
+++ b/src/puya/awst_build/eb/storage/global_state.py
@@ -12,6 +12,7 @@ from puya.awst.nodes import (
     BytesConstant,
     BytesEncoding,
     Expression,
+    ExpressionStatement,
     Not,
     StateDelete,
     StateExists,
@@ -291,4 +292,4 @@ class _Get(_MemberFunction):
 class _Value(ValueProxyExpressionBuilder[pytypes.PyType, AppStateExpression]):
     @typing.override
     def delete(self, location: SourceLocation) -> Statement:
-        return StateDelete(field=self.resolve(), source_location=location)
+        return ExpressionStatement(StateDelete(field=self.resolve(), source_location=location))

--- a/src/puya/awst_build/eb/storage/local_state.py
+++ b/src/puya/awst_build/eb/storage/local_state.py
@@ -12,6 +12,7 @@ from puya.awst.nodes import (
     BytesConstant,
     BytesEncoding,
     Expression,
+    ExpressionStatement,
     IntegerConstant,
     StateDelete,
     StateExists,
@@ -320,4 +321,4 @@ class _Maybe(_MemberFunction):
 
 class _Value(ValueProxyExpressionBuilder[pytypes.PyType, AppAccountStateExpression]):
     def delete(self, location: SourceLocation) -> Statement:
-        return StateDelete(field=self.resolve(), source_location=location)
+        return ExpressionStatement(StateDelete(field=self.resolve(), source_location=location))

--- a/src/puya/ir/builder/main.py
+++ b/src/puya/ir/builder/main.py
@@ -726,7 +726,7 @@ class FunctionIRBuilder(
     def visit_state_get_ex(self, expr: awst_nodes.StateGetEx) -> TExpression:
         return storage.visit_state_get_ex(self.context, expr)
 
-    def visit_state_delete(self, statement: awst_nodes.StateDelete) -> TStatement:
+    def visit_state_delete(self, statement: awst_nodes.StateDelete) -> TExpression:
         return storage.visit_state_delete(self.context, statement)
 
     def visit_state_get(self, expr: awst_nodes.StateGet) -> TExpression:

--- a/src/puya/ir/builder/storage.py
+++ b/src/puya/ir/builder/storage.py
@@ -86,7 +86,9 @@ def visit_state_get_ex(
     )
 
 
-def visit_state_delete(context: IRFunctionBuildContext, statement: awst_nodes.StateDelete) -> None:
+def visit_state_delete(
+    context: IRFunctionBuildContext, statement: awst_nodes.StateDelete
+) -> ValueProvider | None:
     match statement.field:
         case awst_nodes.BoxValueExpression(key=awst_key):
             op = AVMOp.box_del
@@ -109,6 +111,7 @@ def visit_state_delete(context: IRFunctionBuildContext, statement: awst_nodes.St
     context.block_builder.add(
         Intrinsic(op=op, args=args, source_location=statement.source_location)
     )
+    return None
 
 
 def _build_state_get_ex(


### PR DESCRIPTION
## Proposed Changes

- Change StateDelete node to be an expression rather than statement as not all user languages have a `delete` statement with applicable use to this scenario
