### PR TITLE
fix: native property of static bytes in puya-ts was throwing unexpected type error

### DIFF
--- a/src/puya/awst/nodes.py
+++ b/src/puya/awst/nodes.py
@@ -580,6 +580,7 @@ class ARC4Decode(Expression):
             wtypes.ARC4UIntN,
             wtypes.ARC4Tuple,
             wtypes.ARC4Struct,
+            wtypes.ARC4StaticArray,  # only if element type is bytes for now
             wtypes.ARC4DynamicArray,  # only if element type is bytes for now
         )
     )

--- a/src/puya/ir/builder/arc4.py
+++ b/src/puya/ir/builder/arc4.py
@@ -91,6 +91,11 @@ def decode_arc4_value(
                 args=[value],
                 source_location=loc,
             )
+        case wtypes.ARC4StaticArray(element_type=wtypes.ARC4UIntN(n=8)), (
+            wtypes.bytes_wtype
+            | wtypes.string_wtype
+        ):
+            return value
         case (
             wtypes.ARC4Tuple()
             | wtypes.ARC4Struct() as arc4_tuple,


### PR DESCRIPTION
## Proposed Changes

- allow `StaticArray<ARC4UIntN<8>, N>` to be passed to ARC4Decode operation to fix the following error when calling `new StaticBytes<32>().native` in `puya-ts`.
  ```
  error: ARC4Decode.value: expression of WType arc4.static_array<arc4.uint8, 33> received, expected arc4.bool or ARC4UIntN or ARC4Tuple or ARC4Struct or ARC4DynamicArray
  ```