### PR TITLE
fix: accept address or index param for VoterParamsGet methods

### DIFF
--- a/langspec.puya.json
+++ b/langspec.puya.json
@@ -6889,7 +6889,7 @@
             "stack_inputs": [
                 {
                     "name": "A",
-                    "stack_type": "any",
+                    "stack_type": "address_or_index",
                     "doc": null
                 }
             ],

--- a/scripts/transform_lang_spec.py
+++ b/scripts/transform_lang_spec.py
@@ -260,6 +260,7 @@ def _patch_lang_spec(lang_spec: dict[str, typing.Any]) -> None:
         "asset_holding_get",
         "balance",
         "min_balance",
+        "voter_params_get",
     ):
         _patch_arg_type(ops, op_name, 0, "any", "address_or_index")
 

--- a/src/puya/ir/avm_ops.py
+++ b/src/puya/ir/avm_ops.py
@@ -6258,7 +6258,8 @@ class AVMOp(enum.StrEnum):
             variant_map={
                 "VoterBalance": Variant(
                     signature=OpSignature(
-                        args=[StackType.any], returns=[StackType.uint64, StackType.bool]
+                        args=[StackType.address_or_index],
+                        returns=[StackType.uint64, StackType.bool],
                     ),
                     enum="VoterBalance",
                     supported_modes=RunMode.app,
@@ -6266,7 +6267,7 @@ class AVMOp(enum.StrEnum):
                 ),
                 "VoterIncentiveEligible": Variant(
                     signature=OpSignature(
-                        args=[StackType.any], returns=[StackType.bool, StackType.bool]
+                        args=[StackType.address_or_index], returns=[StackType.bool, StackType.bool]
                     ),
                     enum="VoterIncentiveEligible",
                     supported_modes=RunMode.app,

--- a/src/puyapy/awst_build/intrinsic_data.py
+++ b/src/puyapy/awst_build/intrinsic_data.py
@@ -5382,7 +5382,7 @@ NAMESPACE_CLASSES: typing.Final[
                 FunctionOpMapping(
                     "voter_params_get",
                     immediates=["VoterBalance"],
-                    args=[(pytypes.BytesType, pytypes.UInt64Type)],
+                    args=[(pytypes.AccountType, pytypes.UInt64Type)],
                 ),
             ],
         ),
@@ -5395,7 +5395,7 @@ NAMESPACE_CLASSES: typing.Final[
                 FunctionOpMapping(
                     "voter_params_get",
                     immediates=["VoterIncentiveEligible"],
-                    args=[(pytypes.BytesType, pytypes.UInt64Type)],
+                    args=[(pytypes.AccountType, pytypes.UInt64Type)],
                 ),
             ],
         ),

--- a/stubs/algopy-stubs/op.pyi
+++ b/stubs/algopy-stubs/op.pyi
@@ -3864,7 +3864,7 @@ class VoterParamsGet:
     Native TEAL op: [`voter_params_get`](https://developer.algorand.org/docs/get-details/dapps/avm/teal/opcodes/v10/#voter_params_get)
     """
     @staticmethod
-    def voter_balance(a: Bytes | UInt64 | bytes | int, /) -> tuple[UInt64, bool]:
+    def voter_balance(a: Account | UInt64 | int, /) -> tuple[UInt64, bool]:
         """
         Min AVM version: 11
         :returns tuple[UInt64, bool]: Online stake in microalgos
@@ -3873,7 +3873,7 @@ class VoterParamsGet:
         """
 
     @staticmethod
-    def voter_incentive_eligible(a: Bytes | UInt64 | bytes | int, /) -> tuple[bool, bool]:
+    def voter_incentive_eligible(a: Account | UInt64 | int, /) -> tuple[bool, bool]:
         """
         Min AVM version: 11
         :returns tuple[bool, bool]: Had this account opted into block payouts

--- a/stubs/pyproject.toml
+++ b/stubs/pyproject.toml
@@ -3,7 +3,7 @@ name = "algorand-python"
 # this version represents the version of the stub API's and should follow semver semantics
 # when updating this value also update src/compile.py:MAX_SUPPORTED_ALGOPY_VERSION_EX if it is a major/minor change
 # also see stubs/README.md#versioning
-version = "2.4.0"
+version = "2.4.1"
 description = "API for writing Algorand Python Smart contracts"
 authors = ["Algorand Foundation <contact@algorand.foundation>"]
 readme = "README.md"


### PR DESCRIPTION
## Proposed Changes

According to the [doc](https://github.com/algorand/go-algorand/blob/b2d41d0608b2a3e4c302df358950bdeb8b80be83/data/transactions/logic/TEAL_opcodes_v11.md#voter_params_get), the stack arg `A` of `voter_params_get` op code is an Account which is the same as the stack arg `A` of `acct_params_get` op code. 

This PR changes the type of parameter `a` for the methods of `VoterParamsGet` class to be `Account | UInt64 | int` to be inline with `AcctParamsGet` class. 


