### PR TITLE
docs: add debugger ref; remove note from algopy testing doc as its no longer in preview

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,5 +59,6 @@ language-guide
 principles
 api
 compiler
-algopy_testing/index
+references/algopy_testing
+references/avm_debugger
 ```

--- a/docs/references/algopy_testing.md
+++ b/docs/references/algopy_testing.md
@@ -8,8 +8,6 @@ The `algorand-python-testing` package provides:
 -   An offline testing environment that simulates core AVM functionality
 -   A familiar Pythonic experience, compatible with testing frameworks like [pytest](https://docs.pytest.org/en/latest/), [unittest](https://docs.python.org/3/library/unittest.html), and [hypothesis](https://hypothesis.readthedocs.io/en/latest/)
 
-> **NOTE**: This package is currently in **preview** and should be used with caution until the first stable release.
-
 ## Quick Start
 
 To get started refer to the [official documentation](https://algorandfoundation.github.io/algorand-python-testing/).

--- a/docs/references/avm_debugger.md
+++ b/docs/references/avm_debugger.md
@@ -1,0 +1,7 @@
+# AlgoKit AVM VSCode Debugger
+
+The AlgoKit AVM VS Code Debugger extension enables line-by-line debugging of Algorand smart contracts on the AVM, supporting both TEAL and Puya contracts. It provides a seamless debugging experience by leveraging AVM simulate traces and source maps.
+
+## Quick Start
+
+For detailed setup instructions, features, and advanced usage, please refer to the [official repository](https://github.com/algorandfoundation/algokit-avm-vscode-debugger).

--- a/docs/references/avm_debugger.md
+++ b/docs/references/avm_debugger.md
@@ -1,6 +1,6 @@
-# AlgoKit AVM VSCode Debugger
+# Breakpoint debugging
 
-The AlgoKit AVM VS Code Debugger extension enables line-by-line debugging of Algorand smart contracts on the AVM, supporting both TEAL and Puya contracts. It provides a seamless debugging experience by leveraging AVM simulate traces and source maps.
+The AlgoKit AVM VS Code Debugger extension enables line-by-line debugging of Algorand Python smart contracts that are executed on the AVM. It provides a seamless debugging experience by leveraging AVM simulate traces and source maps.
 
 ## Quick Start
 


### PR DESCRIPTION
## Proposed Changes

- Adds reference to vscode debug extension
- Removes a note claiming that algopy testing is in preview (its now stable)