### PR TITLE
Don't inline TEAL blocks with a single predecessor when their label is referenced multiple times

### DIFF
--- a/examples/sizes.txt
+++ b/examples/sizes.txt
@@ -102,6 +102,7 @@
  nested_loops/Nested                            213     200       -    |        132     120       - 
  regression_tests/Issue118                      136     102      96    |         75      52      49 
  regression_tests/Issue194                       31       8       -    |         21       4       - 
+ regression_tests/TealSwitchInlining             27      22    None    |         14      10    None 
  reinterpret_cast                               137      83      76    |         70      38      35 
  scratch_slots                                   94      84       -    |         56      43       - 
  scratch_slots/2                                 94      84       -    |         56      43       - 
@@ -138,4 +139,4 @@
  unssa/UnSSA                                    420     266       -    |        237     153       - 
  voting/VotingRoundApp                         1584    1426    1415    |        725     624     625 
  with_reentrancy/WithReentrancy                 245     214       -    |        126     108       - 
- Total                                        70520   39117   36225    |      33296   18249   16976 
+ Total                                        70547   39139   36225    |      33310   18259   16976 

--- a/examples/sizes.txt
+++ b/examples/sizes.txt
@@ -102,7 +102,7 @@
  nested_loops/Nested                            213     200       -    |        132     120       - 
  regression_tests/Issue118                      136     102      96    |         75      52      49 
  regression_tests/Issue194                       31       8       -    |         21       4       - 
- regression_tests/TealSwitchInlining             27      22    None    |         14      10    None 
+ regression_tests/TealSwitchInlining             27      22      19    |         14      10       8 
  reinterpret_cast                               137      83      76    |         70      38      35 
  scratch_slots                                   94      84       -    |         56      43       - 
  scratch_slots/2                                 94      84       -    |         56      43       - 
@@ -139,4 +139,4 @@
  unssa/UnSSA                                    420     266       -    |        237     153       - 
  voting/VotingRoundApp                         1584    1426    1415    |        725     624     625 
  with_reentrancy/WithReentrancy                 245     214       -    |        126     108       - 
- Total                                        70547   39139   36225    |      33310   18259   16976 
+ Total                                        70547   39139   36244    |      33310   18259   16984 

--- a/src/puya/teal/optimize/main.py
+++ b/src/puya/teal/optimize/main.py
@@ -174,13 +174,13 @@ def _remove_unreachable_blocks(teal_sub: models.TealSubroutine) -> None:
 
 
 def _inline_singly_referenced_blocks(teal_sub: models.TealSubroutine) -> None:
-    predecessors = defaultdict[str, set[str]](set)
-    predecessors[teal_sub.blocks[0].label].add("<entrypoint>")
+    predecessors = defaultdict[str, list[str]](list)
+    predecessors[teal_sub.blocks[0].label].append("<entrypoint>")
     for block in teal_sub.blocks:
         for op in block.ops:
             if isinstance(op, models.ControlOp):
                 for target_label in op.targets:
-                    predecessors[target_label].add(block.label)
+                    predecessors[target_label].append(block.label)
 
     pairs = dict[str, str]()
     inlineable = set[str]()
@@ -189,7 +189,7 @@ def _inline_singly_referenced_blocks(teal_sub: models.TealSubroutine) -> None:
             case models.Branch(target=target_label):
                 target_predecessors = predecessors[target_label]
                 if len(target_predecessors) == 1:
-                    assert target_predecessors == {block.label}
+                    assert target_predecessors == [block.label]
                     pairs[block.label] = target_label
                     inlineable.add(target_label)
 

--- a/test_cases/regression_tests/out/TealSwitchInlining.approval.puya.map
+++ b/test_cases/regression_tests/out/TealSwitchInlining.approval.puya.map
@@ -1,0 +1,63 @@
+{
+  "version": 3,
+  "sources": [
+    "../teal_switch_inlining.py"
+  ],
+  "mappings": ";AAUc;;AAAN;;;;;;AAUe;;AAAP;AAFO;;AAAP;AAFO;;AAAP",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program",
+      "params": {},
+      "block": "main",
+      "stack_in": [],
+      "op": "txn NumAppArgs",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "3": {
+      "op": "switch main_switch_case_0@1 main_switch_case_1@2",
+      "stack_out": []
+    },
+    "9": {
+      "op": "pushint 1 // 1"
+    },
+    "11": {
+      "op": "return"
+    },
+    "12": {
+      "block": "main_switch_case_1@2",
+      "stack_in": [],
+      "op": "pushint 0 // 0",
+      "defined_out": [
+        "0"
+      ],
+      "stack_out": [
+        "0"
+      ]
+    },
+    "14": {
+      "op": "return",
+      "stack_out": []
+    },
+    "15": {
+      "block": "main_switch_case_0@1",
+      "stack_in": [],
+      "op": "pushint 1 // 1",
+      "defined_out": [
+        "1"
+      ],
+      "stack_out": [
+        "1"
+      ]
+    },
+    "17": {
+      "op": "return",
+      "stack_out": []
+    }
+  }
+}

--- a/test_cases/regression_tests/out/TealSwitchInlining.approval.teal
+++ b/test_cases/regression_tests/out/TealSwitchInlining.approval.teal
@@ -1,0 +1,37 @@
+#pragma version 10
+#pragma typetrack false
+
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:11
+    // match a.Txn.num_app_args:
+    txn NumAppArgs
+    // regression_tests/teal_switch_inlining.py:11-21
+    // match a.Txn.num_app_args:
+    //     # at -O2, this block and the default block will be de-duplicated,
+    //     # resulting in there being a reference to the default block in the `switch` cases
+    //     # also, which cannot be inlined an must be preserved despite only having a single
+    //     # predecessor block
+    //     case 0:
+    //         return True
+    //     case 1:
+    //         return False
+    //     case _:
+    //         return True
+    switch main_switch_case_0@1 main_switch_case_1@2
+    // regression_tests/teal_switch_inlining.py:21
+    // return True
+    pushint 1 // 1
+    return
+
+main_switch_case_1@2:
+    // regression_tests/teal_switch_inlining.py:19
+    // return False
+    pushint 0 // 0
+    return
+
+main_switch_case_0@1:
+    // regression_tests/teal_switch_inlining.py:17
+    // return True
+    pushint 1 // 1
+    return

--- a/test_cases/regression_tests/out/TealSwitchInlining.clear.puya.map
+++ b/test_cases/regression_tests/out/TealSwitchInlining.clear.puya.map
@@ -1,0 +1,27 @@
+{
+  "version": 3,
+  "sources": [
+    "../teal_switch_inlining.py"
+  ],
+  "mappings": ";AAuBe;;AAAP",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program",
+      "params": {},
+      "block": "main",
+      "stack_in": [],
+      "op": "pushint 1 // 1",
+      "defined_out": [
+        "1"
+      ],
+      "stack_out": [
+        "1"
+      ]
+    },
+    "3": {
+      "op": "return",
+      "stack_out": []
+    }
+  }
+}

