### PR TITLE
chore: restoring output sourcemaps flag defaults to true

### DIFF
--- a/src/puyapy/__main__.py
+++ b/src/puyapy/__main__.py
@@ -36,7 +36,7 @@ def main() -> None:
     parser.add_argument(
         "--output-source-map",
         action=argparse.BooleanOptionalAction,
-        default=False,
+        default=True,
         help="Output debug source maps",
     )
     parser.add_argument(


### PR DESCRIPTION
## Proposed Changes

- As part of the puya debugging outcome, output source maps flag was introduced with default value set to False. Now that the extension with latest puya sourcemaps is ready for release - this pr re introduces default True value set to the sourcemaps. This is also to unblock generic uses of newer AVM Debugger Extension with existing v6  (utils ts ) and v2 (utils-py) packages on algorand python template. Utils ts v7, ts-debug and debug related utils-py changes along with updates in python template are to be shipped later in coming weeks (as soon as v7 of utils-ts is published on npm). 