### PR TITLE
temporarily pin to Python 3.12.6 in CI/CD to get consistent output behaviour

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.12.6"
           cache: "poetry"
 
       - name: Install dependencies

--- a/.github/workflows/check-python.yaml
+++ b/.github/workflows/check-python.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.12.6"
           cache: "poetry"
 
       - name: Install dependencies
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.12.6"
           cache: "poetry"
 
       - name: Install dependencies
@@ -96,7 +96,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.12.6"
           cache: "poetry"
 
       - name: Install dependencies
@@ -123,7 +123,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.12.6"
           cache: "poetry"
 
       - name: Install dependencies

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.12.6"
           cache: "poetry"
 
       - name: Install dependencies

--- a/test_cases/literals/puya.log
+++ b/test_cases/literals/puya.log
@@ -13,7 +13,7 @@ literals/folding.py:49:12 warning: expression is always True
 literals/folding.py:50:17 warning: expression is always False
 literals/folding.py:53:12 warning: due to Python ints being signed, bitwise inversion yield a negative number
 literals/folding.py:80:12 warning: due to Python ints being signed, bitwise inversion yield a negative number
-literals/folding.py:80:12 warning: Bitwise inversion '~' on bool is deprecated. This returns the bitwise inversion of the underlying int object and is usually not what you expect from negating a bool. Use the 'not' operator for boolean negation or ~int(x) if you really want the bitwise inversion of the underlying int.
+literals/folding.py:80:12 warning: Bitwise inversion '~' on bool is deprecated and will be removed in Python 3.16. This returns the bitwise inversion of the underlying int object and is usually not what you expect from negating a bool. Use the 'not' operator for boolean negation or ~int(x) if you really want the bitwise inversion of the underlying int.
 info: writing literals/out/module.awst
 debug: Sealing block@0: // L12
 debug: Terminated block@0: // L12


### PR DESCRIPTION
To get CI/CD working I've temporarily pinned all Actions to Python 3.12.6, apparently a deprecation warning has changed vs 3.12.5, which was included in an approval output. And Actions seems to have only been slowly upgrading each task (probably due to caching?) so output was inconsistent between checks. In general we want the latest patch release, so once that change settles we should remove the explicit patch version again.