--- a/test_cases/regression_tests/out/TealSwitchInlining.clear.teal
+++ b/test_cases/regression_tests/out/TealSwitchInlining.clear.teal
@@ -1,0 +1,9 @@
+#pragma version 10
+#pragma typetrack false
+
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:24
+    // return True
+    pushint 1 // 1
+    return

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.0.ssa.ir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.0.ssa.ir
@@ -1,0 +1,10 @@
+main test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program:
+    block@0: // L10
+        let tmp%0#0: uint64 = (txn NumAppArgs)
+        switch tmp%0#0 {0u => block@1, 1u => block@2, * => block@3}
+    block@1: // switch_case_0_L17
+        return 1u
+    block@2: // switch_case_1_L19
+        return 0u
+    block@3: // switch_case_default_L21
+        return 1u

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.1.ssa.opt.ir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.1.ssa.opt.ir
@@ -1,0 +1,10 @@
+main test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program:
+    block@0: // L10
+        let tmp%0#0: uint64 = (txn NumAppArgs)
+        goto_nth [block@1, block@2][tmp%0#0] else goto block@3
+    block@1: // switch_case_0_L17
+        return 1u
+    block@2: // switch_case_1_L19
+        return 0u
+    block@3: // switch_case_default_L21
+        return 1u

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.2.destructured.ir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.2.destructured.ir
@@ -1,0 +1,10 @@
+main test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program:
+    block@0: // L10
+        let tmp%0#0: uint64 = (txn NumAppArgs)
+        goto_nth [block@1, block@2][tmp%0#0] else goto block@3
+    block@1: // switch_case_0_L17
+        return 1u
+    block@2: // switch_case_1_L19
+        return 0u
+    block@3: // switch_case_default_L21
+        return 1u

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.3.lstack.mir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.3.lstack.mir
@@ -1,0 +1,40 @@
+// Op                                                                                        Stack (out)
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:11
+    // match a.Txn.num_app_args:
+    txn NumAppArgs                                                                           tmp%0#0
+    // regression_tests/teal_switch_inlining.py:11-21
+    // match a.Txn.num_app_args:
+    //     # at -O2, this block and the default block will be de-duplicated,
+    //     # resulting in there being a reference to the default block in the `switch` cases
+    //     # also, which cannot be inlined an must be preserved despite only having a single
+    //     # predecessor block
+    //     case 0:
+    //         return True
+    //     case 1:
+    //         return False
+    //     case _:
+    //         return True
+    l-load tmp%0#0 0                                                                         tmp%0#0
+    switch main_switch_case_0@1 main_switch_case_1@2 ; b main_switch_case_default@3
+
+main_switch_case_0@1:
+    // regression_tests/teal_switch_inlining.py:17
+    // return True
+    int 1                                                                                    1
+    return
+
+main_switch_case_1@2:
+    // regression_tests/teal_switch_inlining.py:19
+    // return False
+    int 0                                                                                    0
+    return
+
+main_switch_case_default@3:
+    // regression_tests/teal_switch_inlining.py:21
+    // return True
+    int 1                                                                                    1
+    return
+
+

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.4.lstack.opt.mir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.4.lstack.opt.mir
@@ -1,0 +1,39 @@
+// Op                                                                                        Stack (out)
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:11
+    // match a.Txn.num_app_args:
+    txn NumAppArgs                                                                           tmp%0#0
+    // regression_tests/teal_switch_inlining.py:11-21
+    // match a.Txn.num_app_args:
+    //     # at -O2, this block and the default block will be de-duplicated,
+    //     # resulting in there being a reference to the default block in the `switch` cases
+    //     # also, which cannot be inlined an must be preserved despite only having a single
+    //     # predecessor block
+    //     case 0:
+    //         return True
+    //     case 1:
+    //         return False
+    //     case _:
+    //         return True
+    switch main_switch_case_0@1 main_switch_case_1@2 ; b main_switch_case_default@3
+
+main_switch_case_0@1:
+    // regression_tests/teal_switch_inlining.py:17
+    // return True
+    int 1                                                                                    1
+    return
+
+main_switch_case_1@2:
+    // regression_tests/teal_switch_inlining.py:19
+    // return False
+    int 0                                                                                    0
+    return
+
+main_switch_case_default@3:
+    // regression_tests/teal_switch_inlining.py:21
+    // return True
+    int 1                                                                                    1
+    return
+
+

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.5.xstack.mir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.5.xstack.mir
@@ -1,0 +1,39 @@
+// Op                                                                                        Stack (out)
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:11
+    // match a.Txn.num_app_args:
+    txn NumAppArgs                                                                           tmp%0#0
+    // regression_tests/teal_switch_inlining.py:11-21
+    // match a.Txn.num_app_args:
+    //     # at -O2, this block and the default block will be de-duplicated,
+    //     # resulting in there being a reference to the default block in the `switch` cases
+    //     # also, which cannot be inlined an must be preserved despite only having a single
+    //     # predecessor block
+    //     case 0:
+    //         return True
+    //     case 1:
+    //         return False
+    //     case _:
+    //         return True
+    switch main_switch_case_0@1 main_switch_case_1@2 ; b main_switch_case_default@3
+
+main_switch_case_0@1:
+    // regression_tests/teal_switch_inlining.py:17
+    // return True
+    int 1                                                                                    1
+    return
+
+main_switch_case_1@2:
+    // regression_tests/teal_switch_inlining.py:19
+    // return False
+    int 0                                                                                    0
+    return
+
+main_switch_case_default@3:
+    // regression_tests/teal_switch_inlining.py:21
+    // return True
+    int 1                                                                                    1
+    return
+
+

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.6.xstack.opt.mir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.6.xstack.opt.mir
@@ -1,0 +1,39 @@
+// Op                                                                                        Stack (out)
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:11
+    // match a.Txn.num_app_args:
+    txn NumAppArgs                                                                           tmp%0#0
+    // regression_tests/teal_switch_inlining.py:11-21
+    // match a.Txn.num_app_args:
+    //     # at -O2, this block and the default block will be de-duplicated,
+    //     # resulting in there being a reference to the default block in the `switch` cases
+    //     # also, which cannot be inlined an must be preserved despite only having a single
+    //     # predecessor block
+    //     case 0:
+    //         return True
+    //     case 1:
+    //         return False
+    //     case _:
+    //         return True
+    switch main_switch_case_0@1 main_switch_case_1@2 ; b main_switch_case_default@3
+
+main_switch_case_0@1:
+    // regression_tests/teal_switch_inlining.py:17
+    // return True
+    int 1                                                                                    1
+    return
+
+main_switch_case_1@2:
+    // regression_tests/teal_switch_inlining.py:19
+    // return False
+    int 0                                                                                    0
+    return
+
+main_switch_case_default@3:
+    // regression_tests/teal_switch_inlining.py:21
+    // return True
+    int 1                                                                                    1
+    return
+
+

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.7.fstack.mir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.7.fstack.mir
@@ -1,0 +1,39 @@
+// Op                                                                                        Stack (out)
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:11
+    // match a.Txn.num_app_args:
+    txn NumAppArgs                                                                           tmp%0#0
+    // regression_tests/teal_switch_inlining.py:11-21
+    // match a.Txn.num_app_args:
+    //     # at -O2, this block and the default block will be de-duplicated,
+    //     # resulting in there being a reference to the default block in the `switch` cases
+    //     # also, which cannot be inlined an must be preserved despite only having a single
+    //     # predecessor block
+    //     case 0:
+    //         return True
+    //     case 1:
+    //         return False
+    //     case _:
+    //         return True
+    switch main_switch_case_0@1 main_switch_case_1@2 ; b main_switch_case_default@3
+
+main_switch_case_0@1:
+    // regression_tests/teal_switch_inlining.py:17
+    // return True
+    int 1                                                                                    1
+    return
+
+main_switch_case_1@2:
+    // regression_tests/teal_switch_inlining.py:19
+    // return False
+    int 0                                                                                    0
+    return
+
+main_switch_case_default@3:
+    // regression_tests/teal_switch_inlining.py:21
+    // return True
+    int 1                                                                                    1
+    return
+
+

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.8.fstack.opt.mir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.8.fstack.opt.mir
@@ -1,0 +1,39 @@
+// Op                                                                                        Stack (out)
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:11
+    // match a.Txn.num_app_args:
+    txn NumAppArgs                                                                           tmp%0#0
+    // regression_tests/teal_switch_inlining.py:11-21
+    // match a.Txn.num_app_args:
+    //     # at -O2, this block and the default block will be de-duplicated,
+    //     # resulting in there being a reference to the default block in the `switch` cases
+    //     # also, which cannot be inlined an must be preserved despite only having a single
+    //     # predecessor block
+    //     case 0:
+    //         return True
+    //     case 1:
+    //         return False
+    //     case _:
+    //         return True
+    switch main_switch_case_0@1 main_switch_case_1@2 ; b main_switch_case_default@3
+
+main_switch_case_0@1:
+    // regression_tests/teal_switch_inlining.py:17
+    // return True
+    int 1                                                                                    1
+    return
+
+main_switch_case_1@2:
+    // regression_tests/teal_switch_inlining.py:19
+    // return False
+    int 0                                                                                    0
+    return
+
+main_switch_case_default@3:
+    // regression_tests/teal_switch_inlining.py:21
+    // return True
+    int 1                                                                                    1
+    return
+
+

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.9.mir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.9.mir
@@ -1,0 +1,39 @@
+// Op                                                                                        Stack (out)
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:11
+    // match a.Txn.num_app_args:
+    txn NumAppArgs                                                                           tmp%0#0
+    // regression_tests/teal_switch_inlining.py:11-21
+    // match a.Txn.num_app_args:
+    //     # at -O2, this block and the default block will be de-duplicated,
+    //     # resulting in there being a reference to the default block in the `switch` cases
+    //     # also, which cannot be inlined an must be preserved despite only having a single
+    //     # predecessor block
+    //     case 0:
+    //         return True
+    //     case 1:
+    //         return False
+    //     case _:
+    //         return True
+    switch main_switch_case_0@1 main_switch_case_1@2 ; b main_switch_case_default@3
+
+main_switch_case_0@1:
+    // regression_tests/teal_switch_inlining.py:17
+    // return True
+    int 1                                                                                    1
+    return
+
+main_switch_case_1@2:
+    // regression_tests/teal_switch_inlining.py:19
+    // return False
+    int 0                                                                                    0
+    return
+
+main_switch_case_default@3:
+    // regression_tests/teal_switch_inlining.py:21
+    // return True
+    int 1                                                                                    1
+    return
+
+

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.0.ssa.ir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.0.ssa.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program:
+    block@0: // L23
+        return 1u

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.1.destructured.ir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.1.destructured.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program:
+    block@0: // L23
+        return 1u

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.2.lstack.mir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.2.lstack.mir
@@ -1,0 +1,9 @@
+// Op                                              Stack (out)
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:24
+    // return True
+    int 1                                          1
+    return
+
+

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.3.lstack.opt.mir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.3.lstack.opt.mir
@@ -1,0 +1,9 @@
+// Op                                              Stack (out)
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:24
+    // return True
+    int 1                                          1
+    return
+
+

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.4.xstack.mir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.4.xstack.mir
@@ -1,0 +1,9 @@
+// Op                                              Stack (out)
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:24
+    // return True
+    int 1                                          1
+    return
+
+

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.5.xstack.opt.mir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.5.xstack.opt.mir
@@ -1,0 +1,9 @@
+// Op                                              Stack (out)
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:24
+    // return True
+    int 1                                          1
+    return
+
+

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.6.fstack.mir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.6.fstack.mir
@@ -1,0 +1,9 @@
+// Op                                              Stack (out)
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:24
+    // return True
+    int 1                                          1
+    return
+
+

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.7.fstack.opt.mir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.7.fstack.opt.mir
@@ -1,0 +1,9 @@
+// Op                                              Stack (out)
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:24
+    // return True
+    int 1                                          1
+    return
+
+

--- a/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.8.mir
+++ b/test_cases/regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.8.mir
@@ -1,0 +1,9 @@
+// Op                                              Stack (out)
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:24
+    // return True
+    int 1                                          1
+    return
+
+

--- a/test_cases/regression_tests/out/module.awst
+++ b/test_cases/regression_tests/out/module.awst
@@ -1,3 +1,29 @@
+contract TealSwitchInlining
+{
+  method_resolution_order: (
+  )
+  
+  subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program(): bool
+  {
+    switch (txn<NumAppArgs>()) {
+      case 0u: {
+        return true
+      }
+      case 1u: {
+        return false
+      }
+      case _: {
+        return true
+      }
+    }
+  }
+  
+  subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program(): bool
+  {
+    return true
+  }
+}
+
 contract Issue194
 {
   method_resolution_order: (

--- a/test_cases/regression_tests/out_O2/TealSwitchInlining.approval.puya.map
+++ b/test_cases/regression_tests/out_O2/TealSwitchInlining.approval.puya.map
@@ -1,0 +1,57 @@
+{
+  "version": 3,
+  "sources": [
+    "../teal_switch_inlining.py"
+  ],
+  "mappings": ";AAUc;;AAAN;;;;;;AAMe;;AAAP;AAEO;;AAAP",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program",
+      "params": {},
+      "block": "main",
+      "stack_in": [],
+      "op": "txn NumAppArgs",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "3": {
+      "op": "switch main_switch_case_0@1 main_switch_case_1@2",
+      "stack_out": []
+    },
+    "9": {
+      "block": "main_switch_case_0@1",
+      "stack_in": [],
+      "op": "pushint 1 // 1",
+      "defined_out": [
+        "1"
+      ],
+      "stack_out": [
+        "1"
+      ]
+    },
+    "11": {
+      "op": "return",
+      "stack_out": []
+    },
+    "12": {
+      "block": "main_switch_case_1@2",
+      "stack_in": [],
+      "op": "pushint 0 // 0",
+      "defined_out": [
+        "0"
+      ],
+      "stack_out": [
+        "0"
+      ]
+    },
+    "14": {
+      "op": "return",
+      "stack_out": []
+    }
+  }
+}

--- a/test_cases/regression_tests/out_O2/TealSwitchInlining.approval.teal
+++ b/test_cases/regression_tests/out_O2/TealSwitchInlining.approval.teal
@@ -1,0 +1,15 @@
+#pragma version 10
+#pragma typetrack false
+
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program() -> uint64:
+main:
+    txn NumAppArgs
+    switch main_switch_case_0@1 main_switch_case_1@2
+
+main_switch_case_0@1:
+    pushint 1 // 1
+    return
+
+main_switch_case_1@2:
+    pushint 0 // 0
+    return

--- a/test_cases/regression_tests/out_O2/TealSwitchInlining.clear.puya.map
+++ b/test_cases/regression_tests/out_O2/TealSwitchInlining.clear.puya.map
@@ -1,0 +1,27 @@
+{
+  "version": 3,
+  "sources": [
+    "../teal_switch_inlining.py"
+  ],
+  "mappings": ";AAuBe;;AAAP",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program",
+      "params": {},
+      "block": "main",
+      "stack_in": [],
+      "op": "pushint 1 // 1",
+      "defined_out": [
+        "1"
+      ],
+      "stack_out": [
+        "1"
+      ]
+    },
+    "3": {
+      "op": "return",
+      "stack_out": []
+    }
+  }
+}

--- a/test_cases/regression_tests/out_O2/TealSwitchInlining.clear.teal
+++ b/test_cases/regression_tests/out_O2/TealSwitchInlining.clear.teal
@@ -1,0 +1,7 @@
+#pragma version 10
+#pragma typetrack false
+
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program() -> uint64:
+main:
+    pushint 1 // 1
+    return

--- a/test_cases/regression_tests/out_O2/TealSwitchInlining.ir/TealSwitchInlining.approval.0.destructured.ir
+++ b/test_cases/regression_tests/out_O2/TealSwitchInlining.ir/TealSwitchInlining.approval.0.destructured.ir
@@ -1,0 +1,8 @@
+main test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program:
+    block@0: // L10
+        let tmp%0#0: uint64 = (txn NumAppArgs)
+        goto_nth [block@1, block@2][tmp%0#0] else goto block@1
+    block@1: // switch_case_0_L17
+        return 1u
+    block@2: // switch_case_1_L19
+        return 0u

--- a/test_cases/regression_tests/out_O2/TealSwitchInlining.ir/TealSwitchInlining.clear.0.destructured.ir
+++ b/test_cases/regression_tests/out_O2/TealSwitchInlining.ir/TealSwitchInlining.clear.0.destructured.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program:
+    block@0: // L23
+        return 1u

--- a/test_cases/regression_tests/out_unoptimized/TealSwitchInlining.approval.puya.map
+++ b/test_cases/regression_tests/out_unoptimized/TealSwitchInlining.approval.puya.map
@@ -1,0 +1,107 @@
+{
+  "version": 3,
+  "sources": [
+    "../teal_switch_inlining.py"
+  ],
+  "mappings": ";;;;;AAUc;;AAKG;AAEA;AAPT;;AAAA;;;;;;AAUe;AAAP;AAFO;AAAP;AAFO;AAAP",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program",
+      "params": {},
+      "block": "main",
+      "stack_in": [],
+      "op": "intcblock 1 0"
+    },
+    "5": {
+      "op": "txn NumAppArgs",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "7": {
+      "op": "intc_1 // 0",
+      "defined_out": [
+        "0",
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0",
+        "0"
+      ]
+    },
+    "8": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "0",
+        "1",
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0",
+        "0",
+        "1"
+      ]
+    },
+    "9": {
+      "op": "uncover 2",
+      "stack_out": [
+        "0",
+        "1",
+        "tmp%0#0"
+      ]
+    },
+    "11": {
+      "op": "match main_switch_case_0@1 main_switch_case_1@2",
+      "stack_out": []
+    },
+    "17": {
+      "block": "main_switch_case_default@3",
+      "stack_in": [],
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "1"
+      ],
+      "stack_out": [
+        "1"
+      ]
+    },
+    "18": {
+      "op": "return",
+      "stack_out": []
+    },
+    "19": {
+      "block": "main_switch_case_1@2",
+      "stack_in": [],
+      "op": "intc_1 // 0",
+      "defined_out": [
+        "0"
+      ],
+      "stack_out": [
+        "0"
+      ]
+    },
+    "20": {
+      "op": "return",
+      "stack_out": []
+    },
+    "21": {
+      "block": "main_switch_case_0@1",
+      "stack_in": [],
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "1"
+      ],
+      "stack_out": [
+        "1"
+      ]
+    },
+    "22": {
+      "op": "return",
+      "stack_out": []
+    }
+  }
+}

