### PR TITLE
unpin Python CI/CD version

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12.6"
+          python-version: "3.12"
           cache: "poetry"
 
       - name: Install dependencies

--- a/.github/workflows/check-python.yaml
+++ b/.github/workflows/check-python.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12.6"
+          python-version: "3.12"
           cache: "poetry"
 
       - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12.6"
+          python-version: "3.12"
           cache: "poetry"
 
       - name: Install dependencies
@@ -98,7 +98,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12.6"
+          python-version: "3.12"
           cache: "poetry"
 
       - name: Install dependencies
@@ -131,7 +131,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12.6"
+          python-version: "3.12"
           cache: "poetry"
 
       - name: Install dependencies

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12.6"
+          python-version: "3.12"
           cache: "poetry"
 
       - name: Install dependencies


### PR DESCRIPTION
revert temporary pinning of Python to 3.12.6 in CI/CD now that GitHub runners appear to have been updated