### PR TITLE
Pin poetry version to less than 2.0 in CI/CD

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -69,7 +69,7 @@ jobs:
           token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install "poetry<2.0"
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/check-python.yaml
+++ b/.github/workflows/check-python.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install "poetry<2.0"
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install "poetry<2.0"
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install "poetry<2.0"
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
@@ -126,7 +126,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install "poetry<2.0"
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install "poetry<2.0"
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5


### PR DESCRIPTION
temporarily pinning poetry to `<2.0` until a release for poetry issue [#9961](https://github.com/python-poetry/poetry/issues/9961) is made