--- a/test_cases/regression_tests/out_unoptimized/TealSwitchInlining.approval.teal
+++ b/test_cases/regression_tests/out_unoptimized/TealSwitchInlining.approval.teal
@@ -1,0 +1,51 @@
+#pragma version 10
+#pragma typetrack false
+
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program() -> uint64:
+main:
+    intcblock 1 0
+    // regression_tests/teal_switch_inlining.py:11
+    // match a.Txn.num_app_args:
+    txn NumAppArgs
+    // regression_tests/teal_switch_inlining.py:12-16
+    // # at -O2, this block and the default block will be de-duplicated,
+    // # resulting in there being a reference to the default block in the `switch` cases
+    // # also, which cannot be inlined an must be preserved despite only having a single
+    // # predecessor block
+    // case 0:
+    intc_1 // 0
+    // regression_tests/teal_switch_inlining.py:18
+    // case 1:
+    intc_0 // 1
+    // regression_tests/teal_switch_inlining.py:11-21
+    // match a.Txn.num_app_args:
+    //     # at -O2, this block and the default block will be de-duplicated,
+    //     # resulting in there being a reference to the default block in the `switch` cases
+    //     # also, which cannot be inlined an must be preserved despite only having a single
+    //     # predecessor block
+    //     case 0:
+    //         return True
+    //     case 1:
+    //         return False
+    //     case _:
+    //         return True
+    uncover 2
+    match main_switch_case_0@1 main_switch_case_1@2
+
+main_switch_case_default@3:
+    // regression_tests/teal_switch_inlining.py:21
+    // return True
+    intc_0 // 1
+    return
+
+main_switch_case_1@2:
+    // regression_tests/teal_switch_inlining.py:19
+    // return False
+    intc_1 // 0
+    return
+
+main_switch_case_0@1:
+    // regression_tests/teal_switch_inlining.py:17
+    // return True
+    intc_0 // 1
+    return

--- a/test_cases/regression_tests/out_unoptimized/TealSwitchInlining.clear.puya.map
+++ b/test_cases/regression_tests/out_unoptimized/TealSwitchInlining.clear.puya.map
@@ -1,0 +1,27 @@
+{
+  "version": 3,
+  "sources": [
+    "../teal_switch_inlining.py"
+  ],
+  "mappings": ";AAuBe;;AAAP",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program",
+      "params": {},
+      "block": "main",
+      "stack_in": [],
+      "op": "pushint 1 // 1",
+      "defined_out": [
+        "1"
+      ],
+      "stack_out": [
+        "1"
+      ]
+    },
+    "3": {
+      "op": "return",
+      "stack_out": []
+    }
+  }
+}

--- a/test_cases/regression_tests/out_unoptimized/TealSwitchInlining.clear.teal
+++ b/test_cases/regression_tests/out_unoptimized/TealSwitchInlining.clear.teal
@@ -1,0 +1,9 @@
+#pragma version 10
+#pragma typetrack false
+
+// test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program() -> uint64:
+main:
+    // regression_tests/teal_switch_inlining.py:24
+    // return True
+    pushint 1 // 1
+    return

--- a/test_cases/regression_tests/out_unoptimized/TealSwitchInlining.ir/TealSwitchInlining.approval.0.destructured.ir
+++ b/test_cases/regression_tests/out_unoptimized/TealSwitchInlining.ir/TealSwitchInlining.approval.0.destructured.ir
@@ -1,0 +1,10 @@
+main test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program:
+    block@0: // L10
+        let tmp%0#0: uint64 = (txn NumAppArgs)
+        switch tmp%0#0 {0u => block@1, 1u => block@2, * => block@3}
+    block@1: // switch_case_0_L17
+        return 1u
+    block@2: // switch_case_1_L19
+        return 0u
+    block@3: // switch_case_default_L21
+        return 1u

--- a/test_cases/regression_tests/out_unoptimized/TealSwitchInlining.ir/TealSwitchInlining.clear.0.destructured.ir
+++ b/test_cases/regression_tests/out_unoptimized/TealSwitchInlining.ir/TealSwitchInlining.clear.0.destructured.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program:
+    block@0: // L23
+        return 1u

--- a/test_cases/regression_tests/puya.log
+++ b/test_cases/regression_tests/puya.log
@@ -364,6 +364,55 @@ debug: Added array_head_and_tail#0 to Phi node: let array_head_and_tail#1: bytes
 debug: Added array_head_and_tail#2 to Phi node: let array_head_and_tail#1: bytes = φ(array_head_and_tail#0 <- block@0, array_head_and_tail#2 <- block@3) in block@3
 debug: Sealing block@4
 debug: Terminated block@4
+debug: Building IR for function test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.__puya_arc4_router__
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Sealing block@1
+debug: Terminated block@1
+debug: Sealing block@2
+debug: Terminated block@2
+debug: Sealing block@3
+debug: Terminated block@3
+debug: Building IR for function test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Sealing block@1
+debug: Terminated block@1
+debug: Sealing block@2
+debug: Terminated block@2
+debug: Sealing block@3
+debug: Terminated block@3
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.recalculate_head_for_elements_with_byte_length_head
+debug: Building IR for function test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.recalculate_head_for_elements_with_byte_length_head
 debug: Building IR for function test_cases.regression_tests.issue_194.Issue194.__puya_arc4_router__
 debug: Sealing block@0
 debug: Terminated block@0
@@ -476,6 +525,85 @@ debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_e
 debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
 debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
 debug: removing unused subroutine _puya_lib.arc4.recalculate_head_for_elements_with_byte_length_head
+debug: Output IR to regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.0.ssa.ir
+info: optimizing approval program of test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining at level 1
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: simplifying a switch with constants into goto nth
+debug: simplified terminator of block@0 from switch tmp%0#0 {0u => block@1, 1u => block@2, * => block@3} to goto_nth [block@1, block@2][tmp%0#0] else goto block@3
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Output IR to regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.1.ssa.opt.ir
+debug: Begin optimization pass 2/100
+debug: Optimizing subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: No optimizations performed in pass 2, ending loop
+debug: Performing SSA IR destructuring for test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
+debug: Performing post-SSA optimizations at level 1
+debug: Output IR to regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.approval.2.destructured.ir
+debug: Output IR to regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.0.ssa.ir
+info: optimizing clear program of test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining at level 1
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: Performing SSA IR destructuring for test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program
+debug: Performing post-SSA optimizations at level 1
+debug: Output IR to regression_tests/out/TealSwitchInlining.ir/TealSwitchInlining.clear.1.destructured.ir
+debug: Inserted main.ops[1]: 'l-store-copy tmp%0#0 0'
+debug: Replaced main.ops[3]: 'v-load tmp%0#0' with 'l-load tmp%0#0'
+debug: Found 1 edge set/s for test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
+regression_tests/teal_switch_inlining.py:10 debug: optimizing TEAL subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program() -> uint64:
+debug: inlining single reference block main_switch_case_default@3 into main
+regression_tests/teal_switch_inlining.py:23 debug: optimizing TEAL subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program() -> uint64:
 debug: Output IR to regression_tests/out/Issue194.ir/Issue194.approval.0.ssa.ir
 info: optimizing approval program of test_cases.regression_tests.issue_194.Issue194 at level 1
 debug: Begin optimization pass 1/100
@@ -881,6 +1009,12 @@ debug: removing explicit jump to fall-through block main_after_if_else@10
 regression_tests/issue_118.py:7 debug: optimizing TEAL subroutine test_cases.regression_tests.issue_118.Issue118.verify(values: bytes) -> bytes:
 debug: inlining single reference block verify_if_body@1 into verify
 debug: optimizing TEAL subroutine algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+info: Writing regression_tests/out/TealSwitchInlining.approval.teal
+info: Writing regression_tests/out/TealSwitchInlining.clear.teal
+info: Writing regression_tests/out/TealSwitchInlining.approval.bin
+info: Writing regression_tests/out/TealSwitchInlining.clear.bin
+info: Writing regression_tests/out/TealSwitchInlining.approval.puya.map
+info: Writing regression_tests/out/TealSwitchInlining.clear.puya.map
 info: Writing regression_tests/out/Issue194.approval.teal
 info: Writing regression_tests/out/Issue194.clear.teal
 info: Writing regression_tests/out/Issue194.approval.bin

--- a/test_cases/regression_tests/puya_O2.log
+++ b/test_cases/regression_tests/puya_O2.log
@@ -599,37 +599,439 @@ debug: Inserted main.ops[1]: 'l-store-copy tmp%0#0 0'
 debug: Replaced main.ops[3]: 'v-load tmp%0#0' with 'l-load tmp%0#0'
 debug: Found 1 edge set/s for test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
 regression_tests/teal_switch_inlining.py:10 debug: optimizing TEAL subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program() -> uint64:
-debug: inlining single reference block main_switch_case_0@1 into main
+debug: removing explicit jump to fall-through block main_switch_case_0@1
 regression_tests/teal_switch_inlining.py:23 debug: optimizing TEAL subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program() -> uint64:
