### PR TITLE
Fix PyTypes inheritance handling

### DIFF
--- a/examples/sizes.txt
+++ b/examples/sizes.txt
@@ -120,7 +120,7 @@
  transaction/Transaction                       1072     897       -    |        654     512       - 
  tuple_support/NestedTuples                    1259     900     897    |        784     510     509 
  tuple_support/TupleComparisons                 124      67       -    |         81      35       - 
- tuple_support/TupleSupport                     667     405       -    |        375     175       - 
+ tuple_support/TupleSupport                     674     405       -    |        378     175       - 
  typed_abi_call/Greeter                        5040    3977    3968    |       2727    1832    1829 
  typed_abi_call/Logger                         1405    1144    1141    |        822     603     602 
  typed_abi_call_txn/Caller                      580     514       -    |        306     263       - 
@@ -131,4 +131,4 @@
  unssa/UnSSA                                    432     368       -    |        241     204       - 
  voting/VotingRoundApp                         1590    1483       -    |        733     649       - 
  with_reentrancy/WithReentrancy                 255     242       -    |        132     122       - 
- Total                                        70250   54092   54033    |      33494   22056   22012 
+ Total                                        70257   54092   54033    |      33497   22056   22012 

--- a/src/puya/awst/wtypes.py
+++ b/src/puya/awst/wtypes.py
@@ -224,8 +224,6 @@ class WTuple(WType):
 
     @types.validator
     def _types_validator(self, _attribute: object, types: tuple[WType, ...]) -> None:
-        if not types:
-            raise CodeError("empty tuples are not supported", self.source_location)
         if void_wtype in types:
             raise CodeError("tuple should not contain void types", self.source_location)
 

--- a/src/puya/ir/builder/_utils.py
+++ b/src/puya/ir/builder/_utils.py
@@ -74,6 +74,8 @@ def assign_targets(
     targets: list[Register],
     assignment_location: SourceLocation | None,
 ) -> None:
