### PR TITLE
fix: remove `slice` from `__getitem__` in `algopy.arc4.DynamicArray` and `algopy.arc4.StaticArray`

### DIFF
--- a/stubs/algopy-stubs/arc4.pyi
+++ b/stubs/algopy-stubs/arc4.pyi
@@ -355,7 +355,7 @@ class StaticArray(
     def length(self) -> algopy.UInt64:
         """Returns the current length of the array"""
 
-    def __getitem__(self, index: algopy.UInt64 | int | slice) -> _TArrayItem: ...
+    def __getitem__(self, index: algopy.UInt64 | int) -> _TArrayItem: ...
     def __setitem__(self, index: algopy.UInt64 | int, value: _TArrayItem) -> _TArrayItem: ...
     def copy(self) -> typing.Self:
         """Create a copy of this array"""
@@ -374,7 +374,7 @@ class DynamicArray(_ABIEncoded, typing.Generic[_TArrayItem], Reversible[_TArrayI
     def length(self) -> algopy.UInt64:
         """Returns the current length of the array"""
 
-    def __getitem__(self, index: algopy.UInt64 | int | slice) -> _TArrayItem: ...
+    def __getitem__(self, index: algopy.UInt64 | int) -> _TArrayItem: ...
     def append(self, item: _TArrayItem, /) -> None:
         """Append an item to this array"""
 

--- a/stubs/pyproject.toml
+++ b/stubs/pyproject.toml
@@ -3,7 +3,7 @@ name = "algorand-python"
 # this version represents the version of the stub API's and should follow semver semantics
 # when updating this value also update src/compile.py:MAX_SUPPORTED_ALGOPY_VERSION_EX if it is a major/minor change
 # also see stubs/README.md#versioning
-version = "2.0.0"
+version = "2.0.1"
 description = "API for writing Algorand Python Smart contracts"
 authors = ["Algorand Foundation <contact@algorand.foundation>"]
 readme = "README.md"


### PR DESCRIPTION
This is a bug-fix (stubs don't accurately reflect what is supported) thus only a patch-level version bump.