### PR TITLE
Make "expected output" tests execute in order within each `.test` file

### DIFF
--- a/src/puyapy/awst_build/context.py
+++ b/src/puyapy/awst_build/context.py
@@ -45,7 +45,7 @@ class ASTConversionContext:
 
     @property
     def mypy_options(self) -> mypy.options.Options:
-        return self._parse_result.manager.options
+        return self._parse_result.mypy_options
 
     def for_module(self, module_path: Path) -> ASTConversionModuleContext:
         return attrs_extend(ASTConversionModuleContext, self, module_path=module_path)

--- a/src/puyapy/awst_build/main.py
+++ b/src/puyapy/awst_build/main.py
@@ -55,9 +55,6 @@ def transform_ast(
     return awst, compilation_set
 
 
-FAKE_ARC4_PATH = Path("/algopy/arc4.py")
-
-
 def _algopy_arc4_module(ctx: ASTConversionContext) -> list[RootNode]:
     from puya.awst import wtypes
     from puya.awst.nodes import (
@@ -70,7 +67,7 @@ def _algopy_arc4_module(ctx: ASTConversionContext) -> list[RootNode]:
         ReturnStatement,
     )
 
-    location = SourceLocation(file=FAKE_ARC4_PATH, line=1)
+    location = SourceLocation(file=Path("/algopy/arc4.py"), line=1)
     _, class_name = constants.ARC4_CONTRACT_BASE.rsplit(".", maxsplit=1)
     cref = ContractReference(constants.ARC4_CONTRACT_BASE)
     ctx.set_state_defs(cref, {})

--- a/src/puyapy/compile.py
+++ b/src/puyapy/compile.py
@@ -106,13 +106,11 @@ def write_arc32_clients(
 def parse_with_mypy(paths: Sequence[Path]) -> ParseResult:
     mypy_options = get_mypy_options()
 
-    # this generates the ASTs from the build sources, and all imported modules (recursively)
-    parse_result = parse_and_typecheck(paths, mypy_options)
-    # Sometimes when we call back into mypy, there might be errors.
-    # We don't want to crash when that happens.
-    parse_result.manager.errors.set_file("<puyapy>", module=None, scope=None, options=mypy_options)
-
-    return parse_result
+    _, ordered_modules = parse_and_typecheck(paths, mypy_options)
+    return ParseResult(
+        mypy_options=mypy_options,
+        ordered_modules=ordered_modules,
+    )
 
 
 def get_mypy_options() -> mypy.options.Options:

--- a/tests/test_transaction_fields.py
+++ b/tests/test_transaction_fields.py
@@ -38,7 +38,7 @@ def _get_type_infos(type_names: Iterable[str]) -> Iterable[mypy.nodes.TypeInfo]:
 
     for type_name in type_names:
         module_id, symbol_name = type_name.rsplit(".", maxsplit=1)
-        module = awst_cache.parse_result.manager.modules[module_id]
+        module = awst_cache.parse_result.ordered_modules[module_id].node
 
         symbol = module.names[symbol_name]
         node = symbol.node

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -73,6 +73,19 @@ class CompilationResult:
     """examples or test_cases path"""
 
 
+def narrowed_parse_result(parse_result: ParseResult, src_path: Path) -> ParseResult:
+    filtered_ordered_modules = {
+        name: sm
+        for name, sm in parse_result.ordered_modules.items()
+        if sm.path.resolve().is_relative_to(src_path.resolve())
+        or sm.discovery_mechanism == SourceDiscoveryMechanism.dependency
+    }
+    return ParseResult(
+        mypy_options=parse_result.mypy_options,
+        ordered_modules=filtered_ordered_modules,
+    )
+
+
 def narrowed_compile_context(
     parse_result: ParseResult,
     src_path: Path,


### PR DESCRIPTION
Refactor expected-output tests to execute in declared order within each `.test file` - useful when debugging.

As part of this, remove mypy BuildManager from ParseResult, which will prevent further coupling of mypy.