-debug: Traceback (most recent call last):
-  File "<git root>/src/puya/errors.py", line 36, in log_exceptions
-    yield
-  File "<git root>/src/puyapy/compile.py", line 77, in compile_to_teal
-    teal = awst_to_teal(
-           ^^^^^^^^^^^^^
-  File "<git root>/src/puya/compile.py", line 71, in awst_to_teal
-    teal = _ir_to_teal(log_ctx, context, ir)
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "<git root>/src/puya/compile.py", line 151, in _ir_to_teal
-    compiled = _contract_ir_to_teal(artifact_context, contract)
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "<git root>/src/puya/compile.py", line 232, in _contract_ir_to_teal
-    approval_program=_compile_program(context, approval),
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "<git root>/src/puya/compile.py", line 252, in _compile_program
-    assembled = assemble_program(context, program)
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "<git root>/src/puya/ussemble/main.py", line 30, in assemble_program
-    return assemble_bytecode_and_debug_info(assemble_ctx, program)
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "<git root>/src/puya/ussemble/assemble.py", line 84, in assemble_bytecode_and_debug_info
-    bytecode.append(_encode_op(avm_op, get_label_offset=get_label_offset))
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "<git root>/src/puya/ussemble/assemble.py", line 260, in _encode_op
-    offsets = [get_label_offset(label) for label in immediate]
-               ^^^^^^^^^^^^^^^^^^^^^^^
-  File "<git root>/src/puya/ussemble/assemble.py", line 82, in get_label_offset
-    return label_pcs[label.name] - pcs[op_index + 1]  # noqa: B023
-           ~~~~~~~~~^^^^^^^^^^^^
-KeyError: 'main_switch_case_0@1'
-critical: KeyError: 'main_switch_case_0@1'
+info: optimizing approval program of test_cases.regression_tests.issue_194.Issue194 at level 2
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.issue_194.Issue194.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Intrinsic Simplifier
+debug: Simplified (!= 1u 0u) to 1u
+debug: Simplified (!= 2u 0u) to 1u
+debug: Simplified (== 1u 1u) to 1u
+debug: Simplified (!= 2u 0u) to 1u
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Removing unused variable tmp%0#0
+debug: Removing unused variable tmp%1#0
+debug: Removing unused variable tmp%2#0
+debug: Removing unused variable two#0
+debug: Removing unused variable tmp%3#0
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: simplifying a switch with constants into goto nth
+debug: simplified terminator of block@0 from switch 1u {1u => block@1, * => block@2} to goto_nth [block@2, block@1][1u] else goto block@2
+debug: simplifying a goto nth with a constant into a goto
+debug: simplified terminator of block@0 from goto_nth [block@2, block@1][1u] else goto block@2 to goto block@1
+debug: Optimizer: Remove Linear Jump
+debug: Merged linear block@1 into block@0
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Removing unreachable blocks: block@2
+debug: Optimizer: Repeated Expression Elimination
+debug: Begin optimization pass 2/100
+debug: Optimizing subroutine test_cases.regression_tests.issue_194.Issue194.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: No optimizations performed in pass 2, ending loop
+debug: Performing SSA IR destructuring for test_cases.regression_tests.issue_194.Issue194.approval_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.issue_194.Issue194.approval_program using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.issue_194.Issue194.approval_program
+debug: Performing post-SSA optimizations at level 2
+debug: Output IR to regression_tests/out_O2/Issue194.ir/Issue194.approval.0.destructured.ir
+info: optimizing clear program of test_cases.regression_tests.issue_194.Issue194 at level 2
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.issue_194.Issue194.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: Performing SSA IR destructuring for test_cases.regression_tests.issue_194.Issue194.clear_state_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.issue_194.Issue194.clear_state_program using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.issue_194.Issue194.clear_state_program
+debug: Performing post-SSA optimizations at level 2
+debug: Output IR to regression_tests/out_O2/Issue194.ir/Issue194.clear.0.destructured.ir
+regression_tests/issue_194.py:6 debug: optimizing TEAL subroutine test_cases.regression_tests.issue_194.Issue194.approval_program() -> uint64:
+regression_tests/issue_194.py:15 debug: optimizing TEAL subroutine test_cases.regression_tests.issue_194.Issue194.clear_state_program() -> uint64:
+info: optimizing approval program of test_cases.regression_tests.issue_118.Issue118 at level 2
+debug: Begin optimization pass 1/100
+debug: marking single-use function test_cases.regression_tests.issue_118.Issue118.verify for inlining
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: inlining call to test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__ in algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Intrinsic Simplifier
+debug: Simplified (== tmp%3#0 NoOp) to (! tmp%3#0)
+debug: Simplified (== tmp%11#0 0u) to (! tmp%11#0)
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Removing unused variable tmp%1#0
+debug: Removing unused variable tmp%6#0
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: simplifying a switch with constants into goto nth
+debug: simplified terminator of block@6 from switch tmp%10#0 {0u => block@7, * => block@8} to goto_nth [block@7][tmp%10#0] else goto block@8
+debug: simplifying a goto nth with two targets into a conditional branch
+debug: simplified terminator of block@6 from goto_nth [block@7][tmp%10#0] else goto block@8 to goto tmp%10#0 ? block@8 : block@7
+debug: Optimizer: Remove Linear Jump
+debug: Replaced predecessor block@1 with block@0 in block@6
+debug: Replaced predecessor block@1 with block@0 in block@2
+debug: Merged linear block@1 into block@0
+debug: Replaced predecessor block@5 with block@4 in block@10
+debug: Merged linear block@5 into block@4
+debug: Replaced predecessor block@9 with block@8 in block@10
+debug: Merged linear block@9 into block@8
+debug: Optimizer: Remove Empty Blocks
+debug: Removed empty block: block@4
+debug: Removed empty block: block@8
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizing subroutine test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__
+debug: Optimizer: Perform Subroutine Inlining
+debug: inlining call to test_cases.regression_tests.issue_118.Issue118.__algopy_default_create in test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__
+regression_tests/issue_118.py:7:6 debug: inlining call to test_cases.regression_tests.issue_118.Issue118.verify in test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Found equivalence set: tmp%7#0, values#0
+debug: Found equivalence set: encoded_bool%0#0, val1#0
+debug: Copy propagation made 2 modifications
+debug: Optimizer: Intrinsic Simplifier
+debug: Simplified (== tmp%3#0 NoOp) to (! tmp%3#0)
+debug: Simplified (setbit 0x00 0u to_encode%0#0) to (setbit 0x00 0u tmp%0#1)
+debug: Simplified (concat 0x val1#0) to val1#0
+debug: Simplified ((extract 6 2) as_bytes%0#0) to 0x0003
+debug: Simplified (len 0x0000) to 2u
+debug: Simplified (+ 3u 2u) to 5u
+debug: Simplified (concat 0x val1#0) to val1#0
+debug: Simplified ((extract 6 2) as_bytes%1#0) to 0x0003
+debug: Simplified (len 0x0000) to 2u
+debug: Simplified (+ 3u 2u) to 5u
+debug: Simplified (== tmp%11#0 0u) to (! tmp%11#0)
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Removing unused variable tmp%1#0
+debug: Removing unused variable tmp%6#0
+debug: Removing unused variable to_encode%0#0
+debug: Removing unused variable current_tail_offset%0#0
+debug: Removing unused variable encoded_tuple_buffer%0#0
+debug: Removing unused variable encoded_tuple_buffer%1#0
+debug: Removing unused variable as_bytes%0#0
+debug: Removing unused variable offset_as_uint16%0#0
+debug: Removing unused variable data_length%0#0
+debug: Removing unused variable current_tail_offset%1#0
+debug: Removing unused variable current_tail_offset%2#0
+debug: Removing unused variable encoded_tuple_buffer%4#0
+debug: Removing unused variable encoded_tuple_buffer%5#0
+debug: Removing unused variable as_bytes%1#0
+debug: Removing unused variable offset_as_uint16%1#0
+debug: Removing unused variable data_length%1#0
+debug: Removing unused variable current_tail_offset%3#0
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: simplifying a switch with constants into goto nth
+debug: simplified terminator of block@5 from switch tmp%10#0 {0u => block@6, * => block@7} to goto_nth [block@6][tmp%10#0] else goto block@7
+debug: simplifying a goto nth with two targets into a conditional branch
+debug: simplified terminator of block@5 from goto_nth [block@6][tmp%10#0] else goto block@7 to goto tmp%10#0 ? block@7 : block@6
+debug: Optimizer: Remove Linear Jump
+debug: Replaced predecessor block@12 with block@2 in block@14
+debug: Replaced predecessor block@12 with block@2 in block@13
+debug: Merged linear block@12 into block@2
+debug: Replaced predecessor block@4 with block@3 in block@9
+debug: Merged linear block@4 into block@3
+debug: Replaced predecessor block@10 with block@6 in block@11
+debug: Merged linear block@10 into block@6
+debug: Merged linear block@11 into block@6
+debug: Replaced predecessor block@8 with block@7 in block@9
+debug: Merged linear block@8 into block@7
+debug: Optimizer: Remove Empty Blocks
+debug: Removed empty block: block@3
+debug: Removed empty block: block@7
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizing subroutine test_cases.regression_tests.issue_118.Issue118.verify
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Found equivalence set: encoded_bool%0#0, val1#0
+debug: Copy propagation made 1 modifications
+debug: Optimizer: Intrinsic Simplifier
+debug: Simplified (setbit 0x00 0u to_encode%0#0) to (setbit 0x00 0u tmp%0#0)
+debug: Simplified (concat 0x val1#0) to val1#0
+debug: Simplified ((extract 6 2) as_bytes%0#0) to 0x0003
+debug: Simplified (len 0x0000) to 2u
+debug: Simplified (+ 3u 2u) to 5u
+debug: Simplified (concat 0x val1#0) to val1#0
+debug: Simplified ((extract 6 2) as_bytes%1#0) to 0x0003
+debug: Simplified (len 0x0000) to 2u
+debug: Simplified (+ 3u 2u) to 5u
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Removing unused variable to_encode%0#0
+debug: Removing unused variable current_tail_offset%0#0
+debug: Removing unused variable encoded_tuple_buffer%0#0
+debug: Removing unused variable encoded_tuple_buffer%1#0
+debug: Removing unused variable as_bytes%0#0
+debug: Removing unused variable offset_as_uint16%0#0
+debug: Removing unused variable data_length%0#0
+debug: Removing unused variable current_tail_offset%1#0
+debug: Removing unused variable current_tail_offset%2#0
+debug: Removing unused variable encoded_tuple_buffer%4#0
+debug: Removing unused variable encoded_tuple_buffer%5#0
+debug: Removing unused variable as_bytes%1#0
+debug: Removing unused variable offset_as_uint16%1#0
+debug: Removing unused variable data_length%1#0
+debug: Removing unused variable current_tail_offset%3#0
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizing subroutine test_cases.regression_tests.issue_118.Issue118.__algopy_default_create
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: removing unused subroutine test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__
+debug: Begin optimization pass 2/100
+debug: marking single-use function test_cases.regression_tests.issue_118.Issue118.verify for inlining
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: inlining call to test_cases.regression_tests.issue_118.Issue118.__algopy_default_create in algopy.arc4.ARC4Contract.approval_program
+regression_tests/issue_118.py:7:6 debug: inlining call to test_cases.regression_tests.issue_118.Issue118.verify in algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Found equivalence set: tmp%7#0, values#0
+debug: Copy propagation made 1 modifications
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Replaced predecessor block@14 with block@3 in block@16
+debug: Replaced predecessor block@14 with block@3 in block@15
+debug: Merged linear block@14 into block@3
+debug: Replaced predecessor block@12 with block@7 in block@13
+debug: Merged linear block@12 into block@7
+debug: Replaced predecessor block@13 with block@7 in block@11
+debug: Merged linear block@13 into block@7
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizing subroutine test_cases.regression_tests.issue_118.Issue118.verify
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizing subroutine test_cases.regression_tests.issue_118.Issue118.__algopy_default_create
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: removing unused subroutine test_cases.regression_tests.issue_118.Issue118.verify
+debug: removing unused subroutine test_cases.regression_tests.issue_118.Issue118.__algopy_default_create
+debug: Begin optimization pass 3/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: No optimizations performed in pass 3, ending loop
+debug: Performing SSA IR destructuring for algopy.arc4.ARC4Contract.approval_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in algopy.arc4.ARC4Contract.approval_program using strategy RootOperandGrouping
+debug: Coalescing tmp%0#1 with [tmp%0#2]
+debug: Coalescing tmp%8#0 with [tmp%8#1]
+debug: Coalescing test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0 with [test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#1, test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#2]
+debug: Coalescing tmp%0#0 with [tmp%0#3]
+debug: Coalescing resulted in 13 replacement/s
+debug: Sequentializing parallel copies in algopy.arc4.ARC4Contract.approval_program
+debug: Performing post-SSA optimizations at level 2
+debug: Output IR to regression_tests/out_O2/Issue118.ir/Issue118.approval.0.destructured.ir
+info: optimizing clear program of test_cases.regression_tests.issue_118.Issue118 at level 2
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: Performing SSA IR destructuring for algopy.arc4.ARC4Contract.clear_state_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in algopy.arc4.ARC4Contract.clear_state_program using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in algopy.arc4.ARC4Contract.clear_state_program
+debug: Performing post-SSA optimizations at level 2
+debug: Output IR to regression_tests/out_O2/Issue118.ir/Issue118.clear.0.destructured.ir
+debug: Inserted main.ops[1]: 'l-store-copy tmp%0#1 0'
+debug: Replaced main.ops[3]: 'v-load tmp%0#1' with 'l-load tmp%0#1'
+debug: Inserted main_abi_routing@2.ops[1]: 'l-store-copy tmp%2#0 0'
+debug: Replaced main_abi_routing@2.ops[4]: 'v-load tmp%2#0' with 'l-load tmp%2#0'
+debug: Inserted main_verify_route@3.ops[1]: 'l-store-copy tmp%3#0 0'
+debug: Replaced main_verify_route@3.ops[3]: 'v-load tmp%3#0' with 'l-load tmp%3#0'
+debug: Inserted main_verify_route@3.ops[5]: 'l-store-copy tmp%4#0 0'
+debug: Replaced main_verify_route@3.ops[7]: 'v-load tmp%4#0' with 'l-load tmp%4#0'
+debug: Inserted main_verify_route@3.ops[10]: 'l-store-copy tmp%5#0 0'
+debug: Replaced main_verify_route@3.ops[12]: 'v-load tmp%5#0' with 'l-load tmp%5#0'
+debug: Inserted main_verify_route@3.ops[26]: 'l-store-copy tmp%1#0 0'
+debug: Replaced main_verify_route@3.ops[28]: 'v-load tmp%1#0' with 'l-load tmp%1#0'
+debug: Inserted main_verify_route@3.ops[31]: 'l-store-copy tmp%2#1 0'
+debug: Replaced main_verify_route@3.ops[33]: 'v-load tmp%2#1' with 'l-load tmp%2#1'
+debug: Inserted main_verify_route@3.ops[17]: 'l-store-copy tmp%0#1 0'
+debug: Replaced main_verify_route@3.ops[21]: 'v-load tmp%0#1' with 'l-load tmp%0#1'
+debug: Inserted main_verify_route@3.ops[15]: 'l-store-copy values#0 0'
+debug: Replaced main_verify_route@3.ops[25]: 'v-load values#0' with 'l-load values#0'
+debug: Inserted main_if_body@15.ops[3]: 'l-store-copy encoded_tuple_buffer%2#0 0'
+debug: Replaced main_if_body@15.ops[5]: 'v-load encoded_tuple_buffer%2#0' with 'l-load encoded_tuple_buffer%2#0'
+debug: Inserted main_if_body@15.ops[8]: 'l-store-copy encoded_tuple_buffer%3#0 0'
+debug: Replaced main_if_body@15.ops[10]: 'v-load encoded_tuple_buffer%3#0' with 'l-load encoded_tuple_buffer%3#0'
+debug: Inserted main_after_if_else@16.ops[3]: 'l-store-copy encoded_tuple_buffer%6#0 0'
+debug: Replaced main_after_if_else@16.ops[5]: 'v-load encoded_tuple_buffer%6#0' with 'l-load encoded_tuple_buffer%6#0'
+debug: Inserted main_after_if_else@16.ops[8]: 'l-store-copy encoded_tuple_buffer%7#0 0'
+debug: Replaced main_after_if_else@16.ops[10]: 'v-load encoded_tuple_buffer%7#0' with 'l-load encoded_tuple_buffer%7#0'
+debug: Inserted main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17.ops[3]: 'l-store-copy tmp%9#0 0'
+debug: Replaced main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17.ops[5]: 'v-load tmp%9#0' with 'l-load tmp%9#0'
+debug: Inserted main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17.ops[8]: 'l-store-copy test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0 0'
+debug: Replaced main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17.ops[10]: 'v-load test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0' with 'l-load test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0'
+debug: Inserted main_bare_routing@6.ops[1]: 'l-store-copy tmp%10#0 0'
+debug: Replaced main_bare_routing@6.ops[3]: 'v-load tmp%10#0' with 'l-load tmp%10#0'
+debug: Inserted main___algopy_default_create@7.ops[1]: 'l-store-copy tmp%11#0 0'
+debug: Replaced main___algopy_default_create@7.ops[3]: 'v-load tmp%11#0' with 'l-load tmp%11#0'
+debug: Inserted main___algopy_default_create@7.ops[5]: 'l-store-copy tmp%12#0 0'
+debug: Replaced main___algopy_default_create@7.ops[7]: 'v-load tmp%12#0' with 'l-load tmp%12#0'
+debug: Inserted main___algopy_default_create@7.ops[10]: 'l-store-copy test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0 0'
+debug: Replaced main___algopy_default_create@7.ops[12]: 'v-load test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0' with 'l-load test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0'
+debug: Inserted main_after_if_else@10.ops[1]: 'l-store-copy test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0 0'
+debug: Replaced main_after_if_else@10.ops[3]: 'v-load test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0' with 'l-load test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0'
+debug: Found 5 edge set/s for algopy.arc4.ARC4Contract.approval_program
+debug: Allocated 3 variable/s to x-stack: tmp%0#0, tmp%8#0, val1#0
+debug: shared x-stack for main_verify_route@3 -> main_if_body@15: val1#0
+debug: shared x-stack for main_verify_route@3 -> main_after_if_else@16: val1#0
+debug: shared x-stack for main_if_body@15 -> main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17: tmp%8#0
+debug: shared x-stack for main_after_if_else@16 -> main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17: tmp%8#0
+debug: shared x-stack for main___algopy_default_create@7 -> main_after_inlined_test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__@11: tmp%0#0
+debug: shared x-stack for main_after_if_else@10 -> main_after_inlined_test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__@11: tmp%0#0
+debug: shared x-stack for main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17 -> main_after_inlined_test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__@11: tmp%0#0
+debug: optimizing TEAL subroutine algopy.arc4.ARC4Contract.approval_program() -> uint64:
+debug: replacing `b main_after_inlined_test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__@11` with `return`
+debug: replacing `b main_after_inlined_test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__@11` with `return`
+debug: inlining single reference block main_abi_routing@2 into main
+debug: inlining single reference block main_after_inlined_test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__@11 into main_after_if_else@10
+debug: inlining single reference block main_if_body@15 into main_verify_route@3
+debug: inlining single reference block main___algopy_default_create@7 into main_bare_routing@6
+debug: removing explicit jump to fall-through block main_after_if_else@10
+debug: removing explicit jump to fall-through block main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17
+debug: optimizing TEAL subroutine algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+info: Writing regression_tests/out_O2/TealSwitchInlining.approval.teal
+info: Writing regression_tests/out_O2/TealSwitchInlining.clear.teal
+info: Writing regression_tests/out_O2/TealSwitchInlining.approval.bin
+info: Writing regression_tests/out_O2/TealSwitchInlining.clear.bin
+info: Writing regression_tests/out_O2/TealSwitchInlining.approval.puya.map
+info: Writing regression_tests/out_O2/TealSwitchInlining.clear.puya.map
+info: Writing regression_tests/out_O2/Issue194.approval.teal
+info: Writing regression_tests/out_O2/Issue194.clear.teal
+info: Writing regression_tests/out_O2/Issue194.approval.bin
+info: Writing regression_tests/out_O2/Issue194.clear.bin
+info: Writing regression_tests/out_O2/Issue194.approval.puya.map
+info: Writing regression_tests/out_O2/Issue194.clear.puya.map
+info: Writing regression_tests/out_O2/Issue118.approval.teal
+info: Writing regression_tests/out_O2/Issue118.clear.teal
+info: Writing regression_tests/out_O2/Issue118.approval.bin
+info: Writing regression_tests/out_O2/Issue118.clear.bin
+info: Writing regression_tests/out_O2/Issue118.approval.puya.map
+info: Writing regression_tests/out_O2/Issue118.clear.puya.map

--- a/test_cases/regression_tests/puya_O2.log
+++ b/test_cases/regression_tests/puya_O2.log
@@ -363,6 +363,55 @@ debug: Added array_head_and_tail#0 to Phi node: let array_head_and_tail#1: bytes
 debug: Added array_head_and_tail#2 to Phi node: let array_head_and_tail#1: bytes = φ(array_head_and_tail#0 <- block@0, array_head_and_tail#2 <- block@3) in block@3
 debug: Sealing block@4
 debug: Terminated block@4
+debug: Building IR for function test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.__puya_arc4_router__
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Sealing block@1
+debug: Terminated block@1
+debug: Sealing block@2
+debug: Terminated block@2
+debug: Sealing block@3
+debug: Terminated block@3
+debug: Building IR for function test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Sealing block@1
+debug: Terminated block@1
+debug: Sealing block@2
+debug: Terminated block@2
+debug: Sealing block@3
+debug: Terminated block@3
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.recalculate_head_for_elements_with_byte_length_head
+debug: Building IR for function test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.recalculate_head_for_elements_with_byte_length_head
 debug: Building IR for function test_cases.regression_tests.issue_194.Issue194.__puya_arc4_router__
 debug: Sealing block@0
 debug: Terminated block@0
@@ -475,40 +524,27 @@ debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_e
 debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
 debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
 debug: removing unused subroutine _puya_lib.arc4.recalculate_head_for_elements_with_byte_length_head
-info: optimizing approval program of test_cases.regression_tests.issue_194.Issue194 at level 2
+info: optimizing approval program of test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining at level 2
 debug: Begin optimization pass 1/100
-debug: Optimizing subroutine test_cases.regression_tests.issue_194.Issue194.approval_program
+debug: Optimizing subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
 debug: Optimizer: Perform Subroutine Inlining
 debug: Optimizer: Split Parallel Copies
 debug: Optimizer: Constant Replacer
 debug: Optimizer: Copy Propagation
 debug: Optimizer: Intrinsic Simplifier
-debug: Simplified (!= 1u 0u) to 1u
-debug: Simplified (!= 2u 0u) to 1u
-debug: Simplified (== 1u 1u) to 1u
-debug: Simplified (!= 2u 0u) to 1u
 debug: Optimizer: Elide Itxn Field Calls
 debug: Optimizer: Remove Unused Variables
-debug: Removing unused variable tmp%0#0
-debug: Removing unused variable tmp%1#0
-debug: Removing unused variable tmp%2#0
-debug: Removing unused variable two#0
-debug: Removing unused variable tmp%3#0
 debug: Optimizer: Inner Txn Field Replacer
 debug: Optimizer: Replace Compiled References
 debug: Optimizer: Simplify Control Ops
 debug: simplifying a switch with constants into goto nth
-debug: simplified terminator of block@0 from switch 1u {1u => block@1, * => block@2} to goto_nth [block@2, block@1][1u] else goto block@2
-debug: simplifying a goto nth with a constant into a goto
-debug: simplified terminator of block@0 from goto_nth [block@2, block@1][1u] else goto block@2 to goto block@1
+debug: simplified terminator of block@0 from switch tmp%0#0 {0u => block@1, 1u => block@2, * => block@3} to goto_nth [block@1, block@2][tmp%0#0] else goto block@3
 debug: Optimizer: Remove Linear Jump
-debug: Merged linear block@1 into block@0
 debug: Optimizer: Remove Empty Blocks
 debug: Optimizer: Remove Unreachable Blocks
-debug: Removing unreachable blocks: block@2
 debug: Optimizer: Repeated Expression Elimination
 debug: Begin optimization pass 2/100
-debug: Optimizing subroutine test_cases.regression_tests.issue_194.Issue194.approval_program
+debug: Optimizing subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
 debug: Optimizer: Perform Subroutine Inlining
 debug: Optimizer: Split Parallel Copies
 debug: Optimizer: Constant Replacer
@@ -524,17 +560,18 @@ debug: Optimizer: Remove Empty Blocks
 debug: Optimizer: Remove Unreachable Blocks
 debug: Optimizer: Repeated Expression Elimination
 debug: No optimizations performed in pass 2, ending loop
-debug: Performing SSA IR destructuring for test_cases.regression_tests.issue_194.Issue194.approval_program
+debug: Performing SSA IR destructuring for test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
 debug: Converting to CSSA
 debug: Removing Phi nodes
-debug: Coalescing local variables in test_cases.regression_tests.issue_194.Issue194.approval_program using strategy RootOperandGrouping
+debug: Coalescing local variables in test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program using strategy RootOperandGrouping
 debug: Coalescing resulted in 0 replacement/s
-debug: Sequentializing parallel copies in test_cases.regression_tests.issue_194.Issue194.approval_program
+debug: Sequentializing parallel copies in test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
 debug: Performing post-SSA optimizations at level 2
-debug: Output IR to regression_tests/out_O2/Issue194.ir/Issue194.approval.0.destructured.ir
-info: optimizing clear program of test_cases.regression_tests.issue_194.Issue194 at level 2
+debug: Removing duplicated block block@3 and updating references to block@1
+debug: Output IR to regression_tests/out_O2/TealSwitchInlining.ir/TealSwitchInlining.approval.0.destructured.ir
+info: optimizing clear program of test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining at level 2
 debug: Begin optimization pass 1/100
-debug: Optimizing subroutine test_cases.regression_tests.issue_194.Issue194.clear_state_program
+debug: Optimizing subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program
 debug: Optimizer: Perform Subroutine Inlining
 debug: Optimizer: Split Parallel Copies
 debug: Optimizer: Constant Replacer
@@ -550,356 +587,49 @@ debug: Optimizer: Remove Empty Blocks
 debug: Optimizer: Remove Unreachable Blocks
 debug: Optimizer: Repeated Expression Elimination
 debug: No optimizations performed in pass 1, ending loop
-debug: Performing SSA IR destructuring for test_cases.regression_tests.issue_194.Issue194.clear_state_program
+debug: Performing SSA IR destructuring for test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program
 debug: Converting to CSSA
 debug: Removing Phi nodes
-debug: Coalescing local variables in test_cases.regression_tests.issue_194.Issue194.clear_state_program using strategy RootOperandGrouping
+debug: Coalescing local variables in test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program using strategy RootOperandGrouping
 debug: Coalescing resulted in 0 replacement/s
-debug: Sequentializing parallel copies in test_cases.regression_tests.issue_194.Issue194.clear_state_program
+debug: Sequentializing parallel copies in test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program
 debug: Performing post-SSA optimizations at level 2
-debug: Output IR to regression_tests/out_O2/Issue194.ir/Issue194.clear.0.destructured.ir
-regression_tests/issue_194.py:6 debug: optimizing TEAL subroutine test_cases.regression_tests.issue_194.Issue194.approval_program() -> uint64:
-regression_tests/issue_194.py:15 debug: optimizing TEAL subroutine test_cases.regression_tests.issue_194.Issue194.clear_state_program() -> uint64:
-info: optimizing approval program of test_cases.regression_tests.issue_118.Issue118 at level 2
-debug: Begin optimization pass 1/100
-debug: marking single-use function test_cases.regression_tests.issue_118.Issue118.verify for inlining
-debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
-debug: Optimizer: Perform Subroutine Inlining
-debug: inlining call to test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__ in algopy.arc4.ARC4Contract.approval_program
-debug: Optimizer: Split Parallel Copies
-debug: Optimizer: Constant Replacer
-debug: Optimizer: Copy Propagation
-debug: Optimizer: Intrinsic Simplifier
-debug: Simplified (== tmp%3#0 NoOp) to (! tmp%3#0)
-debug: Simplified (== tmp%11#0 0u) to (! tmp%11#0)
-debug: Optimizer: Elide Itxn Field Calls
-debug: Optimizer: Remove Unused Variables
-debug: Removing unused variable tmp%1#0
-debug: Removing unused variable tmp%6#0
-debug: Optimizer: Inner Txn Field Replacer
-debug: Optimizer: Replace Compiled References
-debug: Optimizer: Simplify Control Ops
-debug: simplifying a switch with constants into goto nth
-debug: simplified terminator of block@6 from switch tmp%10#0 {0u => block@7, * => block@8} to goto_nth [block@7][tmp%10#0] else goto block@8
-debug: simplifying a goto nth with two targets into a conditional branch
-debug: simplified terminator of block@6 from goto_nth [block@7][tmp%10#0] else goto block@8 to goto tmp%10#0 ? block@8 : block@7
-debug: Optimizer: Remove Linear Jump
-debug: Replaced predecessor block@1 with block@0 in block@6
-debug: Replaced predecessor block@1 with block@0 in block@2
-debug: Merged linear block@1 into block@0
-debug: Replaced predecessor block@5 with block@4 in block@10
-debug: Merged linear block@5 into block@4
-debug: Replaced predecessor block@9 with block@8 in block@10
-debug: Merged linear block@9 into block@8
-debug: Optimizer: Remove Empty Blocks
-debug: Removed empty block: block@4
-debug: Removed empty block: block@8
-debug: Optimizer: Remove Unreachable Blocks
-debug: Optimizer: Repeated Expression Elimination
-debug: Optimizing subroutine test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__
-debug: Optimizer: Perform Subroutine Inlining
-debug: inlining call to test_cases.regression_tests.issue_118.Issue118.__algopy_default_create in test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__
-regression_tests/issue_118.py:7:6 debug: inlining call to test_cases.regression_tests.issue_118.Issue118.verify in test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__
-debug: Optimizer: Split Parallel Copies
-debug: Optimizer: Constant Replacer
-debug: Optimizer: Copy Propagation
-debug: Found equivalence set: tmp%7#0, values#0
-debug: Found equivalence set: encoded_bool%0#0, val1#0
-debug: Copy propagation made 2 modifications
-debug: Optimizer: Intrinsic Simplifier
-debug: Simplified (== tmp%3#0 NoOp) to (! tmp%3#0)
-debug: Simplified (setbit 0x00 0u to_encode%0#0) to (setbit 0x00 0u tmp%0#1)
-debug: Simplified (concat 0x val1#0) to val1#0
-debug: Simplified ((extract 6 2) as_bytes%0#0) to 0x0003
-debug: Simplified (len 0x0000) to 2u
-debug: Simplified (+ 3u 2u) to 5u
-debug: Simplified (concat 0x val1#0) to val1#0
-debug: Simplified ((extract 6 2) as_bytes%1#0) to 0x0003
-debug: Simplified (len 0x0000) to 2u
-debug: Simplified (+ 3u 2u) to 5u
-debug: Simplified (== tmp%11#0 0u) to (! tmp%11#0)
-debug: Optimizer: Elide Itxn Field Calls
-debug: Optimizer: Remove Unused Variables
-debug: Removing unused variable tmp%1#0
-debug: Removing unused variable tmp%6#0
-debug: Removing unused variable to_encode%0#0
-debug: Removing unused variable current_tail_offset%0#0
-debug: Removing unused variable encoded_tuple_buffer%0#0
-debug: Removing unused variable encoded_tuple_buffer%1#0
-debug: Removing unused variable as_bytes%0#0
-debug: Removing unused variable offset_as_uint16%0#0
-debug: Removing unused variable data_length%0#0
-debug: Removing unused variable current_tail_offset%1#0
-debug: Removing unused variable current_tail_offset%2#0
-debug: Removing unused variable encoded_tuple_buffer%4#0
-debug: Removing unused variable encoded_tuple_buffer%5#0
-debug: Removing unused variable as_bytes%1#0
-debug: Removing unused variable offset_as_uint16%1#0
-debug: Removing unused variable data_length%1#0
-debug: Removing unused variable current_tail_offset%3#0
-debug: Optimizer: Inner Txn Field Replacer
-debug: Optimizer: Replace Compiled References
-debug: Optimizer: Simplify Control Ops
-debug: simplifying a switch with constants into goto nth
-debug: simplified terminator of block@5 from switch tmp%10#0 {0u => block@6, * => block@7} to goto_nth [block@6][tmp%10#0] else goto block@7
-debug: simplifying a goto nth with two targets into a conditional branch
-debug: simplified terminator of block@5 from goto_nth [block@6][tmp%10#0] else goto block@7 to goto tmp%10#0 ? block@7 : block@6
-debug: Optimizer: Remove Linear Jump
-debug: Replaced predecessor block@12 with block@2 in block@14
-debug: Replaced predecessor block@12 with block@2 in block@13
-debug: Merged linear block@12 into block@2
-debug: Replaced predecessor block@4 with block@3 in block@9
-debug: Merged linear block@4 into block@3
-debug: Replaced predecessor block@10 with block@6 in block@11
-debug: Merged linear block@10 into block@6
-debug: Merged linear block@11 into block@6
-debug: Replaced predecessor block@8 with block@7 in block@9
-debug: Merged linear block@8 into block@7
-debug: Optimizer: Remove Empty Blocks
-debug: Removed empty block: block@3
-debug: Removed empty block: block@7
-debug: Optimizer: Remove Unreachable Blocks
-debug: Optimizer: Repeated Expression Elimination
-debug: Optimizing subroutine test_cases.regression_tests.issue_118.Issue118.verify
-debug: Optimizer: Perform Subroutine Inlining
-debug: Optimizer: Split Parallel Copies
-debug: Optimizer: Constant Replacer
-debug: Optimizer: Copy Propagation
-debug: Found equivalence set: encoded_bool%0#0, val1#0
-debug: Copy propagation made 1 modifications
-debug: Optimizer: Intrinsic Simplifier
-debug: Simplified (setbit 0x00 0u to_encode%0#0) to (setbit 0x00 0u tmp%0#0)
-debug: Simplified (concat 0x val1#0) to val1#0
-debug: Simplified ((extract 6 2) as_bytes%0#0) to 0x0003
-debug: Simplified (len 0x0000) to 2u
-debug: Simplified (+ 3u 2u) to 5u
-debug: Simplified (concat 0x val1#0) to val1#0
-debug: Simplified ((extract 6 2) as_bytes%1#0) to 0x0003
-debug: Simplified (len 0x0000) to 2u
-debug: Simplified (+ 3u 2u) to 5u
-debug: Optimizer: Elide Itxn Field Calls
-debug: Optimizer: Remove Unused Variables
-debug: Removing unused variable to_encode%0#0
-debug: Removing unused variable current_tail_offset%0#0
-debug: Removing unused variable encoded_tuple_buffer%0#0
-debug: Removing unused variable encoded_tuple_buffer%1#0
-debug: Removing unused variable as_bytes%0#0
-debug: Removing unused variable offset_as_uint16%0#0
-debug: Removing unused variable data_length%0#0
-debug: Removing unused variable current_tail_offset%1#0
-debug: Removing unused variable current_tail_offset%2#0
-debug: Removing unused variable encoded_tuple_buffer%4#0
-debug: Removing unused variable encoded_tuple_buffer%5#0
-debug: Removing unused variable as_bytes%1#0
-debug: Removing unused variable offset_as_uint16%1#0
-debug: Removing unused variable data_length%1#0
-debug: Removing unused variable current_tail_offset%3#0
-debug: Optimizer: Inner Txn Field Replacer
-debug: Optimizer: Replace Compiled References
-debug: Optimizer: Simplify Control Ops
-debug: Optimizer: Remove Linear Jump
-debug: Optimizer: Remove Empty Blocks
-debug: Optimizer: Remove Unreachable Blocks
-debug: Optimizer: Repeated Expression Elimination
-debug: Optimizing subroutine test_cases.regression_tests.issue_118.Issue118.__algopy_default_create
-debug: Optimizer: Perform Subroutine Inlining
-debug: Optimizer: Split Parallel Copies
-debug: Optimizer: Constant Replacer
-debug: Optimizer: Copy Propagation
-debug: Optimizer: Intrinsic Simplifier
-debug: Optimizer: Elide Itxn Field Calls
-debug: Optimizer: Remove Unused Variables
-debug: Optimizer: Inner Txn Field Replacer
-debug: Optimizer: Replace Compiled References
-debug: Optimizer: Simplify Control Ops
-debug: Optimizer: Remove Linear Jump
-debug: Optimizer: Remove Empty Blocks
-debug: Optimizer: Remove Unreachable Blocks
-debug: Optimizer: Repeated Expression Elimination
-debug: removing unused subroutine test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__
-debug: Begin optimization pass 2/100
-debug: marking single-use function test_cases.regression_tests.issue_118.Issue118.verify for inlining
-debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
-debug: Optimizer: Perform Subroutine Inlining
-debug: inlining call to test_cases.regression_tests.issue_118.Issue118.__algopy_default_create in algopy.arc4.ARC4Contract.approval_program
-regression_tests/issue_118.py:7:6 debug: inlining call to test_cases.regression_tests.issue_118.Issue118.verify in algopy.arc4.ARC4Contract.approval_program
-debug: Optimizer: Split Parallel Copies
-debug: Optimizer: Constant Replacer
-debug: Optimizer: Copy Propagation
-debug: Found equivalence set: tmp%7#0, values#0
-debug: Copy propagation made 1 modifications
-debug: Optimizer: Intrinsic Simplifier
-debug: Optimizer: Elide Itxn Field Calls
-debug: Optimizer: Remove Unused Variables
-debug: Optimizer: Inner Txn Field Replacer
-debug: Optimizer: Replace Compiled References
-debug: Optimizer: Simplify Control Ops
-debug: Optimizer: Remove Linear Jump
-debug: Replaced predecessor block@14 with block@3 in block@16
-debug: Replaced predecessor block@14 with block@3 in block@15
-debug: Merged linear block@14 into block@3
-debug: Replaced predecessor block@12 with block@7 in block@13
-debug: Merged linear block@12 into block@7
-debug: Replaced predecessor block@13 with block@7 in block@11
-debug: Merged linear block@13 into block@7
-debug: Optimizer: Remove Empty Blocks
-debug: Optimizer: Remove Unreachable Blocks
-debug: Optimizer: Repeated Expression Elimination
-debug: Optimizing subroutine test_cases.regression_tests.issue_118.Issue118.verify
-debug: Optimizer: Perform Subroutine Inlining
-debug: Optimizer: Split Parallel Copies
-debug: Optimizer: Constant Replacer
-debug: Optimizer: Copy Propagation
-debug: Optimizer: Intrinsic Simplifier
-debug: Optimizer: Elide Itxn Field Calls
-debug: Optimizer: Remove Unused Variables
-debug: Optimizer: Inner Txn Field Replacer
-debug: Optimizer: Replace Compiled References
-debug: Optimizer: Simplify Control Ops
-debug: Optimizer: Remove Linear Jump
-debug: Optimizer: Remove Empty Blocks
-debug: Optimizer: Remove Unreachable Blocks
-debug: Optimizer: Repeated Expression Elimination
-debug: Optimizing subroutine test_cases.regression_tests.issue_118.Issue118.__algopy_default_create
-debug: Optimizer: Perform Subroutine Inlining
-debug: Optimizer: Split Parallel Copies
-debug: Optimizer: Constant Replacer
-debug: Optimizer: Copy Propagation
-debug: Optimizer: Intrinsic Simplifier
-debug: Optimizer: Elide Itxn Field Calls
-debug: Optimizer: Remove Unused Variables
-debug: Optimizer: Inner Txn Field Replacer
-debug: Optimizer: Replace Compiled References
-debug: Optimizer: Simplify Control Ops
-debug: Optimizer: Remove Linear Jump
-debug: Optimizer: Remove Empty Blocks
-debug: Optimizer: Remove Unreachable Blocks
-debug: Optimizer: Repeated Expression Elimination
-debug: removing unused subroutine test_cases.regression_tests.issue_118.Issue118.verify
-debug: removing unused subroutine test_cases.regression_tests.issue_118.Issue118.__algopy_default_create
-debug: Begin optimization pass 3/100
-debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
-debug: Optimizer: Perform Subroutine Inlining
-debug: Optimizer: Split Parallel Copies
-debug: Optimizer: Constant Replacer
-debug: Optimizer: Copy Propagation
-debug: Optimizer: Intrinsic Simplifier
-debug: Optimizer: Elide Itxn Field Calls
-debug: Optimizer: Remove Unused Variables
-debug: Optimizer: Inner Txn Field Replacer
-debug: Optimizer: Replace Compiled References
-debug: Optimizer: Simplify Control Ops
-debug: Optimizer: Remove Linear Jump
-debug: Optimizer: Remove Empty Blocks
-debug: Optimizer: Remove Unreachable Blocks
-debug: Optimizer: Repeated Expression Elimination
-debug: No optimizations performed in pass 3, ending loop
-debug: Performing SSA IR destructuring for algopy.arc4.ARC4Contract.approval_program
-debug: Converting to CSSA
-debug: Removing Phi nodes
-debug: Coalescing local variables in algopy.arc4.ARC4Contract.approval_program using strategy RootOperandGrouping
-debug: Coalescing tmp%0#1 with [tmp%0#2]
-debug: Coalescing tmp%8#0 with [tmp%8#1]
-debug: Coalescing test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0 with [test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#1, test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#2]
-debug: Coalescing tmp%0#0 with [tmp%0#3]
-debug: Coalescing resulted in 13 replacement/s
-debug: Sequentializing parallel copies in algopy.arc4.ARC4Contract.approval_program
-debug: Performing post-SSA optimizations at level 2
-debug: Output IR to regression_tests/out_O2/Issue118.ir/Issue118.approval.0.destructured.ir
-info: optimizing clear program of test_cases.regression_tests.issue_118.Issue118 at level 2
-debug: Begin optimization pass 1/100
-debug: Optimizing subroutine algopy.arc4.ARC4Contract.clear_state_program
-debug: Optimizer: Perform Subroutine Inlining
-debug: Optimizer: Split Parallel Copies
-debug: Optimizer: Constant Replacer
-debug: Optimizer: Copy Propagation
-debug: Optimizer: Intrinsic Simplifier
-debug: Optimizer: Elide Itxn Field Calls
-debug: Optimizer: Remove Unused Variables
-debug: Optimizer: Inner Txn Field Replacer
-debug: Optimizer: Replace Compiled References
-debug: Optimizer: Simplify Control Ops
-debug: Optimizer: Remove Linear Jump
-debug: Optimizer: Remove Empty Blocks
-debug: Optimizer: Remove Unreachable Blocks
-debug: Optimizer: Repeated Expression Elimination
-debug: No optimizations performed in pass 1, ending loop
-debug: Performing SSA IR destructuring for algopy.arc4.ARC4Contract.clear_state_program
-debug: Converting to CSSA
-debug: Removing Phi nodes
-debug: Coalescing local variables in algopy.arc4.ARC4Contract.clear_state_program using strategy RootOperandGrouping
-debug: Coalescing resulted in 0 replacement/s
-debug: Sequentializing parallel copies in algopy.arc4.ARC4Contract.clear_state_program
-debug: Performing post-SSA optimizations at level 2
-debug: Output IR to regression_tests/out_O2/Issue118.ir/Issue118.clear.0.destructured.ir
-debug: Inserted main.ops[1]: 'l-store-copy tmp%0#1 0'
-debug: Replaced main.ops[3]: 'v-load tmp%0#1' with 'l-load tmp%0#1'
-debug: Inserted main_abi_routing@2.ops[1]: 'l-store-copy tmp%2#0 0'
-debug: Replaced main_abi_routing@2.ops[4]: 'v-load tmp%2#0' with 'l-load tmp%2#0'
-debug: Inserted main_verify_route@3.ops[1]: 'l-store-copy tmp%3#0 0'
-debug: Replaced main_verify_route@3.ops[3]: 'v-load tmp%3#0' with 'l-load tmp%3#0'
-debug: Inserted main_verify_route@3.ops[5]: 'l-store-copy tmp%4#0 0'
-debug: Replaced main_verify_route@3.ops[7]: 'v-load tmp%4#0' with 'l-load tmp%4#0'
-debug: Inserted main_verify_route@3.ops[10]: 'l-store-copy tmp%5#0 0'
-debug: Replaced main_verify_route@3.ops[12]: 'v-load tmp%5#0' with 'l-load tmp%5#0'
-debug: Inserted main_verify_route@3.ops[26]: 'l-store-copy tmp%1#0 0'
-debug: Replaced main_verify_route@3.ops[28]: 'v-load tmp%1#0' with 'l-load tmp%1#0'
-debug: Inserted main_verify_route@3.ops[31]: 'l-store-copy tmp%2#1 0'
-debug: Replaced main_verify_route@3.ops[33]: 'v-load tmp%2#1' with 'l-load tmp%2#1'
-debug: Inserted main_verify_route@3.ops[17]: 'l-store-copy tmp%0#1 0'
-debug: Replaced main_verify_route@3.ops[21]: 'v-load tmp%0#1' with 'l-load tmp%0#1'
-debug: Inserted main_verify_route@3.ops[15]: 'l-store-copy values#0 0'
-debug: Replaced main_verify_route@3.ops[25]: 'v-load values#0' with 'l-load values#0'
-debug: Inserted main_if_body@15.ops[3]: 'l-store-copy encoded_tuple_buffer%2#0 0'
-debug: Replaced main_if_body@15.ops[5]: 'v-load encoded_tuple_buffer%2#0' with 'l-load encoded_tuple_buffer%2#0'
-debug: Inserted main_if_body@15.ops[8]: 'l-store-copy encoded_tuple_buffer%3#0 0'
-debug: Replaced main_if_body@15.ops[10]: 'v-load encoded_tuple_buffer%3#0' with 'l-load encoded_tuple_buffer%3#0'
-debug: Inserted main_after_if_else@16.ops[3]: 'l-store-copy encoded_tuple_buffer%6#0 0'
-debug: Replaced main_after_if_else@16.ops[5]: 'v-load encoded_tuple_buffer%6#0' with 'l-load encoded_tuple_buffer%6#0'
-debug: Inserted main_after_if_else@16.ops[8]: 'l-store-copy encoded_tuple_buffer%7#0 0'
-debug: Replaced main_after_if_else@16.ops[10]: 'v-load encoded_tuple_buffer%7#0' with 'l-load encoded_tuple_buffer%7#0'
-debug: Inserted main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17.ops[3]: 'l-store-copy tmp%9#0 0'
-debug: Replaced main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17.ops[5]: 'v-load tmp%9#0' with 'l-load tmp%9#0'
-debug: Inserted main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17.ops[8]: 'l-store-copy test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0 0'
-debug: Replaced main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17.ops[10]: 'v-load test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0' with 'l-load test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0'
-debug: Inserted main_bare_routing@6.ops[1]: 'l-store-copy tmp%10#0 0'
-debug: Replaced main_bare_routing@6.ops[3]: 'v-load tmp%10#0' with 'l-load tmp%10#0'
-debug: Inserted main___algopy_default_create@7.ops[1]: 'l-store-copy tmp%11#0 0'
-debug: Replaced main___algopy_default_create@7.ops[3]: 'v-load tmp%11#0' with 'l-load tmp%11#0'
-debug: Inserted main___algopy_default_create@7.ops[5]: 'l-store-copy tmp%12#0 0'
-debug: Replaced main___algopy_default_create@7.ops[7]: 'v-load tmp%12#0' with 'l-load tmp%12#0'
-debug: Inserted main___algopy_default_create@7.ops[10]: 'l-store-copy test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0 0'
-debug: Replaced main___algopy_default_create@7.ops[12]: 'v-load test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0' with 'l-load test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0'
-debug: Inserted main_after_if_else@10.ops[1]: 'l-store-copy test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0 0'
-debug: Replaced main_after_if_else@10.ops[3]: 'v-load test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0' with 'l-load test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__%0#0'
-debug: Found 5 edge set/s for algopy.arc4.ARC4Contract.approval_program
-debug: Allocated 3 variable/s to x-stack: tmp%0#0, tmp%8#0, val1#0
-debug: shared x-stack for main_verify_route@3 -> main_if_body@15: val1#0
-debug: shared x-stack for main_verify_route@3 -> main_after_if_else@16: val1#0
-debug: shared x-stack for main_if_body@15 -> main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17: tmp%8#0
-debug: shared x-stack for main_after_if_else@16 -> main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17: tmp%8#0
-debug: shared x-stack for main___algopy_default_create@7 -> main_after_inlined_test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__@11: tmp%0#0
-debug: shared x-stack for main_after_if_else@10 -> main_after_inlined_test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__@11: tmp%0#0
-debug: shared x-stack for main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17 -> main_after_inlined_test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__@11: tmp%0#0
-debug: optimizing TEAL subroutine algopy.arc4.ARC4Contract.approval_program() -> uint64:
-debug: replacing `b main_after_inlined_test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__@11` with `return`
-debug: replacing `b main_after_inlined_test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__@11` with `return`
-debug: inlining single reference block main_abi_routing@2 into main
-debug: inlining single reference block main_after_inlined_test_cases.regression_tests.issue_118.Issue118.__puya_arc4_router__@11 into main_after_if_else@10
-debug: inlining single reference block main_if_body@15 into main_verify_route@3
-debug: inlining single reference block main___algopy_default_create@7 into main_bare_routing@6
-debug: removing explicit jump to fall-through block main_after_if_else@10
-debug: removing explicit jump to fall-through block main_after_inlined_test_cases.regression_tests.issue_118.Issue118.verify@17
-debug: optimizing TEAL subroutine algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
-info: Writing regression_tests/out_O2/Issue194.approval.teal
-info: Writing regression_tests/out_O2/Issue194.clear.teal
-info: Writing regression_tests/out_O2/Issue194.approval.bin
-info: Writing regression_tests/out_O2/Issue194.clear.bin
-info: Writing regression_tests/out_O2/Issue194.approval.puya.map
-info: Writing regression_tests/out_O2/Issue194.clear.puya.map
-info: Writing regression_tests/out_O2/Issue118.approval.teal
-info: Writing regression_tests/out_O2/Issue118.clear.teal
-info: Writing regression_tests/out_O2/Issue118.approval.bin
-info: Writing regression_tests/out_O2/Issue118.clear.bin
-info: Writing regression_tests/out_O2/Issue118.approval.puya.map
-info: Writing regression_tests/out_O2/Issue118.clear.puya.map
+debug: Output IR to regression_tests/out_O2/TealSwitchInlining.ir/TealSwitchInlining.clear.0.destructured.ir
+debug: Inserted main.ops[1]: 'l-store-copy tmp%0#0 0'
+debug: Replaced main.ops[3]: 'v-load tmp%0#0' with 'l-load tmp%0#0'
+debug: Found 1 edge set/s for test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
+regression_tests/teal_switch_inlining.py:10 debug: optimizing TEAL subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program() -> uint64:
+debug: inlining single reference block main_switch_case_0@1 into main
+regression_tests/teal_switch_inlining.py:23 debug: optimizing TEAL subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program() -> uint64:
+debug: Traceback (most recent call last):
+  File "<git root>/src/puya/errors.py", line 36, in log_exceptions
+    yield
+  File "<git root>/src/puyapy/compile.py", line 77, in compile_to_teal
+    teal = awst_to_teal(
+           ^^^^^^^^^^^^^
+  File "<git root>/src/puya/compile.py", line 71, in awst_to_teal
+    teal = _ir_to_teal(log_ctx, context, ir)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "<git root>/src/puya/compile.py", line 151, in _ir_to_teal
+    compiled = _contract_ir_to_teal(artifact_context, contract)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "<git root>/src/puya/compile.py", line 232, in _contract_ir_to_teal
+    approval_program=_compile_program(context, approval),
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "<git root>/src/puya/compile.py", line 252, in _compile_program
+    assembled = assemble_program(context, program)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "<git root>/src/puya/ussemble/main.py", line 30, in assemble_program
+    return assemble_bytecode_and_debug_info(assemble_ctx, program)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "<git root>/src/puya/ussemble/assemble.py", line 84, in assemble_bytecode_and_debug_info
+    bytecode.append(_encode_op(avm_op, get_label_offset=get_label_offset))
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "<git root>/src/puya/ussemble/assemble.py", line 260, in _encode_op
+    offsets = [get_label_offset(label) for label in immediate]
+               ^^^^^^^^^^^^^^^^^^^^^^^
+  File "<git root>/src/puya/ussemble/assemble.py", line 82, in get_label_offset
+    return label_pcs[label.name] - pcs[op_index + 1]  # noqa: B023
+           ~~~~~~~~~^^^^^^^^^^^^
+KeyError: 'main_switch_case_0@1'
+critical: KeyError: 'main_switch_case_0@1'

--- a/test_cases/regression_tests/puya_unoptimized.log
+++ b/test_cases/regression_tests/puya_unoptimized.log
@@ -363,6 +363,55 @@ debug: Added array_head_and_tail#0 to Phi node: let array_head_and_tail#1: bytes
 debug: Added array_head_and_tail#2 to Phi node: let array_head_and_tail#1: bytes = φ(array_head_and_tail#0 <- block@0, array_head_and_tail#2 <- block@3) in block@3
 debug: Sealing block@4
 debug: Terminated block@4
+debug: Building IR for function test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.__puya_arc4_router__
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Sealing block@1
+debug: Terminated block@1
+debug: Sealing block@2
+debug: Terminated block@2
+debug: Sealing block@3
+debug: Terminated block@3
+debug: Building IR for function test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Sealing block@1
+debug: Terminated block@1
+debug: Sealing block@2
+debug: Terminated block@2
+debug: Sealing block@3
+debug: Terminated block@3
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.recalculate_head_for_elements_with_byte_length_head
+debug: Building IR for function test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.recalculate_head_for_elements_with_byte_length_head
 debug: Building IR for function test_cases.regression_tests.issue_194.Issue194.__puya_arc4_router__
 debug: Sealing block@0
 debug: Terminated block@0
@@ -475,6 +524,48 @@ debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_e
 debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
 debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
 debug: removing unused subroutine _puya_lib.arc4.recalculate_head_for_elements_with_byte_length_head
+info: optimizing approval program of test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining at level 0
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: No optimizations performed in pass 1, ending loop
+debug: Performing SSA IR destructuring for test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
+debug: Performing post-SSA optimizations at level 0
+debug: Output IR to regression_tests/out_unoptimized/TealSwitchInlining.ir/TealSwitchInlining.approval.0.destructured.ir
+info: optimizing clear program of test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining at level 0
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: No optimizations performed in pass 1, ending loop
+debug: Performing SSA IR destructuring for test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program
+debug: Performing post-SSA optimizations at level 0
+debug: Output IR to regression_tests/out_unoptimized/TealSwitchInlining.ir/TealSwitchInlining.clear.0.destructured.ir
+debug: Inserted main.ops[1]: 'l-store-copy tmp%0#0 0'
+debug: Replaced main.ops[5]: 'v-load tmp%0#0' with 'l-load tmp%0#0'
+debug: Found 1 edge set/s for test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program
+regression_tests/teal_switch_inlining.py:10 debug: optimizing TEAL subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.approval_program() -> uint64:
+debug: removing explicit jump to fall-through block main_switch_case_default@3
+regression_tests/teal_switch_inlining.py:23 debug: optimizing TEAL subroutine test_cases.regression_tests.teal_switch_inlining.TealSwitchInlining.clear_state_program() -> uint64:
 info: optimizing approval program of test_cases.regression_tests.issue_194.Issue194 at level 0
 debug: Begin optimization pass 1/100
 debug: Optimizing subroutine test_cases.regression_tests.issue_194.Issue194.approval_program
@@ -733,6 +824,12 @@ debug: removing explicit jump to fall-through block main_after_inlined_test_case
 regression_tests/issue_118.py:7 debug: optimizing TEAL subroutine test_cases.regression_tests.issue_118.Issue118.verify(values: bytes) -> bytes:
 debug: removing explicit jump to fall-through block verify_if_body@1
 debug: optimizing TEAL subroutine algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+info: Writing regression_tests/out_unoptimized/TealSwitchInlining.approval.teal
+info: Writing regression_tests/out_unoptimized/TealSwitchInlining.clear.teal
+info: Writing regression_tests/out_unoptimized/TealSwitchInlining.approval.bin
+info: Writing regression_tests/out_unoptimized/TealSwitchInlining.clear.bin
+info: Writing regression_tests/out_unoptimized/TealSwitchInlining.approval.puya.map
+info: Writing regression_tests/out_unoptimized/TealSwitchInlining.clear.puya.map
 info: Writing regression_tests/out_unoptimized/Issue194.approval.teal
 info: Writing regression_tests/out_unoptimized/Issue194.clear.teal
 info: Writing regression_tests/out_unoptimized/Issue194.approval.bin

--- a/test_cases/regression_tests/teal_switch_inlining.py
+++ b/test_cases/regression_tests/teal_switch_inlining.py
@@ -1,0 +1,24 @@
+import algopy as a
+
+
+class TealSwitchInlining(a.Contract):
+    """Test for an issue introduced by TEAL block optimizations,
+    whereby a target that is referenced multiple times by the same source block
+    might be incorrectly inlined, when it should remain a labelled destination.
+    """
+
+    def approval_program(self) -> bool:
+        match a.Txn.num_app_args:
+            # at -O2, this block and the default block will be de-duplicated,
+            # resulting in there being a reference to the default block in the `switch` cases
+            # also, which cannot be inlined an must be preserved despite only having a single
+            # predecessor block
+            case 0:
+                return True
+            case 1:
+                return False
+            case _:
+                return True
+
+    def clear_state_program(self) -> bool:
+        return True


### PR DESCRIPTION
This issue could occur when there is a default fall through block in a `switch` or `match` scenario, which is also targeted by said op, and would cause a compilation failure.