+    if not (source.types or targets):
+        return
     for target in targets:
         context.ssa.write_variable(target.name, context.block_builder.active_block, target)
     context.block_builder.add(

--- a/src/puyapy/awst_build/context.py
+++ b/src/puyapy/awst_build/context.py
@@ -276,7 +276,7 @@ def type_to_pytype(
                     name = func_like.definition.fullname
                 else:
                     name = repr(func_like)
-                if "first_arg" in func_like.def_extras:
+                if func_like.def_extras.get("first_arg"):
                     _self_arg, *func_args = func_args
                 return pytypes.FuncType(
                     name=name,

--- a/src/puyapy/awst_build/eb/_bytes_backed.py
+++ b/src/puyapy/awst_build/eb/_bytes_backed.py
@@ -48,7 +48,9 @@ class _FromBytes(FunctionBuilder):
             args, pytypes.BytesType, location, resolve_literal=True
         )
         result_expr = ReinterpretCast(
-            expr=arg.resolve(), wtype=self.result_type.wtype, source_location=location
+            expr=arg.resolve(),
+            wtype=self.result_type.checked_wtype(location),
+            source_location=location,
         )
         return builder_for_instance(self.result_type, result_expr)
 

--- a/src/puyapy/awst_build/eb/_literals.py
+++ b/src/puyapy/awst_build/eb/_literals.py
@@ -34,7 +34,7 @@ class LiteralBuilderImpl(LiteralBuilder):
         self._value = value
         match value:
             case bool():
-                typ = pytypes.BoolType
+                typ: pytypes.PyType = pytypes.BoolType
             case int():
                 typ = pytypes.IntLiteralType
             case str():

--- a/src/puyapy/awst_build/eb/_utils.py
+++ b/src/puyapy/awst_build/eb/_utils.py
@@ -29,7 +29,7 @@ def dummy_value(pytype: pytypes.PyType, location: SourceLocation) -> InstanceBui
         from puyapy.awst_build.eb._literals import LiteralBuilderImpl
 
         return LiteralBuilderImpl(pytype.python_type(), location)
-    expr = VarExpression(name="", wtype=pytype.wtype, source_location=location)
+    expr = VarExpression(name="", wtype=pytype.checked_wtype(location), source_location=location)
     return builder_for_instance(pytype, expr)
 
 
@@ -79,14 +79,15 @@ def constant_bool_and_error(
 
 def compare_bytes(
     *,
-    lhs: InstanceBuilder,
+    self: InstanceBuilder,
     op: BuilderComparisonOp,
-    rhs: InstanceBuilder,
+    other: InstanceBuilder,
     source_location: SourceLocation,
 ) -> InstanceBuilder:
-    if rhs.pytype != lhs.pytype:
+    # defer to most derived type if not equal
+    if not (other.pytype <= self.pytype):
         return NotImplemented
-    return _compare_expr_bytes_unchecked(lhs.resolve(), op, rhs.resolve(), source_location)
+    return _compare_expr_bytes_unchecked(self.resolve(), op, other.resolve(), source_location)
 
 
 def compare_expr_bytes(

--- a/src/puyapy/awst_build/eb/arc4/bool.py
+++ b/src/puyapy/awst_build/eb/arc4/bool.py
@@ -101,4 +101,4 @@ class ARC4BoolExpressionBuilder(
         if other.pytype == pytypes.BoolType:
             lhs = self._native(self.source_location)
             return lhs.compare(other, op, location)
-        return compare_bytes(lhs=self, op=op, rhs=other, source_location=location)
+        return compare_bytes(self=self, op=op, other=other, source_location=location)

--- a/src/puyapy/awst_build/eb/arc4/dynamic_bytes.py
+++ b/src/puyapy/awst_build/eb/arc4/dynamic_bytes.py
@@ -62,7 +62,9 @@ class DynamicBytesTypeBuilder(BytesBackedTypeBuilder[pytypes.ArrayType]):
                 bytes_expr: Expression = BytesConstant(
                     value=b"", encoding=BytesEncoding.unknown, source_location=location
                 )
-            case [InstanceBuilder(pytype=pytypes.BytesType) as eb]:
+            case [
+                InstanceBuilder(pytype=single_arg_pytype) as eb
+            ] if pytypes.BytesType <= single_arg_pytype:
                 bytes_expr = eb.resolve()
             case _:
                 non_literal_args = tuple(_coerce_to_byte(a).resolve() for a in args)

--- a/src/puyapy/awst_build/eb/arc4/emit.py
+++ b/src/puyapy/awst_build/eb/arc4/emit.py
@@ -32,7 +32,7 @@ class EmitBuilder(FunctionBuilder):
         match first:
             case InstanceBuilder(
                 pytype=pytypes.StructType() as struct_type
-            ) as event_arg_eb if pytypes.ARC4StructBaseType in struct_type.mro:
+            ) as event_arg_eb if pytypes.ARC4StructBaseType < struct_type:
                 event_name = struct_type.name.split(".")[-1]
                 if rest:
                     logger.error(

--- a/src/puyapy/awst_build/eb/arc4/struct.py
+++ b/src/puyapy/awst_build/eb/arc4/struct.py
@@ -26,7 +26,7 @@ logger = log.get_logger(__name__)
 class ARC4StructTypeBuilder(BytesBackedTypeBuilder[pytypes.StructType]):
     def __init__(self, typ: pytypes.PyType, location: SourceLocation):
         assert isinstance(typ, pytypes.StructType)
-        assert pytypes.ARC4StructBaseType in typ.mro
+        assert pytypes.ARC4StructBaseType < typ
         super().__init__(typ, location)
 
     @typing.override
@@ -84,7 +84,7 @@ class ARC4StructExpressionBuilder(
     def compare(
         self, other: InstanceBuilder, op: BuilderComparisonOp, location: SourceLocation
     ) -> InstanceBuilder:
-        return compare_bytes(lhs=self, op=op, rhs=other, source_location=location)
+        return compare_bytes(self=self, op=op, other=other, source_location=location)
 
     def bool_eval(self, location: SourceLocation, *, negate: bool = False) -> InstanceBuilder:
         return constant_bool_and_error(value=True, location=location, negate=negate)

--- a/src/puyapy/awst_build/eb/arc4/ufixed.py
+++ b/src/puyapy/awst_build/eb/arc4/ufixed.py
@@ -135,4 +135,4 @@ class UFixedNxMExpressionBuilder(
         self, other: InstanceBuilder, op: BuilderComparisonOp, location: SourceLocation
     ) -> InstanceBuilder:
         other = other.resolve_literal(UFixedNxMTypeBuilder(self.pytype, other.source_location))
-        return compare_bytes(op=op, lhs=self, rhs=other, source_location=location)
+        return compare_bytes(op=op, self=self, other=other, source_location=location)

--- a/src/puyapy/awst_build/eb/binary_bool_op.py
+++ b/src/puyapy/awst_build/eb/binary_bool_op.py
@@ -120,6 +120,8 @@ class BinaryBoolOpBuilder(InstanceBuilder):
                 " which isn't supported unless evaluating a boolean condition",
                 self.source_location,
             )
+        result_wtype = self.pytype.checked_wtype(self.source_location)
+
         # (left:uint64 and right:uint64) => left_cache if not bool(left_cache := left) else right
         # (left:uint64 or right:uint64) => left_cache if bool(left_cache := left) else right
         left_cache = self._left.single_eval()
@@ -130,7 +132,7 @@ class BinaryBoolOpBuilder(InstanceBuilder):
             condition=condition.resolve(),
             true_expr=left_cache.resolve(),
             false_expr=self._right.resolve(),
-            wtype=self.pytype.wtype,
+            wtype=result_wtype,
             source_location=self.source_location,
         )
         return expr_result

--- a/src/puyapy/awst_build/eb/bool.py
+++ b/src/puyapy/awst_build/eb/bool.py
@@ -79,9 +79,7 @@ class BoolExpressionBuilder(NotIterableInstanceExpressionBuilder):
     def compare(
         self, other: InstanceBuilder, op: BuilderComparisonOp, location: SourceLocation
     ) -> InstanceBuilder:
-        if other.pytype == self.pytype:
-            pass
-        else:
+        if other.pytype != pytypes.BoolType:
             return NotImplemented
         cmp_expr = NumericComparisonExpression(
             source_location=location,
@@ -95,7 +93,7 @@ class BoolExpressionBuilder(NotIterableInstanceExpressionBuilder):
     def bool_binary_op(
         self, other: InstanceBuilder, op: BinaryBooleanOperator, location: SourceLocation
     ) -> InstanceBuilder:
-        if other.pytype != self.pytype:
+        if other.pytype != pytypes.BoolType:
             return super().bool_binary_op(other, op, location)
         result = BooleanBinaryOperation(
             left=self.resolve(),

--- a/src/puyapy/awst_build/eb/bytes.py
+++ b/src/puyapy/awst_build/eb/bytes.py
@@ -156,7 +156,7 @@ class _FromEncodedStr(FunctionBuilder):
         return dummy_value(pytypes.BytesType, location)
 
 
-class BytesExpressionBuilder(InstanceExpressionBuilder):
+class BytesExpressionBuilder(InstanceExpressionBuilder[pytypes.RuntimeType]):
     def __init__(self, expr: Expression):
         super().__init__(pytypes.BytesType, expr)
 
@@ -250,7 +250,7 @@ class BytesExpressionBuilder(InstanceExpressionBuilder):
         self, other: InstanceBuilder, op: BuilderComparisonOp, location: SourceLocation
     ) -> InstanceBuilder:
         other = other.resolve_literal(converter=BytesTypeBuilder(other.source_location))
-        return compare_bytes(lhs=self, op=op, rhs=other, source_location=location)
+        return compare_bytes(self=self, op=op, other=other, source_location=location)
 
     @typing.override
     def binary_op(
@@ -266,7 +266,7 @@ class BytesExpressionBuilder(InstanceExpressionBuilder):
             return NotImplemented
 
         other = other.resolve_literal(converter=BytesTypeBuilder(other.source_location))
-        if other.pytype != self.pytype:
+        if not (pytypes.BytesType <= other.pytype):
             return NotImplemented
 
         lhs = self.resolve()

--- a/src/puyapy/awst_build/eb/conditional_literal.py
+++ b/src/puyapy/awst_build/eb/conditional_literal.py
@@ -34,8 +34,7 @@ class ConditionalLiteralBuilder(InstanceBuilder):
         location: SourceLocation
     ):
         super().__init__(location)
-        assert true_literal.pytype == false_literal.pytype  # TODO: fixme
-        self._pytype = true_literal.pytype
+        self._pytype = _common_base(true_literal.pytype, false_literal.pytype, location)
         self._true_literal = true_literal
         self._false_literal = false_literal
         self._condition = condition
@@ -82,7 +81,7 @@ class ConditionalLiteralBuilder(InstanceBuilder):
     def _resolve_literals(
         self, true_b: InstanceBuilder, false_b: InstanceBuilder
     ) -> InstanceBuilder:
-        assert true_b.pytype == false_b.pytype  # TODO: fixme
+        result_pytype = _common_base(true_b.pytype, false_b.pytype, self.source_location)
         result_pytype = true_b.pytype
         true_expr = true_b.resolve()
         false_expr = false_b.resolve()
@@ -268,3 +267,12 @@ class ConditionalLiteralBuilder(InstanceBuilder):
             condition=condition,
             location=self.source_location,
         )
+
+
+def _common_base(a: pytypes.PyType, b: pytypes.PyType, location: SourceLocation) -> pytypes.PyType:
+    if a <= b:
+        return a
+    elif b < a:
+        return b
+    else:
+        raise CodeError("type mismatch", location)

--- a/src/puyapy/awst_build/eb/contracts.py
+++ b/src/puyapy/awst_build/eb/contracts.py
@@ -126,7 +126,7 @@ def _builder_for_storage_access(
     if not isinstance(typ, pytypes.StorageProxyType | pytypes.StorageMapProxyType):
         app_global_expr = AppStateExpression(
             key=key,
-            wtype=typ.wtype,
+            wtype=typ.checked_wtype(location),
             exists_assertion_message=f"check self.{member_name} exists",
             source_location=location,
         )

--- a/src/puyapy/awst_build/eb/intrinsics.py
+++ b/src/puyapy/awst_build/eb/intrinsics.py
@@ -91,7 +91,7 @@ class IntrinsicNamespaceTypeBuilder(TypeBuilder[pytypes.IntrinsicNamespaceType])
             intrinsic_expr = IntrinsicCall(
                 op_code=mapping.op_code,
                 immediates=[mapping.immediate],
-                wtype=mapping.typ.wtype,
+                wtype=mapping.wtype,
                 source_location=location,
             )
             return builder_for_instance(mapping.typ, intrinsic_expr)
@@ -189,7 +189,7 @@ def _map_call(
             stack_args.append(expect.argument_of_type_else_dummy(arg_in, *allowed_pytypes))
     return IntrinsicCall(
         op_code=op_mapping.op_code,
-        wtype=ast_mapper.result.wtype,
+        wtype=ast_mapper.result_wtype,
         immediates=typing.cast(list[str | int], immediates),
         stack_args=[a.resolve() for a in stack_args],
         source_location=location,

--- a/src/puyapy/awst_build/eb/log.py
+++ b/src/puyapy/awst_build/eb/log.py
@@ -35,7 +35,7 @@ class LogBuilder(FunctionBuilder):
             sep = empty_utf8
         else:
             sep_arg = args.pop(sep_index)
-            if isinstance(sep_arg, InstanceBuilder) and sep_arg.pytype in (
+            if isinstance(sep_arg, InstanceBuilder) and sep_arg.pytype.is_type_or_subtype(
                 pytypes.StringType,
                 pytypes.StrLiteralType,
                 pytypes.BytesType,
@@ -51,7 +51,7 @@ class LogBuilder(FunctionBuilder):
             if not isinstance(arg, InstanceBuilder):
                 expect.not_this_type(arg, default=expect.default_none)
             else:
-                if arg.pytype == pytypes.IntLiteralType:
+                if arg.pytype == pytypes.IntLiteralType:  # match int exactly, ie exclude bool
                     arg = arg.resolve_literal(UInt64TypeBuilder(arg.source_location))
                 # TODO: make to_bytes non-throwing
                 bytes_expr = arg.to_bytes(arg.source_location)

--- a/src/puyapy/awst_build/eb/reference_types/_base.py
+++ b/src/puyapy/awst_build/eb/reference_types/_base.py
@@ -33,16 +33,16 @@ class ReferenceValueExpressionBuilder(NotIterableInstanceExpressionBuilder, abc.
         expr: Expression,
         *,
         typ: pytypes.PyType,
-        native_type: pytypes.PyType,
+        native_type: pytypes.RuntimeType,
         native_access_member: str,
-        field_mapping: Mapping[str, tuple[str, pytypes.PyType]],
+        field_mapping: Mapping[str, tuple[str, pytypes.RuntimeType]],
         field_op_code: str,
         field_bool_comment: str,
     ):
         super().__init__(typ, expr)
         self.native_type = native_type
         self.native_access_member = native_access_member
-        self.field_mapping = immutabledict[str, tuple[str, pytypes.PyType]](field_mapping)
+        self.field_mapping = immutabledict[str, tuple[str, pytypes.RuntimeType]](field_mapping)
         self.field_op_code = field_op_code
         self.field_bool_comment = field_bool_comment
 
@@ -75,7 +75,7 @@ class UInt64BackedReferenceValueExpressionBuilder(ReferenceValueExpressionBuilde
         typ: pytypes.PyType,
         typ_literal_converter: Callable[[SourceLocation], TypeBuilder],
         native_access_member: str,
-        field_mapping: Mapping[str, tuple[str, pytypes.PyType]],
+        field_mapping: Mapping[str, tuple[str, pytypes.RuntimeType]],
         field_op_code: str,
         field_bool_comment: str,
     ):

--- a/src/puyapy/awst_build/eb/reference_types/asset.py
+++ b/src/puyapy/awst_build/eb/reference_types/asset.py
@@ -28,7 +28,7 @@ from puyapy.awst_build.eb.reference_types._base import UInt64BackedReferenceValu
 logger = log.get_logger(__name__)
 
 
-class AssetTypeBuilder(TypeBuilder):
+class AssetTypeBuilder(TypeBuilder[pytypes.RuntimeType]):
     def __init__(self, location: SourceLocation):
         super().__init__(pytypes.AssetType, location)
 

--- a/src/puyapy/awst_build/eb/storage/_common.py
+++ b/src/puyapy/awst_build/eb/storage/_common.py
@@ -90,10 +90,9 @@ class BoxValueExpressionBuilder(ValueProxyExpressionBuilder[pytypes.PyType, BoxV
 
     @typing.override
     def index(self, index: InstanceBuilder, location: SourceLocation) -> InstanceBuilder:
-        if self.pytype != pytypes.BytesType:
-            return super().index(index, location)
-        else:
+        if pytypes.BytesType <= self.pytype:
             return index_box_bytes(self.resolve(), index, location)
+        return super().index(index, location)
 
     @typing.override
     def slice_index(
@@ -103,10 +102,9 @@ class BoxValueExpressionBuilder(ValueProxyExpressionBuilder[pytypes.PyType, BoxV
         stride: InstanceBuilder | None,
         location: SourceLocation,
     ) -> InstanceBuilder:
-        if self.pytype != pytypes.BytesType:
-            return super().slice_index(begin_index, end_index, stride, location)
-        else:
+        if pytypes.BytesType <= self.pytype:
             return slice_box_bytes(self.resolve(), begin_index, end_index, stride, location)
+        return super().slice_index(begin_index, end_index, stride, location)
 
 
 class _ValueBytes(ValueProxyExpressionBuilder):

--- a/src/puyapy/awst_build/eb/storage/_storage.py
+++ b/src/puyapy/awst_build/eb/storage/_storage.py
@@ -168,7 +168,7 @@ def extract_key_override(
 ) -> Expression | None:
     if key_arg is None:
         return None
-    elif isinstance(key_arg, InstanceBuilder) and key_arg.pytype in (
+    if isinstance(key_arg, InstanceBuilder) and key_arg.pytype.is_type_or_subtype(
         pytypes.StringType,
         pytypes.StrLiteralType,
         pytypes.BytesType,

--- a/src/puyapy/awst_build/eb/storage/box.py
+++ b/src/puyapy/awst_build/eb/storage/box.py
@@ -128,7 +128,7 @@ class BoxProxyExpressionBuilder(
             exists_assertion_message = "check Box exists"
         return BoxValueExpression(
             key=self.resolve(),
-            wtype=self.pytype.content.wtype,
+            wtype=self.pytype.content_wtype,
             exists_assertion_message=exists_assertion_message,
             source_location=location,
         )

--- a/src/puyapy/awst_build/eb/storage/box_map.py
+++ b/src/puyapy/awst_build/eb/storage/box_map.py
@@ -107,7 +107,7 @@ def _init(
             location=location,
         )
     # the type of the key is not retained in the AWST, so to
-    wtypes.validate_persistable(key.wtype, location)
+    wtypes.validate_persistable(result_type.key_wtype, location)
 
     typed_args = parse_storage_proxy_constructor_args(
         arg_mapping,
@@ -136,7 +136,6 @@ class BoxMapProxyExpressionBuilder(
     ) -> BoxValueExpression:
         key_data = key.to_bytes(location)
         key_prefix = self.resolve()
-        content_wtype = self.pytype.content.wtype
         full_key = intrinsic_factory.concat(
             key_prefix, key_data, location, result_type=wtypes.box_key
         )
@@ -146,7 +145,7 @@ class BoxMapProxyExpressionBuilder(
             exists_assertion_message = "check BoxMap entry exists"
         return BoxValueExpression(
             key=full_key,
-            wtype=content_wtype,
+            wtype=self.pytype.content_wtype,
             exists_assertion_message=exists_assertion_message,
             source_location=location,
         )

--- a/src/puyapy/awst_build/eb/storage/box_ref.py
+++ b/src/puyapy/awst_build/eb/storage/box_ref.py
@@ -185,7 +185,7 @@ class _IntrinsicMethod(FunctionBuilder):
         box_proxy: Expression,
         op_code: str,
         args: dict[str, pytypes.PyType],
-        return_type: pytypes.PyType,
+        return_type: pytypes.RuntimeType,
     ) -> None:
         super().__init__(location)
         self.box_proxy = box_proxy

--- a/src/puyapy/awst_build/eb/storage/local_state.py
+++ b/src/puyapy/awst_build/eb/storage/local_state.py
@@ -205,7 +205,7 @@ def _build_field(
     return AppAccountStateExpression(
         key=self.resolve(),
         account=index_expr,
-        wtype=self.pytype.content.wtype,
+        wtype=self.pytype.content_wtype,
         exists_assertion_message=exists_assertion_message,
         source_location=location,
     )

--- a/src/puyapy/awst_build/eb/string.py
+++ b/src/puyapy/awst_build/eb/string.py
@@ -136,7 +136,8 @@ class StringExpressionBuilder(BytesBackedInstanceExpressionBuilder):
             return NotImplemented
 
         other = other.resolve_literal(converter=StringTypeBuilder(other.source_location))
-        if other.pytype != self.pytype:
+        # defer to most derived if not equal
+        if not (other.pytype <= pytypes.StringType):
             return NotImplemented
 
         lhs = self.resolve()
@@ -157,7 +158,7 @@ class StringExpressionBuilder(BytesBackedInstanceExpressionBuilder):
         self, other: InstanceBuilder, op: BuilderComparisonOp, location: SourceLocation
     ) -> InstanceBuilder:
         other = other.resolve_literal(converter=StringTypeBuilder(other.source_location))
-        return compare_bytes(lhs=self, op=op, rhs=other, source_location=location)
+        return compare_bytes(self=self, op=op, other=other, source_location=location)
 
     @typing.override
     def bool_eval(self, location: SourceLocation, *, negate: bool = False) -> InstanceBuilder:

--- a/src/puyapy/awst_build/eb/struct.py
+++ b/src/puyapy/awst_build/eb/struct.py
@@ -12,7 +12,7 @@ from puyapy.awst_build.eb.interface import InstanceBuilder, NodeBuilder, TypeBui
 class StructSubclassExpressionBuilder(TypeBuilder[pytypes.StructType]):
     def __init__(self, typ: pytypes.PyType, location: SourceLocation):
         assert isinstance(typ, pytypes.StructType)
-        assert pytypes.StructBaseType in typ.mro
+        assert pytypes.StructBaseType < typ
         super().__init__(typ, location)
 
     def call(

--- a/src/puyapy/awst_build/eb/template_variables.py
+++ b/src/puyapy/awst_build/eb/template_variables.py
@@ -70,7 +70,7 @@ class TemplateVariableExpressionBuilder(FunctionBuilder):
 
         result_expr = TemplateVar(
             name=prefix_value + var_name,
-            wtype=self.result_type.wtype,
+            wtype=self.result_type.checked_wtype(location),
             source_location=location,
         )
         return builder_for_instance(self.result_type, result_expr)

--- a/src/puyapy/awst_build/eb/transaction/base.py
+++ b/src/puyapy/awst_build/eb/transaction/base.py
@@ -24,14 +24,14 @@ class BaseTransactionExpressionBuilder(NotIterableInstanceExpressionBuilder, abc
 
     @abc.abstractmethod
     def get_field_value(
-        self, field: TxnField, typ: pytypes.PyType, location: SourceLocation
+        self, field: TxnField, typ: pytypes.RuntimeType, location: SourceLocation
     ) -> InstanceBuilder: ...
 
     @abc.abstractmethod
     def get_array_field_value(
         self,
         field: TxnField,
-        typ: pytypes.PyType,
+        typ: pytypes.RuntimeType,
         index: InstanceBuilder,
         location: SourceLocation,
     ) -> InstanceBuilder: ...

--- a/src/puyapy/awst_build/eb/transaction/group.py
+++ b/src/puyapy/awst_build/eb/transaction/group.py
@@ -59,7 +59,7 @@ class GroupTransactionTypeBuilder(TypeBuilder[pytypes.GroupTransactionType]):
             args, location, default=expect.default_dummy_value(pytypes.UInt64Type)
         )
         typ = self.produces()
-        if arg.pytype == pytypes.IntLiteralType:
+        if arg.pytype == pytypes.IntLiteralType:  # exact type, exclude bool
             return arg.resolve_literal(GroupTransactionTypeBuilder(typ, location))
         group_index = expect.argument_of_type_else_dummy(arg, pytypes.UInt64Type).resolve()
         txn = GroupTransactionReference(
@@ -75,7 +75,7 @@ class GroupTransactionExpressionBuilder(BaseTransactionExpressionBuilder):
 
     @typing.override
     def get_field_value(
-        self, field: TxnField, typ: pytypes.PyType, location: SourceLocation
+        self, field: TxnField, typ: pytypes.RuntimeType, location: SourceLocation
     ) -> InstanceBuilder:
         assert not field.is_array
         assert typ.wtype.scalar_type == field.avm_type
@@ -92,12 +92,12 @@ class GroupTransactionExpressionBuilder(BaseTransactionExpressionBuilder):
     def get_array_field_value(
         self,
         field: TxnField,
-        typ: pytypes.PyType,
+        typ: pytypes.RuntimeType,
         index: InstanceBuilder,
         location: SourceLocation,
     ) -> InstanceBuilder:
         assert field.is_array
-        assert index.pytype == pytypes.UInt64Type
+        assert pytypes.UInt64Type <= index.pytype
         assert typ.wtype.scalar_type == field.avm_type
         expr = IntrinsicCall(
             op_code="gtxnsas",

--- a/src/puyapy/awst_build/eb/transaction/itxn_args.py
+++ b/src/puyapy/awst_build/eb/transaction/itxn_args.py
@@ -43,7 +43,7 @@ class PythonITxnArgument:
         if self.array_promote:
             assert self.field.is_array
         if self.auto_serialize_bytes:
-            assert self.type == pytypes.BytesType
+            assert self.type is pytypes.BytesType
             assert not self.additional_types
             assert not self.literal_overrides
 
@@ -75,13 +75,13 @@ class PythonITxnArgument:
 
     def _validate_and_convert_item(self, item: InstanceBuilder) -> InstanceBuilder:
         if self.field == TxnField.ApplicationArgs:
-            if item.pytype == pytypes.AccountType:
+            if pytypes.AccountType <= item.pytype:
                 logger.warning(
                     f"{item.pytype} will not be added to foreign array,"
                     f" use .bytes to suppress this warning",
                     location=item.source_location,
                 )
-            elif item.pytype in (pytypes.AssetType, pytypes.ApplicationType):
+            elif item.pytype.is_type_or_subtype(pytypes.AssetType, pytypes.ApplicationType):
                 logger.warning(
                     f"{item.pytype} will not be added to foreign array,"
                     f" use .id to suppress this warning",

--- a/src/puyapy/awst_build/eb/transaction/txn_fields.py
+++ b/src/puyapy/awst_build/eb/transaction/txn_fields.py
@@ -10,7 +10,7 @@ logger = log.get_logger(__name__)
 @attrs.frozen
 class PythonTxnField:
     field: TxnField
-    type: pytypes.PyType
+    type: pytypes.RuntimeType
 
 
 PYTHON_TXN_FIELDS = {

--- a/src/puyapy/awst_build/eb/tuple.py
+++ b/src/puyapy/awst_build/eb/tuple.py
@@ -81,6 +81,7 @@ class TupleTypeBuilder(TypeBuilder[pytypes.TupleType]):
         location: SourceLocation,
     ) -> InstanceBuilder:
         result = _init(args, location)
+        # equality comparison okay because type constrained to TupleType
         if result.pytype != self.produces():
             raise CodeError("type mismatch between tuple parameters and argument types", location)
         return result
@@ -387,7 +388,7 @@ class TupleExpressionBuilder(
             raise CodeError("empty slices are not supported", location)
 
         updated_type = pytypes.GenericTupleType.parameterise(slice_types, location)
-        updated_wtype = updated_type.wtype
+        updated_wtype = updated_type.checked_wtype(location)
         return TupleExpressionBuilder(
             SliceExpression(
                 source_location=location,

--- a/src/puyapy/awst_build/pytypes.py
+++ b/src/puyapy/awst_build/pytypes.py
@@ -28,7 +28,10 @@ if typing.TYPE_CHECKING:
 logger = log.get_logger(__name__)
 
 
-@attrs.frozen(kw_only=True, str=False)
+ErrorMessage = typing.NewType("ErrorMessage", str)
+
+
+@attrs.frozen(kw_only=True, str=False, order=False)
 class PyType(abc.ABC):
     name: str
     """The canonical fully qualified type name"""
@@ -72,8 +75,17 @@ class PyType(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def wtype(self) -> wtypes.WType:
+    def wtype(self) -> wtypes.WType | ErrorMessage:
         """The WType that this type represents, if any."""
+
+    def checked_wtype(self, location: SourceLocation | None) -> wtypes.WType:
+        match self.wtype:
+            case wtypes.WType() as wtype:
+                return wtype
+            case str(msg):
+                raise CodeError(msg, location)
+            case _:
+                typing.assert_never(self.wtype)
 
     def parameterise(
         self,
@@ -83,8 +95,46 @@ class PyType(abc.ABC):
         """Produce parameterised type.
         Throws if not a generic type of if a parameterised generic type."""
         if self.generic:
-            raise CodeError(f"Type already has parameters: {self}", source_location)
-        raise CodeError(f"Not a generic type: {self}", source_location)
+            raise CodeError(f"type already has parameters: {self}", source_location)
+        raise CodeError(f"not a generic type: {self}", source_location)
+
+    @typing.final
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, PyType):
+            return NotImplemented
+        # self < other -> self is a supertype of other
+        return self in other.mro
+
+    @typing.final
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, PyType):
+            return NotImplemented
+        return self == other or self < other
+
+    @typing.final
+    def __gt__(self, other: object) -> bool:
+        if not isinstance(other, PyType):
+            return NotImplemented
+        raise TypeError("types are partial ordered")
+
+    @typing.final
+    def __ge__(self, other: object) -> bool:
+        if not isinstance(other, PyType):
+            return NotImplemented
+        raise TypeError("types are partial ordered")
+
+    def is_type_or_subtype(self, *of_any: PyType) -> bool:
+        return any(of <= self for of in of_any)
+
+    def is_type_or_supertype(self, *of_any: PyType) -> bool:
+        return any(self <= of for of in of_any)
+
+
+class RuntimeType(PyType, abc.ABC):
+    @typing.override
+    @property
+    @abc.abstractmethod
+    def wtype(self) -> wtypes.WType: ...
 
 
 _builtins_registry: typing.Final = dict[str, PyType]()
@@ -126,7 +176,7 @@ _Parameterise = typing_extensions.TypeAliasType(
 
 
 @typing.final
-@attrs.frozen
+@attrs.frozen(order=False)
 class _GenericType(PyType, abc.ABC, typing.Generic[_TPyType]):
     """Represents a typing.Generic type with unknown parameters"""
 
@@ -138,8 +188,8 @@ class _GenericType(PyType, abc.ABC, typing.Generic[_TPyType]):
 
     @typing.override
     @property
-    def wtype(self) -> typing.Never:
-        raise CodeError("Generic type usage requires parameters")
+    def wtype(self) -> ErrorMessage:
+        return ErrorMessage("generic type usage requires parameters")
 
     @typing.override
     def parameterise(
@@ -159,7 +209,7 @@ def _parameterise_type_type(
         (arg,) = args
     except ValueError:
         raise CodeError(
-            f"Expected a single type parameter, got {len(args)} parameters", source_location
+            f"expected a single type parameter, got {len(args)} parameters", source_location
         ) from None
     return TypeType(typ=arg)
 
@@ -171,7 +221,7 @@ GenericTypeType: typing.Final[PyType] = _GenericType(
 
 
 @typing.final
-@attrs.frozen
+@attrs.frozen(order=False)
 class TypeType(PyType):
     typ: PyType
     generic: PyType = attrs.field(default=GenericTypeType, init=False)
@@ -183,12 +233,12 @@ class TypeType(PyType):
 
     @typing.override
     @property
-    def wtype(self) -> typing.Never:
-        raise CodeError("type objects are not usable as values")
+    def wtype(self) -> ErrorMessage:
+        return ErrorMessage("type objects are not usable as values")
 
 
 @typing.final
-@attrs.frozen
+@attrs.frozen(order=False)
 class TypingLiteralType(PyType):
     value: TypingLiteralValue
     source_location: SourceLocation | None
@@ -203,8 +253,8 @@ class TypingLiteralType(PyType):
 
     @typing.override
     @property
-    def wtype(self) -> typing.Never:
-        raise CodeError(f"{self} is not usable as a value", self.source_location)
+    def wtype(self) -> ErrorMessage:
+        return ErrorMessage(f"{self} is not usable as a value")
 
 
 def _flatten_nested_unions(types: Sequence[PyType]) -> tuple[PyType, ...]:
@@ -218,7 +268,7 @@ def _flatten_nested_unions(types: Sequence[PyType]) -> tuple[PyType, ...]:
 
 
 @typing.final
-@attrs.frozen
+@attrs.frozen(order=False)
 class UnionType(PyType):
     types: tuple[PyType, ...] = attrs.field(
         converter=_flatten_nested_unions, validator=attrs.validators.min_len(2)
@@ -235,24 +285,24 @@ class UnionType(PyType):
 
     @typing.override
     @property
-    def wtype(self) -> typing.Never:
-        raise CodeError("type unions are unsupported at this location", self.source_location)
+    def wtype(self) -> ErrorMessage:
+        return ErrorMessage("type unions are unsupported at this location")
 
 
-@attrs.frozen
+@attrs.frozen(order=False)
 class _BaseType(PyType):
     """Type that is only usable as a base type"""
 
     @typing.override
     @property
-    def wtype(self) -> typing.Never:
-        raise CodeError(f"{self} is only usable as a base type")
+    def wtype(self) -> ErrorMessage:
+        return ErrorMessage(f"{self} is only usable as a base type")
 
     def __attrs_post_init__(self) -> None:
         _register_builtin(self)
 
 
-@attrs.frozen
+@attrs.frozen(kw_only=True, order=False)
 class TupleLikeType(PyType, abc.ABC):
     items: tuple[PyType, ...]
     source_location: SourceLocation | None
@@ -271,16 +321,25 @@ GenericTupleType: typing.Final = _GenericType(
 )
 
 
-@attrs.frozen(kw_only=True)
+@attrs.frozen(kw_only=True, order=False)
 class TupleType(TupleLikeType):
     generic: PyType | None = attrs.field(default=GenericTupleType, init=False)
     bases: tuple[PyType, ...] = attrs.field(default=(), init=False)
     mro: tuple[PyType, ...] = attrs.field(default=(), init=False)
 
     @property
-    def wtype(self) -> wtypes.WTuple:
+    def wtype(self) -> wtypes.WTuple | ErrorMessage:
+        item_wtypes = []
+        for i in self.items:
+            match i.wtype:
+                case wtypes.WType() as wtype:
+                    item_wtypes.append(wtype)
+                case ErrorMessage() as err:
+                    return err
+                case other:
+                    typing.assert_never(other)
         return wtypes.WTuple(
-            types=(i.wtype for i in self.items),
+            types=item_wtypes,
             source_location=self.source_location,
         )
 
@@ -288,51 +347,64 @@ class TupleType(TupleLikeType):
 NamedTupleBaseType: typing.Final[PyType] = _BaseType(name="typing.NamedTuple")
 
 
-@attrs.frozen
-class NamedTupleType(TupleType):
+@attrs.frozen(kw_only=True, order=False)
+class NamedTupleType(TupleType, RuntimeType):
     fields: immutabledict[str, PyType] = attrs.field(converter=immutabledict)
     items: tuple[PyType, ...] = attrs.field(init=False)
     generic: None = attrs.field(default=None, init=False)
     bases: tuple[PyType, ...] = attrs.field(default=(NamedTupleBaseType,), init=False)
     mro: tuple[PyType, ...] = attrs.field(default=(NamedTupleBaseType,), init=False)
+    wtype: wtypes.WTuple = attrs.field(init=False)
 
     @items.default
     def _items(self) -> tuple[PyType, ...]:
         return tuple(self.fields.values())
 
-    @typing.override
-    @property
-    def wtype(self) -> wtypes.WTuple:
-        return wtypes.WTuple(
+    @wtype.default
+    def _wtype(self) -> wtypes.WTuple:
+        unnamed_type = super().wtype
+        if isinstance(unnamed_type, str):
+            raise CodeError(unnamed_type, self.source_location)
+        return attrs.evolve(
+            unnamed_type,
             name=self.name,
-            types=(i.wtype for i in self.items),
             names=tuple(self.fields),
-            source_location=self.source_location,
         )
 
 
-@typing.final
-@attrs.frozen
-class ArrayType(PyType):
+@attrs.frozen(order=False)
+class SequenceType(PyType, abc.ABC):
     items: PyType
+
+
+@typing.final
+@attrs.frozen(order=False)
+class ArrayType(SequenceType, RuntimeType):
     size: int | None
     wtype: wtypes.WType
+    # convenience accessors
+    items_wtype: wtypes.WType
 
 
 @typing.final
-@attrs.frozen
-class StorageProxyType(PyType):
+@attrs.frozen(order=False)
+class StorageProxyType(RuntimeType):
     content: PyType
     wtype: wtypes.WType
+    # convenience accessors
+    content_wtype: wtypes.WType
 
 
 @typing.final
-@attrs.frozen
-class StorageMapProxyType(PyType):
+@attrs.frozen(order=False)
+class StorageMapProxyType(RuntimeType):
     generic: PyType
     key: PyType
     content: PyType
     wtype: wtypes.WType
+    # convenience accessors
+    key_wtype: wtypes.WType
+    content_wtype: wtypes.WType
 
 
 @typing.final
@@ -344,7 +416,7 @@ class FuncArg:
 
 
 @typing.final
-@attrs.frozen(kw_only=True)
+@attrs.frozen(kw_only=True, order=False)
 class FuncType(PyType):
     ret_type: PyType
     args: tuple[FuncArg, ...] = attrs.field(converter=tuple[FuncArg, ...])
@@ -355,21 +427,21 @@ class FuncType(PyType):
 
     @typing.override
     @property
-    def wtype(self) -> typing.Never:
-        raise CodeError("function objects are not usable as values")
+    def wtype(self) -> ErrorMessage:
+        return ErrorMessage("function objects are not usable as values")
 
 
 @typing.final
-@attrs.frozen
+@attrs.frozen(order=False)
 class StaticType(PyType):
     @typing.override
     @property
-    def wtype(self) -> typing.Never:
-        raise CodeError(f"{self} is only usable as a type and cannot be instantiated")
+    def wtype(self) -> ErrorMessage:
+        return ErrorMessage(f"{self} is only usable as a type and cannot be instantiated")
 
 
 @typing.final
-@attrs.frozen(kw_only=True)
+@attrs.frozen(kw_only=True, order=False)
 class ContractType(PyType):
     generic: None = attrs.field(default=None, init=False)
     module_name: str
@@ -383,16 +455,16 @@ class ContractType(PyType):
 
     @typing.override
     @property
-    def wtype(self) -> typing.Never:
-        raise CodeError(f"{self} is only usable as a type and cannot be instantiated")
+    def wtype(self) -> ErrorMessage:
+        return ErrorMessage(f"{self} is only usable as a type and cannot be instantiated")
 
 
 ObjectType: typing.Final[PyType] = _register_builtin(StaticType(name="builtins.object"))
 
 
 @typing.final
-@attrs.frozen(init=False)
-class StructType(PyType):
+@attrs.frozen(init=False, order=False)
+class StructType(RuntimeType):
     fields: immutabledict[str, PyType] = attrs.field(
         converter=immutabledict, validator=[attrs.validators.min_len(1)]
     )
@@ -418,8 +490,9 @@ class StructType(PyType):
         frozen: bool,
         source_location: SourceLocation | None,
     ):
-        field_wtypes = {name: field_typ.wtype for name, field_typ in fields.items()}
-        # TODO: this is a bit of a kludge
+        field_wtypes = {
+            name: field_typ.checked_wtype(source_location) for name, field_typ in fields.items()
+        }  # TODO: this is a bit of a kludge
         wtype_cls: type[wtypes.ARC4Struct | wtypes.WStructType]
         if base is ARC4StructBaseType:
             wtype_cls = wtypes.ARC4Struct
@@ -442,8 +515,8 @@ class StructType(PyType):
 
 
 @typing.final
-@attrs.frozen
-class _SimpleType(PyType):
+@attrs.frozen(order=False)
+class _SimpleType(RuntimeType):
     wtype: wtypes.WType
 
     def __attrs_post_init__(self) -> None:
@@ -451,7 +524,7 @@ class _SimpleType(PyType):
 
 
 @typing.final
-@attrs.frozen
+@attrs.frozen(order=False)
 class LiteralOnlyType(PyType):
     python_type: type[int | bytes | str]
     name: str = attrs.field(init=False)
@@ -462,49 +535,54 @@ class LiteralOnlyType(PyType):
 
     @typing.override
     @property
-    def wtype(self) -> typing.Never:
-        raise CodeError(f"Python literals of type {self} cannot be used as runtime values")
+    def wtype(self) -> ErrorMessage:
+        return ErrorMessage(f"Python literals of type {self} cannot be used as runtime values")
 
 
-NoneType: typing.Final[PyType] = _SimpleType(name="types.NoneType", wtype=wtypes.void_wtype)
+NoneType: typing.Final[RuntimeType] = _SimpleType(name="types.NoneType", wtype=wtypes.void_wtype)
 NeverType: typing.Final[PyType] = _SimpleType(name="typing.Never", wtype=wtypes.void_wtype)
-BoolType: typing.Final[PyType] = _SimpleType(name="builtins.bool", wtype=wtypes.bool_wtype)
 IntLiteralType: typing.Final = _register_builtin(LiteralOnlyType(int))
 StrLiteralType: typing.Final = _register_builtin(LiteralOnlyType(str))
 BytesLiteralType: typing.Final = _register_builtin(LiteralOnlyType(bytes))
+BoolType: typing.Final[RuntimeType] = _SimpleType(
+    name="builtins.bool",
+    wtype=wtypes.bool_wtype,
+    bases=[IntLiteralType],
+    mro=[IntLiteralType],
+)
 
-UInt64Type: typing.Final[PyType] = _SimpleType(
+UInt64Type: typing.Final[RuntimeType] = _SimpleType(
     name="algopy._primitives.UInt64",
     wtype=wtypes.uint64_wtype,
 )
-BigUIntType: typing.Final[PyType] = _SimpleType(
+BigUIntType: typing.Final[RuntimeType] = _SimpleType(
     name="algopy._primitives.BigUInt",
     wtype=wtypes.biguint_wtype,
 )
-BytesType: typing.Final[PyType] = _SimpleType(
+BytesType: typing.Final[RuntimeType] = _SimpleType(
     name="algopy._primitives.Bytes",
     wtype=wtypes.bytes_wtype,
 )
-StringType: typing.Final[PyType] = _SimpleType(
+StringType: typing.Final[RuntimeType] = _SimpleType(
     name="algopy._primitives.String",
     wtype=wtypes.string_wtype,
 )
-AccountType: typing.Final[PyType] = _SimpleType(
+AccountType: typing.Final[RuntimeType] = _SimpleType(
     name="algopy._reference.Account",
     wtype=wtypes.account_wtype,
 )
-AssetType: typing.Final[PyType] = _SimpleType(
+AssetType: typing.Final[RuntimeType] = _SimpleType(
     name="algopy._reference.Asset",
     wtype=wtypes.asset_wtype,
 )
-ApplicationType: typing.Final[PyType] = _SimpleType(
+ApplicationType: typing.Final[RuntimeType] = _SimpleType(
     name="algopy._reference.Application",
     wtype=wtypes.application_wtype,
 )
 
 
-@attrs.frozen(init=False)
-class UInt64EnumType(PyType):
+@attrs.frozen(init=False, order=False)
+class UInt64EnumType(RuntimeType):
     def __init__(self, name: str):
         self.__attrs_init__(
             name=name,
@@ -528,21 +606,21 @@ OpUpFeeSourceType: typing.Final = UInt64EnumType(
     name="algopy._util.OpUpFeeSource",
 )
 
-ARC4StringType: typing.Final[PyType] = _SimpleType(
+ARC4StringType: typing.Final[RuntimeType] = _SimpleType(
     name="algopy.arc4.String",
     wtype=wtypes.arc4_string_alias,
 )
-ARC4BoolType: typing.Final[PyType] = _SimpleType(
+ARC4BoolType: typing.Final[RuntimeType] = _SimpleType(
     name="algopy.arc4.Bool",
     wtype=wtypes.arc4_bool_wtype,
 )
 
 
-@attrs.frozen
-class ARC4UIntNType(PyType):
+@attrs.frozen(order=False)
+class ARC4UIntNType(RuntimeType):
     bits: int
     wtype: wtypes.ARC4UIntN
-    native_type: PyType
+    native_type: RuntimeType
 
 
 def _require_int_literal(
@@ -565,7 +643,7 @@ def _require_int_literal(
 
 
 def _make_arc4_unsigned_int_parameterise(
-    *, native_type: PyType, max_bits: int | None = None
+    *, native_type: RuntimeType, max_bits: int | None = None
 ) -> _Parameterise:
     def parameterise(
         self: _GenericType, args: _TypeArgs, source_location: SourceLocation | None
@@ -574,11 +652,11 @@ def _make_arc4_unsigned_int_parameterise(
             (bits_t,) = args
         except ValueError:
             raise CodeError(
-                f"Expected a single type parameter, got {len(args)} parameters", source_location
+                f"expected a single type parameter, got {len(args)} parameters", source_location
             ) from None
         bits = _require_int_literal(self, bits_t, source_location)
         if (max_bits is not None) and bits > max_bits:
-            raise CodeError(f"Max bit size of {self} is {max_bits}, got {bits}", source_location)
+            raise CodeError(f"max bit size of {self} is {max_bits}, got {bits}", source_location)
 
         name = f"{self.name}[{bits_t.name}]"
         return ARC4UIntNType(
@@ -626,8 +704,8 @@ ARC4ByteType: typing.Final = _register_builtin(
 )
 
 
-@attrs.frozen
-class ARC4UFixedNxMType(PyType):
+@attrs.frozen(order=False)
+class ARC4UFixedNxMType(RuntimeType):
     generic: _GenericType
     bits: int
     precision: int
@@ -642,14 +720,14 @@ def _make_arc4_unsigned_fixed_parameterise(*, max_bits: int | None = None) -> _P
             bits_t, precision_t = args
         except ValueError:
             raise CodeError(
-                f"Expected two type parameters, got {len(args)} parameters", source_location
+                f"expected two type parameters, got {len(args)} parameters", source_location
             ) from None
         bits = _require_int_literal(self, bits_t, source_location, position_qualifier="first")
         precision = _require_int_literal(
             self, precision_t, source_location, position_qualifier="second"
         )
         if (max_bits is not None) and bits > max_bits:
-            raise CodeError(f"Max bit size of {self} is {max_bits}, got {bits}", source_location)
+            raise CodeError(f"max bit size of {self} is {max_bits}, got {bits}", source_location)
 
         name = f"{self.name}[{bits_t.name}, {precision_t.name}]"
         return ARC4UFixedNxMType(
@@ -673,37 +751,35 @@ GenericARC4BigUFixedNxMType: typing.Final = _GenericType(
 )
 
 
-@typing.final
-@attrs.frozen(kw_only=True)
-class ARC4TupleType(TupleLikeType):
-    generic: PyType
-    bases: tuple[PyType, ...] = attrs.field(default=(), init=False)
-    mro: tuple[PyType, ...] = attrs.field(default=(), init=False)
-
-    @property
-    def wtype(self) -> wtypes.ARC4Tuple:
-        return wtypes.ARC4Tuple(
-            types=(i.wtype for i in self.items),
-            source_location=self.source_location,
-        )
-
-
 def _parameterise_arc4_tuple(
-    self: _GenericType[ARC4TupleType], args: _TypeArgs, source_location: SourceLocation | None
+    self: _GenericType[ARC4TupleType],  # noqa: ARG001
+    args: _TypeArgs,
+    source_location: SourceLocation | None,
 ) -> ARC4TupleType:
-    name = f"{self.name}[{', '.join(pyt.name for pyt in args)}]"
-    return ARC4TupleType(
-        generic=self,
-        name=name,
-        items=tuple(args),
-        source_location=source_location,
-    )
+    item_wtypes = tuple(arg.checked_wtype(source_location) for arg in args)
+    wtype = wtypes.ARC4Tuple(types=item_wtypes, source_location=source_location)
+    return ARC4TupleType(items=tuple(args), wtype=wtype, source_location=source_location)
 
 
 GenericARC4TupleType: typing.Final = _GenericType(
     name="algopy.arc4.Tuple",
     parameterise=_parameterise_arc4_tuple,
 )
+
+
+@typing.final
+@attrs.frozen(kw_only=True, order=False)
+class ARC4TupleType(TupleLikeType, RuntimeType):
+    generic: _GenericType = attrs.field(default=GenericARC4TupleType, init=False)
+    name: str = attrs.field(init=False)
+    bases: tuple[PyType, ...] = attrs.field(default=(), init=False)
+    mro: tuple[PyType, ...] = attrs.field(default=(), init=False)
+    wtype: wtypes.ARC4Tuple
+
+    @name.default
+    def _name(self) -> str:
+        return f"{self.generic.name}[{', '.join(pyt.name for pyt in self.items)}]"
+
 
 CompiledContractType: typing.Final = _register_builtin(
     NamedTupleType(
@@ -732,8 +808,8 @@ CompiledLogicSigType: typing.Final = _register_builtin(
 
 
 @typing.final
-@attrs.frozen
-class VariadicTupleType(PyType):
+@attrs.frozen(order=False)
+class VariadicTupleType(SequenceType):
     items: PyType
     generic: _GenericType = attrs.field(default=GenericTupleType, init=False)
     bases: tuple[PyType, ...] = attrs.field(default=(), init=False)
@@ -746,8 +822,8 @@ class VariadicTupleType(PyType):
 
     @typing.override
     @property
-    def wtype(self) -> typing.Never:
-        raise CodeError("variadic tuples cannot be used as runtime values")
+    def wtype(self) -> ErrorMessage:
+        return ErrorMessage("variadic tuples cannot be used as runtime values")
 
 
 def _make_array_parameterise(
@@ -760,15 +836,18 @@ def _make_array_parameterise(
             (arg,) = args
         except ValueError:
             raise CodeError(
-                f"Expected a single type parameter, got {len(args)} parameters", source_location
+                f"expected a single type parameter, got {len(args)} parameters", source_location
             ) from None
         name = f"{self.name}[{arg.name}]"
+        items_wtype = arg.checked_wtype(source_location)
+
         return ArrayType(
             generic=self,
             name=name,
             size=None,
             items=arg,
-            wtype=typ(element_type=arg.wtype, source_location=source_location),
+            wtype=typ(element_type=items_wtype, source_location=source_location),
+            items_wtype=items_wtype,
         )
 
     return parameterise
@@ -793,6 +872,7 @@ ARC4DynamicBytesType: typing.Final = _register_builtin(
         ),
         size=None,
         items=ARC4ByteType,
+        items_wtype=ARC4ByteType.wtype,
         bases=[GenericARC4DynamicArrayType.parameterise([ARC4ByteType], source_location=None)],
         mro=[GenericARC4DynamicArrayType.parameterise([ARC4ByteType], source_location=None)],
     )
@@ -806,21 +886,24 @@ def _parameterise_arc4_static_array(
         items, size_t = args
     except ValueError:
         raise CodeError(
-            f"Expected a single type parameter, got {len(args)} parameters", source_location
+            f"expected a single type parameter, got {len(args)} parameters", source_location
         ) from None
     size = _require_int_literal(self, size_t, source_location, position_qualifier="second")
     if size < 0:
-        raise CodeError("Array size should be non-negative", source_location)
+        raise CodeError("array size should be non-negative", source_location)
 
     name = f"{self.name}[{items.name}, {size_t.name}]"
+    items_wtype = items.checked_wtype(source_location)
+
     return ArrayType(
         generic=self,
         name=name,
         size=size,
         items=items,
         wtype=wtypes.ARC4StaticArray(
-            element_type=items.wtype, array_size=size, source_location=source_location
+            element_type=items_wtype, array_size=size, source_location=source_location
         ),
+        items_wtype=items_wtype,
     )
 
 
@@ -835,6 +918,7 @@ ARC4AddressType: typing.Final = _register_builtin(
         size=32,
         generic=None,
         items=ARC4ByteType,
+        items_wtype=ARC4ByteType.wtype,
         bases=[
             GenericARC4StaticArrayType.parameterise(
                 [ARC4ByteType, TypingLiteralType(value=32, source_location=None)],
@@ -851,7 +935,7 @@ ARC4AddressType: typing.Final = _register_builtin(
 )
 
 
-def _make_storage_parameterise(key_wtype: wtypes.WType) -> _Parameterise[StorageProxyType]:
+def _make_storage_parameterise(wtype: wtypes.WType) -> _Parameterise[StorageProxyType]:
     def parameterise(
         self: _GenericType[StorageProxyType],
         args: _TypeArgs,
@@ -861,14 +945,16 @@ def _make_storage_parameterise(key_wtype: wtypes.WType) -> _Parameterise[Storage
             (arg,) = args
         except ValueError:
             raise CodeError(
-                f"Expected a single type parameter, got {len(args)} parameters", source_location
+                f"expected a single type parameter, got {len(args)} parameters", source_location
             ) from None
         name = f"{self.name}[{arg.name}]"
+        content_wtype = arg.checked_wtype(source_location)
         return StorageProxyType(
             generic=self,
             name=name,
             content=arg,
-            wtype=key_wtype,
+            wtype=wtype,
+            content_wtype=content_wtype,
         )
 
     return parameterise
@@ -883,15 +969,19 @@ def _parameterise_storage_map(
         key, content = args
     except ValueError:
         raise CodeError(
-            f"Expected two type parameters, got {len(args)} parameters", source_location
+            f"expected two type parameters, got {len(args)} parameters", source_location
         ) from None
     name = f"{self.name}[{key.name}, {content.name}]"
+    key_wtype = key.checked_wtype(source_location)
+    content_wtype = content.checked_wtype(source_location)
     return StorageMapProxyType(
         generic=self,
         name=name,
         key=key,
         content=content,
         wtype=wtypes.box_key,
+        key_wtype=key_wtype,
+        content_wtype=content_wtype,
     )
 
 
@@ -911,6 +1001,7 @@ BoxRefType: typing.Final = _register_builtin(
     StorageProxyType(
         name="algopy._box.BoxRef",
         content=BytesType,
+        content_wtype=BytesType.wtype,
         wtype=wtypes.box_key,
         generic=None,
     )
@@ -922,7 +1013,7 @@ GenericBoxMapType: typing.Final = _GenericType(
 )
 
 
-@attrs.frozen
+@attrs.frozen(order=False)
 class TransactionRelatedType(PyType, abc.ABC):
     transaction_type: TransactionType | None
     """None implies "any" type, which may be considered as either union or an intersection"""
@@ -932,19 +1023,19 @@ class TransactionRelatedType(PyType, abc.ABC):
 
 
 @typing.final
-@attrs.frozen
+@attrs.frozen(order=False)
 class GroupTransactionType(TransactionRelatedType):
     wtype: wtypes.WGroupTransaction
 
 
 @typing.final
-@attrs.frozen
+@attrs.frozen(order=False)
 class InnerTransactionFieldsetType(TransactionRelatedType):
     wtype: wtypes.WInnerTransactionFields
 
 
 @typing.final
-@attrs.frozen
+@attrs.frozen(order=False)
 class InnerTransactionResultType(TransactionRelatedType):
     wtype: wtypes.WInnerTransaction
 
@@ -1021,15 +1112,15 @@ InnerTransactionResultTypes: typing.Final[
 ] = {kind: _make_itxn_result_type(kind) for kind in _all_txn_kinds}
 
 
-@attrs.frozen(kw_only=True)
+@attrs.frozen(kw_only=True, order=False)
 class _CompileTimeType(PyType):
     _wtype_error: str
 
     @typing.override
     @property
-    def wtype(self) -> typing.Never:
+    def wtype(self) -> ErrorMessage:
         msg = self._wtype_error.format(self=self)
-        raise CodeError(msg)
+        return ErrorMessage(msg)
 
     def __attrs_post_init__(self) -> None:
         _register_builtin(self)
@@ -1041,7 +1132,7 @@ BytesBackedType: typing.Final[PyType] = _CompileTimeType(
 )
 
 
-@attrs.frozen(kw_only=True)
+@attrs.frozen(kw_only=True, order=False)
 class IntrinsicEnumType(PyType):
     generic: None = attrs.field(default=None, init=False)
     bases: tuple[PyType, ...] = attrs.field(
@@ -1052,8 +1143,8 @@ class IntrinsicEnumType(PyType):
     members: immutabledict[str, str] = attrs.field(converter=immutabledict)
 
     @property
-    def wtype(self) -> wtypes.WType:
-        raise CodeError(f"{self} is only valid as a literal argument to an algopy.op function")
+    def wtype(self) -> ErrorMessage:
+        return ErrorMessage(f"{self} is only valid as a literal argument to an algopy.op function")
 
 
 def _make_intrinsic_enum_types() -> Sequence[IntrinsicEnumType]:
@@ -1070,7 +1161,7 @@ def _make_intrinsic_enum_types() -> Sequence[IntrinsicEnumType]:
     ]
 
 
-@attrs.frozen(kw_only=True)
+@attrs.frozen(kw_only=True, order=False)
 class IntrinsicNamespaceType(PyType):
     generic: None = attrs.field(default=None, init=False)
     bases: tuple[PyType, ...] = attrs.field(default=(), init=False)
@@ -1080,8 +1171,8 @@ class IntrinsicNamespaceType(PyType):
     )
 
     @property
-    def wtype(self) -> wtypes.WType:
-        raise CodeError(f"{self} is a namespace type only and not usable at runtime")
+    def wtype(self) -> ErrorMessage:
+        return ErrorMessage(f"{self} is a namespace type only and not usable at runtime")
 
 
 def _make_intrinsic_namespace_types() -> Sequence[IntrinsicNamespaceType]:
@@ -1148,7 +1239,7 @@ StructBaseType: typing.Final[PyType] = _BaseType(name="algopy._struct.Struct")
 
 
 @typing.final
-@attrs.frozen
+@attrs.frozen(order=False)
 class PseudoGenericFunctionType(PyType):
     return_type: PyType
     generic: _GenericType[PseudoGenericFunctionType]
@@ -1156,8 +1247,8 @@ class PseudoGenericFunctionType(PyType):
     mro: tuple[PyType, ...] = attrs.field(default=(), init=False)
 
     @property
-    def wtype(self) -> typing.Never:
-        raise CodeError(f"{self} is not a value")
+    def wtype(self) -> ErrorMessage:
+        return ErrorMessage(f"{self} is not a value")
 
 
 def _parameterise_pseudo_generic_function_type(
@@ -1169,7 +1260,7 @@ def _parameterise_pseudo_generic_function_type(
         (arg,) = args
     except ValueError:
         raise CodeError(
-            f"Expected a single type parameter, got {len(args)} parameters", source_location
+            f"expected a single type parameter, got {len(args)} parameters", source_location
         ) from None
     name = f"{self.name}[{arg.name}]"
     return PseudoGenericFunctionType(generic=self, name=name, return_type=arg)

--- a/stubs/algopy-stubs/_box.pyi
+++ b/stubs/algopy-stubs/_box.pyi
@@ -5,6 +5,7 @@ from algopy import Bytes, UInt64, String
 _TKey = typing.TypeVar("_TKey")
 _TValue = typing.TypeVar("_TValue")
 
+@typing.final
 class Box(typing.Generic[_TValue]):
     """
     Box abstracts the reading and writing of a single value to a single box.
@@ -58,6 +59,7 @@ class Box(typing.Generic[_TValue]):
         Get the length of this Box. Fails if the box does not exist
         """
 
+@typing.final
 class BoxRef:
     """
     BoxRef abstracts the reading and writing of boxes containing raw binary data. The size is
@@ -158,6 +160,7 @@ class BoxRef:
         Get the length of this Box. Fails if the box does not exist
         """
 
+@typing.final
 class BoxMap(typing.Generic[_TKey, _TValue]):
     """
     BoxMap abstracts the reading and writing of a set of boxes using a common key and content type.

--- a/stubs/algopy-stubs/_compiled.pyi
+++ b/stubs/algopy-stubs/_compiled.pyi
@@ -8,6 +8,7 @@ from algopy import (
     UInt64,
 )
 
+@typing.final
 class CompiledContract(typing.NamedTuple):
     """
     Provides compiled programs and state allocation values for a Contract.
@@ -56,6 +57,7 @@ class CompiledContract(typing.NamedTuple):
     when calling compile_contract
     """
 
+@typing.final
 class CompiledLogicSig(typing.NamedTuple):
     """
     Provides account for a Logic Signature.

--- a/stubs/algopy-stubs/_constants.pyi
+++ b/stubs/algopy-stubs/_constants.pyi
@@ -1,5 +1,7 @@
+import typing
 from algopy import UInt64
 
+@typing.final
 class OnCompleteAction(UInt64):
     """On Completion actions available in an application call transaction"""
 
@@ -28,6 +30,7 @@ class OnCompleteAction(UInt64):
     delete the AppParams for the application from the creator's balance
     record"""
 
+@typing.final
 class TransactionType(UInt64):
     """The different transaction types available in a transaction"""
 

--- a/stubs/algopy-stubs/_contract.pyi
+++ b/stubs/algopy-stubs/_contract.pyi
@@ -1,7 +1,9 @@
 import abc
+import typing
 
 from algopy import UInt64, urange
 
+@typing.final
 class StateTotals:
     """
     Options class to manually define the total amount of global and local state contract will use,

--- a/stubs/algopy-stubs/_logic_sig.pyi
+++ b/stubs/algopy-stubs/_logic_sig.pyi
@@ -3,6 +3,7 @@ from collections.abc import Callable
 
 from algopy import UInt64
 
+@typing.final
 class LogicSig:
     """A logic signature"""
 

--- a/stubs/algopy-stubs/_reference.pyi
+++ b/stubs/algopy-stubs/_reference.pyi
@@ -1,5 +1,7 @@
+import typing
 from algopy import Bytes, BytesBacked, UInt64
 
+@typing.final
 class Account(BytesBacked):
     """An Account on the Algorand network.
 
@@ -142,6 +144,7 @@ class Account(BytesBacked):
         ```
         """
 
+@typing.final
 class Asset:
     """An Asset on the Algorand network."""
 
@@ -287,6 +290,7 @@ class Asset:
         ```
         """
 
+@typing.final
 class Application:
     """An Application on the Algorand network."""
 

--- a/stubs/algopy-stubs/_state.pyi
+++ b/stubs/algopy-stubs/_state.pyi
@@ -4,6 +4,7 @@ from algopy import Account, Bytes, String, UInt64
 
 _TState = typing.TypeVar("_TState")
 
+@typing.final
 class LocalState(typing.Generic[_TState]):
     """Local state associated with the application and an account"""
 
@@ -78,6 +79,7 @@ class LocalState(typing.Generic[_TState]):
         ```
         """
 
+@typing.final
 class GlobalState(typing.Generic[_TState]):
     """Global state associated with the application, the key will be the name of the member, this
     is assigned to

--- a/stubs/algopy-stubs/_unsigned_builtins.pyi
+++ b/stubs/algopy-stubs/_unsigned_builtins.pyi
@@ -10,6 +10,7 @@ from collections.abc import Iterable, Iterator, Reversible
 
 from algopy import UInt64
 
+@typing.final
 class urange(Reversible[UInt64]):  # noqa: N801
     """Produces a sequence of UInt64 from start (inclusive) to stop (exclusive) by step.
 
@@ -29,6 +30,7 @@ class urange(Reversible[UInt64]):  # noqa: N801
 
 _T = typing.TypeVar("_T")
 
+@typing.final
 class uenumerate(Reversible[tuple[UInt64, _T]]):  # noqa: N801
     """Yields pairs containing a count (from zero) and a value yielded by the iterable argument.
 

--- a/stubs/algopy-stubs/_util.pyi
+++ b/stubs/algopy-stubs/_util.pyi
@@ -1,5 +1,7 @@
+import typing
 from algopy import Bytes, BytesBacked, String, UInt64
 
+@typing.final
 class OpUpFeeSource(UInt64):
     """Defines the source of fees for the OpUp utility."""
 

--- a/test_cases/tuple_support/out/TupleSupport.ssa.ir
+++ b/test_cases/tuple_support/out/TupleSupport.ssa.ir
@@ -111,6 +111,7 @@ contract test_cases.tuple_support.tuple_support.TupleSupport:
                 (assert tmp%29#0)
                 let tmp%30#0: bool = (== x.1#0 0x)
                 (assert tmp%30#0)
+                test_cases.tuple_support.tuple_support.test_empty()
                 let tmp%31#0: uint64 = (+ a#0 b#0)
                 return tmp%31#0
         
@@ -285,6 +286,10 @@ contract test_cases.tuple_support.tuple_support.TupleSupport:
                 let tup.0#0: uint64 = (1u)
                 let tmp%0#0: bool = (== tup.0#0 1u)
                 (assert tmp%0#0)
+                return 
+        
+        subroutine test_cases.tuple_support.tuple_support.test_empty() -> void:
+            block@0: // L178
                 return 
     
     program clear-state:

--- a/test_cases/tuple_support/out/module.awst
+++ b/test_cases/tuple_support/out/module.awst
@@ -54,6 +54,7 @@ contract TupleSupport
     x: tuple<uint64,bytes> = (0u, hex<"">)
     assert(x[0] == 0u)
     assert(x[1] == hex<"">)
+    test_cases.tuple_support.tuple_support.test_empty()
     return a + b
   }
   
@@ -112,6 +113,7 @@ contract TupleSupport
     x: tuple<uint64,bytes> = (0u, hex<"">)
     assert(x[0] == 0u)
     assert(x[1] == hex<"">)
+    test_cases.tuple_support.tuple_support.test_empty()
     return a + b
   }
 }
@@ -217,6 +219,16 @@ subroutine slicing(values: tuple<uint64,uint64,uint64,uint64,uint64,uint64,uint6
   assert(test_cases.tuple_support.tuple_support.add_three_values(one_to_three) == values[0] + values[1] + values[2])
   assert(one_to_three[1u:2u][0] == one_to_three[1])
   assert(&&(&&(one_to_three[0] == SINGLE_EVAL(id=7, source=one_to_three[:])[0], one_to_three[1] == SINGLE_EVAL(id=7)[1]), one_to_three[2] == SINGLE_EVAL(id=7)[2]))
+}
+
+subroutine test_empty(): void
+{
+  empty: tuple<> = ()
+  empty2: tuple<> = empty
+  (): tuple<> = empty
+  (): tuple<> = ()
+  assert(true)
+  assert(true)
 }
 
 contract TupleComparisons

--- a/test_cases/tuple_support/out_unoptimized/TupleSupport.approval.teal
+++ b/test_cases/tuple_support/out_unoptimized/TupleSupport.approval.teal
@@ -317,6 +317,9 @@ main_after_if_else@12:
     dup
     ==
     assert
+    // tuple_support/tuple_support.py:64
+    // test_empty()
+    callsub test_empty
     // tuple_support/tuple_support.py:11
     // (a, b) = (UInt64(1), UInt64(2))
     intc_0 // 1
@@ -773,4 +776,13 @@ single_tuple:
     dup
     ==
     assert
+    retsub
+
+
+// test_cases.tuple_support.tuple_support.test_empty() -> void:
+test_empty:
+    // tuple_support/tuple_support.py:178-179
+    // @subroutine
+    // def test_empty() -> None:
+    proto 0 0
     retsub

--- a/test_cases/tuple_support/out_unoptimized/TupleSupport.destructured.ir
+++ b/test_cases/tuple_support/out_unoptimized/TupleSupport.destructured.ir
@@ -99,6 +99,7 @@ contract test_cases.tuple_support.tuple_support.TupleSupport:
                 (assert tmp%29#0)
                 let tmp%30#0: bool = (== 0x 0x)
                 (assert tmp%30#0)
+                test_cases.tuple_support.tuple_support.test_empty()
                 let tmp%31#0: uint64 = (+ 1u 2u)
                 return tmp%31#0
         
@@ -264,6 +265,10 @@ contract test_cases.tuple_support.tuple_support.TupleSupport:
             block@0: // L76
                 let tmp%0#0: bool = (== 1u 1u)
                 (assert tmp%0#0)
+                return 
+        
+        subroutine test_cases.tuple_support.tuple_support.test_empty() -> void:
+            block@0: // L178
                 return 
     
     program clear-state:

--- a/test_cases/tuple_support/puya.log
+++ b/test_cases/tuple_support/puya.log
@@ -430,6 +430,10 @@ debug: Sealing block@0: // L82
 debug: Terminated block@0: // L82
 debug: Sealing block@0: // L76
 debug: Terminated block@0: // L76
+debug: Sealing block@0: // L178
+tuple_support/tuple_support.py:184:5 warning: assertion is always true, ignoring
+tuple_support/tuple_support.py:185:5 warning: assertion is always true, ignoring
+debug: Terminated block@0: // L178
 debug: Sealing block@0: // L1
 debug: Terminated block@0: // L1
 debug: Sealing block@1: // call __init___L1
@@ -1100,6 +1104,20 @@ debug: Optimizer: Intrinsic Simplifier
 debug: Simplified (== 1u 1u) to 1u
 debug: Optimizer: Remove Unused Variables
 debug: Removing unused variable tup.0#0
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Remove Calls To No Op Subroutines
+debug: Optimizing subroutine test_cases.tuple_support.tuple_support.test_empty
+debug: Splitting parallel copies prior to optimization
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Remove Unused Variables
 debug: Optimizer: Inner Txn Field Replacer
 debug: Optimizer: Replace Compiled References
 debug: Optimizer: Simplify Control Ops

--- a/test_cases/tuple_support/tuple_support.py
+++ b/test_cases/tuple_support/tuple_support.py
@@ -61,7 +61,7 @@ class TupleSupport(Contract):
         x = tuple[UInt64, Bytes]((UInt64(), Bytes()))
         assert x[0] == 0
         assert x[1] == b""
-
+        test_empty()
         return a + b
 
     def clear_state_program(self) -> UInt64:
@@ -173,3 +173,13 @@ def slicing(values: tuple[UInt64, UInt64, UInt64, UInt64, UInt64, UInt64, UInt64
     assert one_to_three[-2:-1][0] == one_to_three[1]
 
     assert one_to_three == one_to_three[:]
+
+
+@subroutine
+def test_empty() -> None:
+    empty = ()
+    empty2 = empty
+    () = empty
+    () = ()
+    assert not empty
+    assert not empty2

--- a/tests/test_expected_output/arc4.test
+++ b/tests/test_expected_output/arc4.test
@@ -1,7 +1,7 @@
 # ruff: noqa
 # fmt: off
 # type: ignore
-import gtxn
+
 ## case: test_invalid_arc4_struct_member_type
 from algopy import *
 
@@ -105,11 +105,11 @@ import typing
 
 from algopy import arc4, subroutine
 
-A: typing.TypeAlias = arc4.UIntN[typing.Literal[72]] ## E: Max bit size of algopy.arc4.UIntN is 64, got 72
+A: typing.TypeAlias = arc4.UIntN[typing.Literal[72]] ## E: max bit size of algopy.arc4.UIntN is 64, got 72
 B: typing.TypeAlias = arc4.BigUIntN[typing.Literal[520]] ## E: Bit size must be between 8 and 512 inclusive
 # TODO: add test for non-8-multiple
 
-C: typing.TypeAlias = arc4.UFixedNxM[typing.Literal[72], typing.Literal[10]] ## E: Max bit size of algopy.arc4.UFixedNxM is 64, got 72
+C: typing.TypeAlias = arc4.UFixedNxM[typing.Literal[72], typing.Literal[10]] ## E: max bit size of algopy.arc4.UFixedNxM is 64, got 72
 D: typing.TypeAlias = arc4.BigUFixedNxM[typing.Literal[520], typing.Literal[10]] ## E: Bit size must be between 8 and 512 inclusive
 # TODO: add test for non-8-multiple
 
@@ -117,7 +117,7 @@ E: typing.TypeAlias = arc4.UFixedNxM[typing.Literal[64], typing.Literal[0]] ## E
 F: typing.TypeAlias = arc4.BigUFixedNxM[typing.Literal[512], typing.Literal[0]] ## E: Precision must be between 1 and 160 inclusive
 
 @subroutine
-def testA(x: A) -> None: ## E: Max bit size of algopy.arc4.UIntN is 64, got 72
+def testA(x: A) -> None: ## E: max bit size of algopy.arc4.UIntN is 64, got 72
     assert x
 
 @subroutine
@@ -125,7 +125,7 @@ def testB(x: B) -> None: ## E: Bit size must be between 8 and 512 inclusive
     assert x
 
 @subroutine
-def testC(x: C) -> None: ## E: Max bit size of algopy.arc4.UFixedNxM is 64, got 72
+def testC(x: C) -> None: ## E: max bit size of algopy.arc4.UFixedNxM is 64, got 72
     assert x
 
 @subroutine
@@ -608,3 +608,27 @@ class MyTest(ARC4Contract):
     def double_use_not_allowed(self, arr1: arc4.DynamicBytes, arr2: arc4.DynamicBytes) -> None:
         arr1.append(arc4.Byte(42))
         arr2.append(arc4.Byte(43))
+
+
+## case: bad_array_types
+import typing
+from algopy import *
+
+
+@subroutine
+def a() -> None:
+    assert not arc4.StaticArray[int, typing.Literal[1]](1) ## E: Python literals of type int cannot be used as runtime values
+
+@subroutine
+def b() -> None:
+    assert not arc4.StaticArray(1) ## E: Python literals of type int cannot be used as runtime values
+
+
+@subroutine
+def c() -> None:
+    assert not arc4.DynamicArray(1) ## E: Python literals of type int cannot be used as runtime values
+
+
+@subroutine
+def d() -> None:
+    assert not arc4.DynamicArray[int]() ## E: Python literals of type int cannot be used as runtime values

--- a/tests/test_expected_output/literals.test
+++ b/tests/test_expected_output/literals.test
@@ -227,7 +227,7 @@ def too_long() -> arc4.DynamicBytes:
     return arc4.DynamicBytes(b"a" * 4096) ## E: encoded bytes exceed max length
 
 
-## case: test_tuple
+## case: test_tuple1
 import typing
 from algopy import *
 
@@ -235,7 +235,12 @@ from algopy import *
 def wrong_type() -> None:
     a = tuple(arc4.DynamicBytes(b"as")) ## E: unhandled argument type
 
+## case: test_tuple2
+import typing
+from algopy import *
 
-@subroutine
-def empty_tuple() -> None:
-    a: tuple[typing.Never, ...] = tuple() ## E: empty tuples are not supported
+
+class MyContract(ARC4Contract):
+    @arc4.abimethod
+    def empty_tuple(self) -> None:
+        a: tuple[typing.Never, ...] = tuple()

--- a/tests/test_expected_output/module.test
+++ b/tests/test_expected_output/module.test
@@ -50,7 +50,7 @@ NotAllowed = collections.namedtuple("NotAllowed", ["x", "y"]) ## E: Unsupported 
 import typing
 from algopy import *
 
-class MyTuple(typing.NamedTuple): ## E: empty tuples are not supported
+class MyTuple(typing.NamedTuple):
     pass
 
 @subroutine

--- a/tests/test_expected_output/tuple.test
+++ b/tests/test_expected_output/tuple.test
@@ -93,10 +93,6 @@ def test_tuple6() -> None:
     )  # type:ignore[assignment]
 
 @subroutine
-def test_tuple7() -> None:
-    tup = () ## E: empty tuples are not supported
-
-@subroutine
 def test_tuple8() -> None:
     a, b = UInt64(), Bytes()
     assert (a, b) != (b, a) # type: ignore[comparison-overlap] ## E: items at index 0 do not support comparison with operator '!='

--- a/tests/test_expected_output/tuple.test
+++ b/tests/test_expected_output/tuple.test
@@ -153,3 +153,12 @@ def iterate_tuple(base: gtxn.TransactionBase) -> None:
         assert a.fee > 0
     for b in (gtxn.PaymentTransaction(1), gtxn.KeyRegistrationTransaction(2)): ## E: unable to iterate heterogeneous tuple without common base type
         assert b.fee > 0
+
+## case: bad_named_tuple
+from algopy import UInt64
+import typing
+
+class NotAllowed(typing.NamedTuple):
+    an_int: UInt64
+    id: int ## E: Python literals of type int cannot be used as runtime values
+    flag: bool = True ## E: unsupported syntax for typing.NamedTuple member declaration


### PR DESCRIPTION
This is a more general fix for the issue surfaced in #272.

Equality comparisons between types (including implied equality comparisons in match statements) don't take into account inheritance relationships. Instead a partial ordering operator is needed whenever a type to be compared against isn't guaranteed to be "final".

Two other small changes:
- fix a cryptic error message encountered when forgetting a "self" parameter in a method declaration
- handle empty tuples, not a particularly useful feature, but simplifies validation, particularly useful for `typing.NamedTuple`