### PR TITLE
Expand ABI method reference type support

### DIFF
--- a/examples/amm/out/ConstantProductAMM.arc56.json
+++ b/examples/amm/out/ConstantProductAMM.arc56.json
@@ -243,7 +243,7 @@
                 },
                 "governor": {
                     "keyType": "AVMString",
-                    "valueType": "AVMBytes",
+                    "valueType": "address",
                     "key": "Z292ZXJub3I="
                 },
                 "pool_token": {

--- a/examples/auction/out/Auction.arc56.json
+++ b/examples/auction/out/Auction.arc56.json
@@ -167,7 +167,7 @@
                 },
                 "previous_bidder": {
                     "keyType": "AVMString",
-                    "valueType": "AVMBytes",
+                    "valueType": "address",
                     "key": "cHJldmlvdXNfYmlkZGVy"
                 }
             },

--- a/examples/box_storage/out/BoxContract.arc56.json
+++ b/examples/box_storage/out/BoxContract.arc56.json
@@ -270,7 +270,7 @@
             "box": {
                 "box_a": {
                     "keyType": "AVMString",
-                    "valueType": "AVMUint64",
+                    "valueType": "uint64",
                     "key": "Ym94X2E="
                 },
                 "box_b": {
@@ -300,7 +300,7 @@
             "local": {},
             "box": {
                 "box_map": {
-                    "keyType": "AVMUint64",
+                    "keyType": "uint64",
                     "valueType": "AVMString",
                     "prefix": ""
                 }

--- a/examples/sizes.txt
+++ b/examples/sizes.txt
@@ -7,6 +7,7 @@
  amm/ConstantProductAMM                        1191    1033     982    |        699     622     604 
  application/Reference                          175     143       -    |         92      76       - 
  arc4_conversions/CheckApp                      594     502     372    |        286     227     168 
+ arc4_conversions/ReferenceReturn               460     380     327    |        232     171     147 
  arc4_conversions/Test                         3269    2467    2318    |       1618    1019    1012 
  arc4_dynamic_arrays/DynamicArray              2605    1428    1138    |       1685     561     488 
  arc4_numeric_comparisons/UIntNOrdering        1100       8       -    |        786       4       - 
@@ -154,4 +155,4 @@
  unssa/UnSSA                                    411     266       -    |        234     153       - 
  voting/VotingRoundApp                         1575    1426    1414    |        722     621     622 
  with_reentrancy/WithReentrancy                 245     214       -    |        126     108       - 
- Total                                        86684   51592   48204    |      43469   25138   23688 
+ Total                                        87144   51972   48531    |      43701   25309   23835 

--- a/examples/tictactoe/out/TicTacToeContract.arc56.json
+++ b/examples/tictactoe/out/TicTacToeContract.arc56.json
@@ -104,7 +104,7 @@
             "global": {
                 "challenger": {
                     "keyType": "AVMString",
-                    "valueType": "AVMBytes",
+                    "valueType": "address",
                     "key": "Y2hhbGxlbmdlcg=="
                 },
                 "winner": {
@@ -114,7 +114,7 @@
                 },
                 "host": {
                     "keyType": "AVMString",
-                    "valueType": "AVMBytes",
+                    "valueType": "address",
                     "key": "aG9zdA=="
                 },
                 "game": {

--- a/examples/voting/out/VotingRoundApp.arc56.json
+++ b/examples/voting/out/VotingRoundApp.arc56.json
@@ -257,7 +257,7 @@
             "local": {},
             "box": {
                 "votes_by_account": {
-                    "keyType": "AVMBytes",
+                    "keyType": "address",
                     "valueType": "uint8[]",
                     "prefix": ""
                 }

--- a/src/puya/ir/_arc4_default_args.py
+++ b/src/puya/ir/_arc4_default_args.py
@@ -111,7 +111,7 @@ def _convert_member_arg_default(
             return f"{member_name!r} does not provide a value"
         return_type_arc4 = wtype_to_arc4(method_source.return_type)
         if return_type_arc4 != param_arc4_type:
-            return f"{member_name!r} does not provide {param_arc4_type!r} type"
+            return f"{method_source.member_name!r} does not provide {param_arc4_type!r} type"
         return models.MethodArgDefaultFromMethod(
             name=abi_method_config.name,
             return_type=return_type_arc4,

--- a/src/puya/ir/_arc4_default_args.py
+++ b/src/puya/ir/_arc4_default_args.py
@@ -107,7 +107,7 @@ def _convert_member_arg_default(
             return f"{member_name!r} is not readonly"
         if method_source.args:
             return f"{member_name!r} does not take zero arguments"
-        if method_source.return_type is wtypes.void_wtype:
+        if method_source.return_type == wtypes.void_wtype:
             return f"{member_name!r} does not provide a value"
         return_type_arc4 = wtype_to_arc4(method_source.return_type)
         if return_type_arc4 != param_arc4_type:

--- a/src/puya/ir/_contract_metadata.py
+++ b/src/puya/ir/_contract_metadata.py
@@ -95,10 +95,18 @@ def _translate_state(
             "AVMString" if state.key.encoding == awst_nodes.BytesEncoding.utf8 else "AVMBytes"
         )
         is_map = False
+    if state.kind == awst_nodes.AppStorageKind.box:
+        avm_uint64_supported = False
+    else:
+        typing.assert_type(
+            state.kind,
+            typing.Literal[
+                awst_nodes.AppStorageKind.app_global, awst_nodes.AppStorageKind.account_local
+            ],
+        )
+        avm_uint64_supported = True
     arc56_value_type = _get_arc56_type(
-        state.storage_wtype,
-        state.source_location,
-        avm_uint64_supported=state.kind != awst_nodes.AppStorageKind.box,
+        state.storage_wtype, state.source_location, avm_uint64_supported=avm_uint64_supported
     )
     return models.ContractState(
         name=state.member_name,

--- a/src/puya/ir/builder/arc4.py
+++ b/src/puya/ir/builder/arc4.py
@@ -455,8 +455,6 @@ def _get_arc4_codec(native_type: wtypes.WType) -> ARC4Codec | None:
             return UInt64Codec()
         case wtypes.bool_wtype:
             return BoolCodec()
-        # a Puya string is just a bytes array that is typed differently to prevent
-        # ASCII assumptions being made
         case wtypes.bytes_wtype:
             return BytesCodec()
         case wtypes.string_wtype:

--- a/src/puya/ir/builder/arc4.py
+++ b/src/puya/ir/builder/arc4.py
@@ -451,7 +451,7 @@ def _get_arc4_codec(native_type: wtypes.WType) -> ARC4Codec | None:
     match native_type:
         case wtypes.biguint_wtype:
             return BigUIntCodec()
-        case wtypes.uint64_wtype:
+        case wtypes.uint64_wtype | wtypes.asset_wtype | wtypes.application_wtype:
             return UInt64Codec()
         case wtypes.bool_wtype:
             return BoolCodec()

--- a/src/puyapy/awst_build/eb/arc4/emit.py
+++ b/src/puyapy/awst_build/eb/arc4/emit.py
@@ -62,7 +62,10 @@ class EmitBuilder(FunctionBuilder):
                     location=location,
                 )
         event_name = struct_type.name.split(".")[-1]
-        event_sig = f"{event_name}{pytype_to_arc4(event_arg_eb.pytype, location)}"
+        event_arc4_name = pytype_to_arc4(
+            event_arg_eb.pytype, encode_resource_types=True, loc=location
+        )
+        event_sig = f"{event_name}{event_arc4_name}"
         emit = Emit(
             signature=event_sig,
             value=event_arg_eb.resolve(),

--- a/src/puyapy/models.py
+++ b/src/puyapy/models.py
@@ -61,7 +61,10 @@ class ARC4ABIMethodData:
                 f"invalid type for an ARC-4 method: {bad_type}", self.config.source_location
             )
 
-        return {k: pytype_to_arc4_pytype(v, on_error=on_error) for k, v in self._signature.items()}
+        return {
+            k: pytype_to_arc4_pytype(v, on_error=on_error, encode_resource_types=k == "output")
+            for k, v in self._signature.items()
+        }
 
     @property
     def signature(self) -> Mapping[str, pytypes.PyType]:

--- a/test_cases/abi_routing/out/Reference.arc56.json
+++ b/test_cases/abi_routing/out/Reference.arc56.json
@@ -630,7 +630,7 @@
                 },
                 "creator": {
                     "keyType": "AVMString",
-                    "valueType": "AVMBytes",
+                    "valueType": "address",
                     "key": "Y3JlYXRvcg=="
                 },
                 "app": {

--- a/test_cases/arc4_conversions/out/ReferenceReturn.approval.puya.map
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.approval.puya.map
@@ -1,0 +1,1368 @@
+{
+  "version": 3,
+  "sources": [
+    "../reference.py"
+  ],
+  "mappings": ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAGA;;AAAA;;;AAAA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA;;;AAAA;;;;;;;;;;;;;;;;;;;;;;AAAA;;AAuCK;;AAAA;AAAA;AAAA;;AAAA;AAAA;;;AAAA;AAAA;AAAA;AAAA;AAAA;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AAAA;;;AAAA;AAAA;AAAA;AAAA;AAAA;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AAAA;;;AAAA;AAAA;AAAA;AAAA;AAAA;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AA3BL;;;AA2BK;;;AAAA;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AAvBL;;;AAuBK;;;AAAA;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AAnBL;;;AAmBK;;;AAAA;;AANA;;AAAA;AAAA;AAAA;;AAAA;AAbL;;;AAAA;AAAA;;AAAA;;;AAAA;AAAA;;AAAA;;;AAAA;AAAA;;AAaK;;;AAAA;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AAAA;AAAA;AAAA;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AAAA;AAAA;AAAA;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AAAA;;;AAAA;AAAA;AAAA;AAAA;AAAA;;AADL;;AAAA;;;;;;;;;AAGe;;AAAP;AAUR;;;AAEQ;;;;;AAAA;;AAAA;AACA;;;;;;;AAAA;;AAAA;AACA;;;;;AAAA;;AAAA;;AAER;;;AAEQ;AAAA;;AAAA;;AAER;;;AAEQ;AAAA;;AAAA;;AAER;;;AAEQ;;AAAA;;AAAA;;AAIO;AAAA;AAAA;AAAA;AAAP;AAIO;AAAA;AAAA;AAAA;AAAP;AAIO;AAAA;;AAAA;AAAA;AAAP",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "algopy.arc4.ARC4Contract.approval_program",
+      "params": {},
+      "block": "main",
+      "stack_in": [],
+      "op": "intcblock 1 0"
+    },
+    "5": {
+      "op": "bytecblock 0x151f7c75 0x151f7c7500000000000004d2 \"apps\" \"assets\" \"accounts\""
+    },
+    "46": {
+      "op": "txn NumAppArgs",
+      "defined_out": [
+        "tmp%0#1"
+      ],
+      "stack_out": [
+        "tmp%0#1"
+      ]
+    },
+    "48": {
+      "op": "bz main_bare_routing@15",
+      "stack_out": []
+    },
+    "51": {
+      "op": "pushbytess 0x6c7a1cb5 0xc8480f0c 0x37c0cbf2 0x864086a7 0x6728b1a1 0xce7e6cd3 0x0a37f6e1 0x4c894d7e 0x62ebcf89 0x924e778c // method \"acc_ret()address\", method \"asset_ret()uint64\", method \"app_ret()uint64\", method \"store(account,application,asset)void\", method \"store_apps(uint64[])void\", method \"store_assets(uint64[])void\", method \"store_accounts(address[])void\", method \"return_apps()uint64[]\", method \"return_assets()uint64[]\", method \"return_accounts()address[]\"",
+      "defined_out": [
+        "Method(acc_ret()address)",
+        "Method(app_ret()uint64)",
+        "Method(asset_ret()uint64)",
+        "Method(return_accounts()address[])",
+        "Method(return_apps()uint64[])",
+        "Method(return_assets()uint64[])",
+        "Method(store(account,application,asset)void)",
+        "Method(store_accounts(address[])void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)"
+      ],
+      "stack_out": [
+        "Method(acc_ret()address)",
+        "Method(asset_ret()uint64)",
+        "Method(app_ret()uint64)",
+        "Method(store(account,application,asset)void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "Method(store_accounts(address[])void)",
+        "Method(return_apps()uint64[])",
+        "Method(return_assets()uint64[])",
+        "Method(return_accounts()address[])"
+      ]
+    },
+    "103": {
+      "op": "txna ApplicationArgs 0",
+      "defined_out": [
+        "Method(acc_ret()address)",
+        "Method(app_ret()uint64)",
+        "Method(asset_ret()uint64)",
+        "Method(return_accounts()address[])",
+        "Method(return_apps()uint64[])",
+        "Method(return_assets()uint64[])",
+        "Method(store(account,application,asset)void)",
+        "Method(store_accounts(address[])void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "tmp%2#0"
+      ],
+      "stack_out": [
+        "Method(acc_ret()address)",
+        "Method(asset_ret()uint64)",
+        "Method(app_ret()uint64)",
+        "Method(store(account,application,asset)void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "Method(store_accounts(address[])void)",
+        "Method(return_apps()uint64[])",
+        "Method(return_assets()uint64[])",
+        "Method(return_accounts()address[])",
+        "tmp%2#0"
+      ]
+    },
+    "106": {
+      "op": "match main_acc_ret_route@3 main_asset_ret_route@4 main_app_ret_route@5 main_store_route@6 main_store_apps_route@7 main_store_assets_route@8 main_store_accounts_route@9 main_return_apps_route@10 main_return_assets_route@11 main_return_accounts_route@12",
+      "stack_out": []
+    },
+    "128": {
+      "block": "main_after_if_else@19",
+      "stack_in": [],
+      "op": "intc_1 // 0",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "129": {
+      "op": "return",
+      "stack_out": []
+    },
+    "130": {
+      "block": "main_return_accounts_route@12",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%53#0"
+      ],
+      "stack_out": [
+        "tmp%53#0"
+      ]
+    },
+    "132": {
+      "op": "!",
+      "defined_out": [
+        "tmp%54#0"
+      ],
+      "stack_out": [
+        "tmp%54#0"
+      ]
+    },
+    "133": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "134": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%55#0"
+      ],
+      "stack_out": [
+        "tmp%55#0"
+      ]
+    },
+    "136": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "137": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts",
+      "op": "callsub return_accounts",
+      "defined_out": [
+        "tmp%57#0"
+      ],
+      "stack_out": [
+        "tmp%57#0"
+      ]
+    },
+    "140": {
+      "op": "bytec_0 // 0x151f7c75",
+      "defined_out": [
+        "0x151f7c75",
+        "tmp%57#0"
+      ],
+      "stack_out": [
+        "tmp%57#0",
+        "0x151f7c75"
+      ]
+    },
+    "141": {
+      "op": "swap",
+      "stack_out": [
+        "0x151f7c75",
+        "tmp%57#0"
+      ]
+    },
+    "142": {
+      "op": "concat",
+      "defined_out": [
+        "tmp%58#0"
+      ],
+      "stack_out": [
+        "tmp%58#0"
+      ]
+    },
+    "143": {
+      "op": "log",
+      "stack_out": []
+    },
+    "144": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "145": {
+      "op": "return",
+      "stack_out": []
+    },
+    "146": {
+      "block": "main_return_assets_route@11",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%47#0"
+      ],
+      "stack_out": [
+        "tmp%47#0"
+      ]
+    },
+    "148": {
+      "op": "!",
+      "defined_out": [
+        "tmp%48#0"
+      ],
+      "stack_out": [
+        "tmp%48#0"
+      ]
+    },
+    "149": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "150": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%49#0"
+      ],
+      "stack_out": [
+        "tmp%49#0"
+      ]
+    },
+    "152": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "153": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.return_assets",
+      "op": "callsub return_assets",
+      "defined_out": [
+        "tmp%51#0"
+      ],
+      "stack_out": [
+        "tmp%51#0"
+      ]
+    },
+    "156": {
+      "op": "bytec_0 // 0x151f7c75",
+      "defined_out": [
+        "0x151f7c75",
+        "tmp%51#0"
+      ],
+      "stack_out": [
+        "tmp%51#0",
+        "0x151f7c75"
+      ]
+    },
+    "157": {
+      "op": "swap",
+      "stack_out": [
+        "0x151f7c75",
+        "tmp%51#0"
+      ]
+    },
+    "158": {
+      "op": "concat",
+      "defined_out": [
+        "tmp%52#0"
+      ],
+      "stack_out": [
+        "tmp%52#0"
+      ]
+    },
+    "159": {
+      "op": "log",
+      "stack_out": []
+    },
+    "160": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "161": {
+      "op": "return",
+      "stack_out": []
+    },
+    "162": {
+      "block": "main_return_apps_route@10",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%41#0"
+      ],
+      "stack_out": [
+        "tmp%41#0"
+      ]
+    },
+    "164": {
+      "op": "!",
+      "defined_out": [
+        "tmp%42#0"
+      ],
+      "stack_out": [
+        "tmp%42#0"
+      ]
+    },
+    "165": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "166": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%43#0"
+      ],
+      "stack_out": [
+        "tmp%43#0"
+      ]
+    },
+    "168": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "169": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.return_apps",
+      "op": "callsub return_apps",
+      "defined_out": [
+        "tmp%45#0"
+      ],
+      "stack_out": [
+        "tmp%45#0"
+      ]
+    },
+    "172": {
+      "op": "bytec_0 // 0x151f7c75",
+      "defined_out": [
+        "0x151f7c75",
+        "tmp%45#0"
+      ],
+      "stack_out": [
+        "tmp%45#0",
+        "0x151f7c75"
+      ]
+    },
+    "173": {
+      "op": "swap",
+      "stack_out": [
+        "0x151f7c75",
+        "tmp%45#0"
+      ]
+    },
+    "174": {
+      "op": "concat",
+      "defined_out": [
+        "tmp%46#0"
+      ],
+      "stack_out": [
+        "tmp%46#0"
+      ]
+    },
+    "175": {
+      "op": "log",
+      "stack_out": []
+    },
+    "176": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "177": {
+      "op": "return",
+      "stack_out": []
+    },
+    "178": {
+      "block": "main_store_accounts_route@9",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%37#0"
+      ],
+      "stack_out": [
+        "tmp%37#0"
+      ]
+    },
+    "180": {
+      "op": "!",
+      "defined_out": [
+        "tmp%38#0"
+      ],
+      "stack_out": [
+        "tmp%38#0"
+      ]
+    },
+    "181": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "182": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%39#0"
+      ],
+      "stack_out": [
+        "tmp%39#0"
+      ]
+    },
+    "184": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "185": {
+      "op": "txna ApplicationArgs 1",
+      "defined_out": [
+        "reinterpret_bytes[32][]%0#0"
+      ],
+      "stack_out": [
+        "reinterpret_bytes[32][]%0#0"
+      ]
+    },
+    "188": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts",
+      "op": "callsub store_accounts",
+      "stack_out": []
+    },
+    "191": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "192": {
+      "op": "return",
+      "stack_out": []
+    },
+    "193": {
+      "block": "main_store_assets_route@8",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%33#0"
+      ],
+      "stack_out": [
+        "tmp%33#0"
+      ]
+    },
+    "195": {
+      "op": "!",
+      "defined_out": [
+        "tmp%34#0"
+      ],
+      "stack_out": [
+        "tmp%34#0"
+      ]
+    },
+    "196": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "197": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%35#0"
+      ],
+      "stack_out": [
+        "tmp%35#0"
+      ]
+    },
+    "199": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "200": {
+      "op": "txna ApplicationArgs 1",
+      "defined_out": [
+        "reinterpret_encoded_uint64[]%1#0"
+      ],
+      "stack_out": [
+        "reinterpret_encoded_uint64[]%1#0"
+      ]
+    },
+    "203": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.store_assets",
+      "op": "callsub store_assets",
+      "stack_out": []
+    },
+    "206": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "207": {
+      "op": "return",
+      "stack_out": []
+    },
+    "208": {
+      "block": "main_store_apps_route@7",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%29#0"
+      ],
+      "stack_out": [
+        "tmp%29#0"
+      ]
+    },
+    "210": {
+      "op": "!",
+      "defined_out": [
+        "tmp%30#0"
+      ],
+      "stack_out": [
+        "tmp%30#0"
+      ]
+    },
+    "211": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "212": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%31#0"
+      ],
+      "stack_out": [
+        "tmp%31#0"
+      ]
+    },
+    "214": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "215": {
+      "op": "txna ApplicationArgs 1",
+      "defined_out": [
+        "reinterpret_encoded_uint64[]%0#0"
+      ],
+      "stack_out": [
+        "reinterpret_encoded_uint64[]%0#0"
+      ]
+    },
+    "218": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.store_apps",
+      "op": "callsub store_apps",
+      "stack_out": []
+    },
+    "221": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "222": {
+      "op": "return",
+      "stack_out": []
+    },
+    "223": {
+      "block": "main_store_route@6",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%19#0"
+      ],
+      "stack_out": [
+        "tmp%19#0"
+      ]
+    },
+    "225": {
+      "op": "!",
+      "defined_out": [
+        "tmp%20#0"
+      ],
+      "stack_out": [
+        "tmp%20#0"
+      ]
+    },
+    "226": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "227": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%21#0"
+      ],
+      "stack_out": [
+        "tmp%21#0"
+      ]
+    },
+    "229": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "230": {
+      "op": "txna ApplicationArgs 1",
+      "defined_out": [
+        "reinterpret_bytes[1]%0#0"
+      ],
+      "stack_out": [
+        "reinterpret_bytes[1]%0#0"
+      ]
+    },
+    "233": {
+      "op": "btoi",
+      "defined_out": [
+        "tmp%23#0"
+      ],
+      "stack_out": [
+        "tmp%23#0"
+      ]
+    },
+    "234": {
+      "op": "txnas Accounts",
+      "defined_out": [
+        "tmp%24#0"
+      ],
+      "stack_out": [
+        "tmp%24#0"
+      ]
+    },
+    "236": {
+      "op": "txna ApplicationArgs 2",
+      "defined_out": [
+        "reinterpret_bytes[1]%1#0",
+        "tmp%24#0"
+      ],
+      "stack_out": [
+        "tmp%24#0",
+        "reinterpret_bytes[1]%1#0"
+      ]
+    },
+    "239": {
+      "op": "btoi",
+      "defined_out": [
+        "tmp%24#0",
+        "tmp%25#0"
+      ],
+      "stack_out": [
+        "tmp%24#0",
+        "tmp%25#0"
+      ]
+    },
+    "240": {
+      "op": "txnas Applications",
+      "defined_out": [
+        "tmp%24#0",
+        "tmp%26#0"
+      ],
+      "stack_out": [
+        "tmp%24#0",
+        "tmp%26#0"
+      ]
+    },
+    "242": {
+      "op": "txna ApplicationArgs 3",
+      "defined_out": [
+        "reinterpret_bytes[1]%2#0",
+        "tmp%24#0",
+        "tmp%26#0"
+      ],
+      "stack_out": [
+        "tmp%24#0",
+        "tmp%26#0",
+        "reinterpret_bytes[1]%2#0"
+      ]
+    },
+    "245": {
+      "op": "btoi",
+      "defined_out": [
+        "tmp%24#0",
+        "tmp%26#0",
+        "tmp%27#0"
+      ],
+      "stack_out": [
+        "tmp%24#0",
+        "tmp%26#0",
+        "tmp%27#0"
+      ]
+    },
+    "246": {
+      "op": "txnas Assets",
+      "defined_out": [
+        "tmp%24#0",
+        "tmp%26#0",
+        "tmp%28#0"
+      ],
+      "stack_out": [
+        "tmp%24#0",
+        "tmp%26#0",
+        "tmp%28#0"
+      ]
+    },
+    "248": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.store",
+      "op": "callsub store",
+      "stack_out": []
+    },
+    "251": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "252": {
+      "op": "return",
+      "stack_out": []
+    },
+    "253": {
+      "block": "main_app_ret_route@5",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%14#0"
+      ],
+      "stack_out": [
+        "tmp%14#0"
+      ]
+    },
+    "255": {
+      "op": "!",
+      "defined_out": [
+        "tmp%15#0"
+      ],
+      "stack_out": [
+        "tmp%15#0"
+      ]
+    },
+    "256": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "257": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%16#0"
+      ],
+      "stack_out": [
+        "tmp%16#0"
+      ]
+    },
+    "259": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "260": {
+      "op": "bytec_1 // 0x151f7c7500000000000004d2",
+      "defined_out": [
+        "0x151f7c7500000000000004d2"
+      ],
+      "stack_out": [
+        "0x151f7c7500000000000004d2"
+      ]
+    },
+    "261": {
+      "op": "log",
+      "stack_out": []
+    },
+    "262": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "263": {
+      "op": "return",
+      "stack_out": []
+    },
+    "264": {
+      "block": "main_asset_ret_route@4",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%9#0"
+      ],
+      "stack_out": [
+        "tmp%9#0"
+      ]
+    },
+    "266": {
+      "op": "!",
+      "defined_out": [
+        "tmp%10#0"
+      ],
+      "stack_out": [
+        "tmp%10#0"
+      ]
+    },
+    "267": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "268": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%11#0"
+      ],
+      "stack_out": [
+        "tmp%11#0"
+      ]
+    },
+    "270": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "271": {
+      "op": "bytec_1 // 0x151f7c7500000000000004d2",
+      "defined_out": [
+        "0x151f7c7500000000000004d2"
+      ],
+      "stack_out": [
+        "0x151f7c7500000000000004d2"
+      ]
+    },
+    "272": {
+      "op": "log",
+      "stack_out": []
+    },
+    "273": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "274": {
+      "op": "return",
+      "stack_out": []
+    },
+    "275": {
+      "block": "main_acc_ret_route@3",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%3#0"
+      ],
+      "stack_out": [
+        "tmp%3#0"
+      ]
+    },
+    "277": {
+      "op": "!",
+      "defined_out": [
+        "tmp%4#0"
+      ],
+      "stack_out": [
+        "tmp%4#0"
+      ]
+    },
+    "278": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "279": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%5#0"
+      ],
+      "stack_out": [
+        "tmp%5#0"
+      ]
+    },
+    "281": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "282": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret",
+      "op": "callsub acc_ret",
+      "defined_out": [
+        "tmp%7#0"
+      ],
+      "stack_out": [
+        "tmp%7#0"
+      ]
+    },
+    "285": {
+      "op": "bytec_0 // 0x151f7c75",
+      "defined_out": [
+        "0x151f7c75",
+        "tmp%7#0"
+      ],
+      "stack_out": [
+        "tmp%7#0",
+        "0x151f7c75"
+      ]
+    },
+    "286": {
+      "op": "swap",
+      "stack_out": [
+        "0x151f7c75",
+        "tmp%7#0"
+      ]
+    },
+    "287": {
+      "op": "concat",
+      "defined_out": [
+        "tmp%8#0"
+      ],
+      "stack_out": [
+        "tmp%8#0"
+      ]
+    },
+    "288": {
+      "op": "log",
+      "stack_out": []
+    },
+    "289": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "290": {
+      "op": "return",
+      "stack_out": []
+    },
+    "291": {
+      "block": "main_bare_routing@15",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%59#0"
+      ],
+      "stack_out": [
+        "tmp%59#0"
+      ]
+    },
+    "293": {
+      "op": "bnz main_after_if_else@19",
+      "stack_out": []
+    },
+    "296": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%60#0"
+      ],
+      "stack_out": [
+        "tmp%60#0"
+      ]
+    },
+    "298": {
+      "op": "!",
+      "defined_out": [
+        "tmp%61#0"
+      ],
+      "stack_out": [
+        "tmp%61#0"
+      ]
+    },
+    "299": {
+      "error": "can only call when creating",
+      "op": "assert // can only call when creating",
+      "stack_out": []
+    },
+    "300": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "301": {
+      "op": "return",
+      "stack_out": []
+    },
+    "302": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret",
+      "params": {},
+      "block": "acc_ret",
+      "stack_in": [],
+      "op": "txn Sender",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "304": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "305": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.store",
+      "params": {
+        "acc#0": "bytes",
+        "app#0": "uint64",
+        "asset#0": "uint64"
+      },
+      "block": "store",
+      "stack_in": [],
+      "op": "proto 3 0"
+    },
+    "308": {
+      "op": "pushbytes \"acc\"",
+      "defined_out": [
+        "\"acc\""
+      ],
+      "stack_out": [
+        "\"acc\""
+      ]
+    },
+    "313": {
+      "op": "frame_dig -3",
+      "defined_out": [
+        "\"acc\"",
+        "acc#0 (copy)"
+      ],
+      "stack_out": [
+        "\"acc\"",
+        "acc#0 (copy)"
+      ]
+    },
+    "315": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "316": {
+      "op": "pushbytes \"asset\"",
+      "defined_out": [
+        "\"asset\""
+      ],
+      "stack_out": [
+        "\"asset\""
+      ]
+    },
+    "323": {
+      "op": "frame_dig -1",
+      "defined_out": [
+        "\"asset\"",
+        "asset#0 (copy)"
+      ],
+      "stack_out": [
+        "\"asset\"",
+        "asset#0 (copy)"
+      ]
+    },
+    "325": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "326": {
+      "op": "pushbytes \"app\"",
+      "defined_out": [
+        "\"app\""
+      ],
+      "stack_out": [
+        "\"app\""
+      ]
+    },
+    "331": {
+      "op": "frame_dig -2",
+      "defined_out": [
+        "\"app\"",
+        "app#0 (copy)"
+      ],
+      "stack_out": [
+        "\"app\"",
+        "app#0 (copy)"
+      ]
+    },
+    "333": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "334": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "335": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.store_apps",
+      "params": {
+        "apps#0": "bytes"
+      },
+      "block": "store_apps",
+      "stack_in": [],
+      "op": "proto 1 0"
+    },
+    "338": {
+      "op": "bytec_2 // \"apps\"",
+      "defined_out": [
+        "\"apps\""
+      ],
+      "stack_out": [
+        "\"apps\""
+      ]
+    },
+    "339": {
+      "op": "frame_dig -1",
+      "defined_out": [
+        "\"apps\"",
+        "apps#0 (copy)"
+      ],
+      "stack_out": [
+        "\"apps\"",
+        "apps#0 (copy)"
+      ]
+    },
+    "341": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "342": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "343": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.store_assets",
+      "params": {
+        "assets#0": "bytes"
+      },
+      "block": "store_assets",
+      "stack_in": [],
+      "op": "proto 1 0"
+    },
+    "346": {
+      "op": "bytec_3 // \"assets\"",
+      "defined_out": [
+        "\"assets\""
+      ],
+      "stack_out": [
+        "\"assets\""
+      ]
+    },
+    "347": {
+      "op": "frame_dig -1",
+      "defined_out": [
+        "\"assets\"",
+        "assets#0 (copy)"
+      ],
+      "stack_out": [
+        "\"assets\"",
+        "assets#0 (copy)"
+      ]
+    },
+    "349": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "350": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "351": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts",
+      "params": {
+        "accounts#0": "bytes"
+      },
+      "block": "store_accounts",
+      "stack_in": [],
+      "op": "proto 1 0"
+    },
+    "354": {
+      "op": "bytec 4 // \"accounts\"",
+      "defined_out": [
+        "\"accounts\""
+      ],
+      "stack_out": [
+        "\"accounts\""
+      ]
+    },
+    "356": {
+      "op": "frame_dig -1",
+      "defined_out": [
+        "\"accounts\"",
+        "accounts#0 (copy)"
+      ],
+      "stack_out": [
+        "\"accounts\"",
+        "accounts#0 (copy)"
+      ]
+    },
+    "358": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "359": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "360": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.return_apps",
+      "params": {},
+      "block": "return_apps",
+      "stack_in": [],
+      "op": "intc_1 // 0",
+      "defined_out": [
+        "0"
+      ],
+      "stack_out": [
+        "0"
+      ]
+    },
+    "361": {
+      "op": "bytec_2 // \"apps\"",
+      "defined_out": [
+        "\"apps\"",
+        "0"
+      ],
+      "stack_out": [
+        "0",
+        "\"apps\""
+      ]
+    },
+    "362": {
+      "op": "app_global_get_ex",
+      "defined_out": [
+        "maybe_exists%0#0",
+        "maybe_value%0#0"
+      ],
+      "stack_out": [
+        "maybe_value%0#0",
+        "maybe_exists%0#0"
+      ]
+    },
+    "363": {
+      "error": "check self.apps exists",
+      "op": "assert // check self.apps exists",
+      "stack_out": [
+        "maybe_value%0#0"
+      ]
+    },
+    "364": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "365": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.return_assets",
+      "params": {},
+      "block": "return_assets",
+      "stack_in": [],
+      "op": "intc_1 // 0",
+      "defined_out": [
+        "0"
+      ],
+      "stack_out": [
+        "0"
+      ]
+    },
+    "366": {
+      "op": "bytec_3 // \"assets\"",
+      "defined_out": [
+        "\"assets\"",
+        "0"
+      ],
+      "stack_out": [
+        "0",
+        "\"assets\""
+      ]
+    },
+    "367": {
+      "op": "app_global_get_ex",
+      "defined_out": [
+        "maybe_exists%0#0",
+        "maybe_value%0#0"
+      ],
+      "stack_out": [
+        "maybe_value%0#0",
+        "maybe_exists%0#0"
+      ]
+    },
+    "368": {
+      "error": "check self.assets exists",
+      "op": "assert // check self.assets exists",
+      "stack_out": [
+        "maybe_value%0#0"
+      ]
+    },
+    "369": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "370": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts",
+      "params": {},
+      "block": "return_accounts",
+      "stack_in": [],
+      "op": "intc_1 // 0",
+      "defined_out": [
+        "0"
+      ],
+      "stack_out": [
+        "0"
+      ]
+    },
+    "371": {
+      "op": "bytec 4 // \"accounts\"",
+      "defined_out": [
+        "\"accounts\"",
+        "0"
+      ],
+      "stack_out": [
+        "0",
+        "\"accounts\""
+      ]
+    },
+    "373": {
+      "op": "app_global_get_ex",
+      "defined_out": [
+        "maybe_exists%0#0",
+        "maybe_value%0#0"
+      ],
+      "stack_out": [
+        "maybe_value%0#0",
+        "maybe_exists%0#0"
+      ]
+    },
+    "374": {
+      "error": "check self.accounts exists",
+      "op": "assert // check self.accounts exists",
+      "stack_out": [
+        "maybe_value%0#0"
+      ]
+    },
+    "375": {
+      "retsub": true,
+      "op": "retsub"
+    }
+  }
+}

--- a/test_cases/arc4_conversions/out/ReferenceReturn.approval.teal
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.approval.teal
@@ -1,0 +1,304 @@
+#pragma version 10
+#pragma typetrack false
+
+// algopy.arc4.ARC4Contract.approval_program() -> uint64:
+main:
+    intcblock 1 0
+    bytecblock 0x151f7c75 0x151f7c7500000000000004d2 "apps" "assets" "accounts"
+    // arc4_conversions/reference.py:4
+    // class ReferenceReturn(arc4.ARC4Contract):
+    txn NumAppArgs
+    bz main_bare_routing@15
+    pushbytess 0x6c7a1cb5 0xc8480f0c 0x37c0cbf2 0x864086a7 0x6728b1a1 0xce7e6cd3 0x0a37f6e1 0x4c894d7e 0x62ebcf89 0x924e778c // method "acc_ret()address", method "asset_ret()uint64", method "app_ret()uint64", method "store(account,application,asset)void", method "store_apps(uint64[])void", method "store_assets(uint64[])void", method "store_accounts(address[])void", method "return_apps()uint64[]", method "return_assets()uint64[]", method "return_accounts()address[]"
+    txna ApplicationArgs 0
+    match main_acc_ret_route@3 main_asset_ret_route@4 main_app_ret_route@5 main_store_route@6 main_store_apps_route@7 main_store_assets_route@8 main_store_accounts_route@9 main_return_apps_route@10 main_return_assets_route@11 main_return_accounts_route@12
+
+main_after_if_else@19:
+    // arc4_conversions/reference.py:4
+    // class ReferenceReturn(arc4.ARC4Contract):
+    intc_1 // 0
+    return
+
+main_return_accounts_route@12:
+    // arc4_conversions/reference.py:43
+    // @arc4.abimethod
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    callsub return_accounts
+    bytec_0 // 0x151f7c75
+    swap
+    concat
+    log
+    intc_0 // 1
+    return
+
+main_return_assets_route@11:
+    // arc4_conversions/reference.py:39
+    // @arc4.abimethod
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    callsub return_assets
+    bytec_0 // 0x151f7c75
+    swap
+    concat
+    log
+    intc_0 // 1
+    return
+
+main_return_apps_route@10:
+    // arc4_conversions/reference.py:35
+    // @arc4.abimethod
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    callsub return_apps
+    bytec_0 // 0x151f7c75
+    swap
+    concat
+    log
+    intc_0 // 1
+    return
+
+main_store_accounts_route@9:
+    // arc4_conversions/reference.py:31
+    // @arc4.abimethod
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    // arc4_conversions/reference.py:4
+    // class ReferenceReturn(arc4.ARC4Contract):
+    txna ApplicationArgs 1
+    // arc4_conversions/reference.py:31
+    // @arc4.abimethod
+    callsub store_accounts
+    intc_0 // 1
+    return
+
+main_store_assets_route@8:
+    // arc4_conversions/reference.py:27
+    // @arc4.abimethod
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    // arc4_conversions/reference.py:4
+    // class ReferenceReturn(arc4.ARC4Contract):
+    txna ApplicationArgs 1
+    // arc4_conversions/reference.py:27
+    // @arc4.abimethod
+    callsub store_assets
+    intc_0 // 1
+    return
+
+main_store_apps_route@7:
+    // arc4_conversions/reference.py:23
+    // @arc4.abimethod
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    // arc4_conversions/reference.py:4
+    // class ReferenceReturn(arc4.ARC4Contract):
+    txna ApplicationArgs 1
+    // arc4_conversions/reference.py:23
+    // @arc4.abimethod
+    callsub store_apps
+    intc_0 // 1
+    return
+
+main_store_route@6:
+    // arc4_conversions/reference.py:17
+    // @arc4.abimethod
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    // arc4_conversions/reference.py:4
+    // class ReferenceReturn(arc4.ARC4Contract):
+    txna ApplicationArgs 1
+    btoi
+    txnas Accounts
+    txna ApplicationArgs 2
+    btoi
+    txnas Applications
+    txna ApplicationArgs 3
+    btoi
+    txnas Assets
+    // arc4_conversions/reference.py:17
+    // @arc4.abimethod
+    callsub store
+    intc_0 // 1
+    return
+
+main_app_ret_route@5:
+    // arc4_conversions/reference.py:13
+    // @arc4.abimethod
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    bytec_1 // 0x151f7c7500000000000004d2
+    log
+    intc_0 // 1
+    return
+
+main_asset_ret_route@4:
+    // arc4_conversions/reference.py:9
+    // @arc4.abimethod
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    bytec_1 // 0x151f7c7500000000000004d2
+    log
+    intc_0 // 1
+    return
+
+main_acc_ret_route@3:
+    // arc4_conversions/reference.py:5
+    // @arc4.abimethod
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    callsub acc_ret
+    bytec_0 // 0x151f7c75
+    swap
+    concat
+    log
+    intc_0 // 1
+    return
+
+main_bare_routing@15:
+    // arc4_conversions/reference.py:4
+    // class ReferenceReturn(arc4.ARC4Contract):
+    txn OnCompletion
+    bnz main_after_if_else@19
+    txn ApplicationID
+    !
+    assert // can only call when creating
+    intc_0 // 1
+    return
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes:
+acc_ret:
+    // arc4_conversions/reference.py:7
+    // return Txn.sender
+    txn Sender
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes, app: uint64, asset: uint64) -> void:
+store:
+    // arc4_conversions/reference.py:17-18
+    // @arc4.abimethod
+    // def store(self, acc: Account, app: Application, asset: Asset) -> None:
+    proto 3 0
+    // arc4_conversions/reference.py:19
+    // self.acc = acc
+    pushbytes "acc"
+    frame_dig -3
+    app_global_put
+    // arc4_conversions/reference.py:20
+    // self.asset = asset
+    pushbytes "asset"
+    frame_dig -1
+    app_global_put
+    // arc4_conversions/reference.py:21
+    // self.app = app
+    pushbytes "app"
+    frame_dig -2
+    app_global_put
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: bytes) -> void:
+store_apps:
+    // arc4_conversions/reference.py:23-24
+    // @arc4.abimethod
+    // def store_apps(self, apps: ImmutableArray[Application]) -> None:
+    proto 1 0
+    // arc4_conversions/reference.py:25
+    // self.apps = apps
+    bytec_2 // "apps"
+    frame_dig -1
+    app_global_put
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: bytes) -> void:
+store_assets:
+    // arc4_conversions/reference.py:27-28
+    // @arc4.abimethod
+    // def store_assets(self, assets: ImmutableArray[Asset]) -> None:
+    proto 1 0
+    // arc4_conversions/reference.py:29
+    // self.assets = assets
+    bytec_3 // "assets"
+    frame_dig -1
+    app_global_put
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes) -> void:
+store_accounts:
+    // arc4_conversions/reference.py:31-32
+    // @arc4.abimethod
+    // def store_accounts(self, accounts: ImmutableArray[Account]) -> None:
+    proto 1 0
+    // arc4_conversions/reference.py:33
+    // self.accounts = accounts
+    bytec 4 // "accounts"
+    frame_dig -1
+    app_global_put
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> bytes:
+return_apps:
+    // arc4_conversions/reference.py:37
+    // return self.apps
+    intc_1 // 0
+    bytec_2 // "apps"
+    app_global_get_ex
+    assert // check self.apps exists
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> bytes:
+return_assets:
+    // arc4_conversions/reference.py:41
+    // return self.assets
+    intc_1 // 0
+    bytec_3 // "assets"
+    app_global_get_ex
+    assert // check self.assets exists
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes:
+return_accounts:
+    // arc4_conversions/reference.py:45
+    // return self.accounts
+    intc_1 // 0
+    bytec 4 // "accounts"
+    app_global_get_ex
+    assert // check self.accounts exists
+    retsub

--- a/test_cases/arc4_conversions/out/ReferenceReturn.arc32.json
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.arc32.json
@@ -1,0 +1,220 @@
+{
+    "hints": {
+        "acc_ret()address": {
+            "call_config": {
+                "no_op": "CALL"
+            }
+        },
+        "asset_ret()uint64": {
+            "call_config": {
+                "no_op": "CALL"
+            }
+        },
+        "app_ret()uint64": {
+            "call_config": {
+                "no_op": "CALL"
+            }
+        },
+        "store(account,application,asset)void": {
+            "call_config": {
+                "no_op": "CALL"
+            }
+        },
+        "store_apps(uint64[])void": {
+            "call_config": {
+                "no_op": "CALL"
+            }
+        },
+        "store_assets(uint64[])void": {
+            "call_config": {
+                "no_op": "CALL"
+            }
+        },
+        "store_accounts(address[])void": {
+            "call_config": {
+                "no_op": "CALL"
+            }
+        },
+        "return_apps()uint64[]": {
+            "call_config": {
+                "no_op": "CALL"
+            }
+        },
+        "return_assets()uint64[]": {
+            "call_config": {
+                "no_op": "CALL"
+            }
+        },
+        "return_accounts()address[]": {
+            "call_config": {
+                "no_op": "CALL"
+            }
+        }
+    },
+    "source": {
+        "approval": "I3ByYWdtYSB2ZXJzaW9uIDEwCiNwcmFnbWEgdHlwZXRyYWNrIGZhbHNlCgovLyBhbGdvcHkuYXJjNC5BUkM0Q29udHJhY3QuYXBwcm92YWxfcHJvZ3JhbSgpIC0+IHVpbnQ2NDoKbWFpbjoKICAgIGludGNibG9jayAxIDAKICAgIGJ5dGVjYmxvY2sgMHgxNTFmN2M3NSAweDE1MWY3Yzc1MDAwMDAwMDAwMDAwMDRkMiAiYXBwcyIgImFzc2V0cyIgImFjY291bnRzIgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6NAogICAgLy8gY2xhc3MgUmVmZXJlbmNlUmV0dXJuKGFyYzQuQVJDNENvbnRyYWN0KToKICAgIHR4biBOdW1BcHBBcmdzCiAgICBieiBtYWluX2JhcmVfcm91dGluZ0AxNQogICAgcHVzaGJ5dGVzcyAweDZjN2ExY2I1IDB4Yzg0ODBmMGMgMHgzN2MwY2JmMiAweDg2NDA4NmE3IDB4NjcyOGIxYTEgMHhjZTdlNmNkMyAweDBhMzdmNmUxIDB4NGM4OTRkN2UgMHg2MmViY2Y4OSAweDkyNGU3NzhjIC8vIG1ldGhvZCAiYWNjX3JldCgpYWRkcmVzcyIsIG1ldGhvZCAiYXNzZXRfcmV0KCl1aW50NjQiLCBtZXRob2QgImFwcF9yZXQoKXVpbnQ2NCIsIG1ldGhvZCAic3RvcmUoYWNjb3VudCxhcHBsaWNhdGlvbixhc3NldCl2b2lkIiwgbWV0aG9kICJzdG9yZV9hcHBzKHVpbnQ2NFtdKXZvaWQiLCBtZXRob2QgInN0b3JlX2Fzc2V0cyh1aW50NjRbXSl2b2lkIiwgbWV0aG9kICJzdG9yZV9hY2NvdW50cyhhZGRyZXNzW10pdm9pZCIsIG1ldGhvZCAicmV0dXJuX2FwcHMoKXVpbnQ2NFtdIiwgbWV0aG9kICJyZXR1cm5fYXNzZXRzKCl1aW50NjRbXSIsIG1ldGhvZCAicmV0dXJuX2FjY291bnRzKClhZGRyZXNzW10iCiAgICB0eG5hIEFwcGxpY2F0aW9uQXJncyAwCiAgICBtYXRjaCBtYWluX2FjY19yZXRfcm91dGVAMyBtYWluX2Fzc2V0X3JldF9yb3V0ZUA0IG1haW5fYXBwX3JldF9yb3V0ZUA1IG1haW5fc3RvcmVfcm91dGVANiBtYWluX3N0b3JlX2FwcHNfcm91dGVANyBtYWluX3N0b3JlX2Fzc2V0c19yb3V0ZUA4IG1haW5fc3RvcmVfYWNjb3VudHNfcm91dGVAOSBtYWluX3JldHVybl9hcHBzX3JvdXRlQDEwIG1haW5fcmV0dXJuX2Fzc2V0c19yb3V0ZUAxMSBtYWluX3JldHVybl9hY2NvdW50c19yb3V0ZUAxMgoKbWFpbl9hZnRlcl9pZl9lbHNlQDE5OgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6NAogICAgLy8gY2xhc3MgUmVmZXJlbmNlUmV0dXJuKGFyYzQuQVJDNENvbnRyYWN0KToKICAgIGludGNfMSAvLyAwCiAgICByZXR1cm4KCm1haW5fcmV0dXJuX2FjY291bnRzX3JvdXRlQDEyOgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6NDMKICAgIC8vIEBhcmM0LmFiaW1ldGhvZAogICAgdHhuIE9uQ29tcGxldGlvbgogICAgIQogICAgYXNzZXJ0IC8vIE9uQ29tcGxldGlvbiBpcyBub3QgTm9PcAogICAgdHhuIEFwcGxpY2F0aW9uSUQKICAgIGFzc2VydCAvLyBjYW4gb25seSBjYWxsIHdoZW4gbm90IGNyZWF0aW5nCiAgICBjYWxsc3ViIHJldHVybl9hY2NvdW50cwogICAgYnl0ZWNfMCAvLyAweDE1MWY3Yzc1CiAgICBzd2FwCiAgICBjb25jYXQKICAgIGxvZwogICAgaW50Y18wIC8vIDEKICAgIHJldHVybgoKbWFpbl9yZXR1cm5fYXNzZXRzX3JvdXRlQDExOgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6MzkKICAgIC8vIEBhcmM0LmFiaW1ldGhvZAogICAgdHhuIE9uQ29tcGxldGlvbgogICAgIQogICAgYXNzZXJ0IC8vIE9uQ29tcGxldGlvbiBpcyBub3QgTm9PcAogICAgdHhuIEFwcGxpY2F0aW9uSUQKICAgIGFzc2VydCAvLyBjYW4gb25seSBjYWxsIHdoZW4gbm90IGNyZWF0aW5nCiAgICBjYWxsc3ViIHJldHVybl9hc3NldHMKICAgIGJ5dGVjXzAgLy8gMHgxNTFmN2M3NQogICAgc3dhcAogICAgY29uY2F0CiAgICBsb2cKICAgIGludGNfMCAvLyAxCiAgICByZXR1cm4KCm1haW5fcmV0dXJuX2FwcHNfcm91dGVAMTA6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weTozNQogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICB0eG4gT25Db21wbGV0aW9uCiAgICAhCiAgICBhc3NlcnQgLy8gT25Db21wbGV0aW9uIGlzIG5vdCBOb09wCiAgICB0eG4gQXBwbGljYXRpb25JRAogICAgYXNzZXJ0IC8vIGNhbiBvbmx5IGNhbGwgd2hlbiBub3QgY3JlYXRpbmcKICAgIGNhbGxzdWIgcmV0dXJuX2FwcHMKICAgIGJ5dGVjXzAgLy8gMHgxNTFmN2M3NQogICAgc3dhcAogICAgY29uY2F0CiAgICBsb2cKICAgIGludGNfMCAvLyAxCiAgICByZXR1cm4KCm1haW5fc3RvcmVfYWNjb3VudHNfcm91dGVAOToKICAgIC8vIGFyYzRfY29udmVyc2lvbnMvcmVmZXJlbmNlLnB5OjMxCiAgICAvLyBAYXJjNC5hYmltZXRob2QKICAgIHR4biBPbkNvbXBsZXRpb24KICAgICEKICAgIGFzc2VydCAvLyBPbkNvbXBsZXRpb24gaXMgbm90IE5vT3AKICAgIHR4biBBcHBsaWNhdGlvbklECiAgICBhc3NlcnQgLy8gY2FuIG9ubHkgY2FsbCB3aGVuIG5vdCBjcmVhdGluZwogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6NAogICAgLy8gY2xhc3MgUmVmZXJlbmNlUmV0dXJuKGFyYzQuQVJDNENvbnRyYWN0KToKICAgIHR4bmEgQXBwbGljYXRpb25BcmdzIDEKICAgIC8vIGFyYzRfY29udmVyc2lvbnMvcmVmZXJlbmNlLnB5OjMxCiAgICAvLyBAYXJjNC5hYmltZXRob2QKICAgIGNhbGxzdWIgc3RvcmVfYWNjb3VudHMKICAgIGludGNfMCAvLyAxCiAgICByZXR1cm4KCm1haW5fc3RvcmVfYXNzZXRzX3JvdXRlQDg6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToyNwogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICB0eG4gT25Db21wbGV0aW9uCiAgICAhCiAgICBhc3NlcnQgLy8gT25Db21wbGV0aW9uIGlzIG5vdCBOb09wCiAgICB0eG4gQXBwbGljYXRpb25JRAogICAgYXNzZXJ0IC8vIGNhbiBvbmx5IGNhbGwgd2hlbiBub3QgY3JlYXRpbmcKICAgIC8vIGFyYzRfY29udmVyc2lvbnMvcmVmZXJlbmNlLnB5OjQKICAgIC8vIGNsYXNzIFJlZmVyZW5jZVJldHVybihhcmM0LkFSQzRDb250cmFjdCk6CiAgICB0eG5hIEFwcGxpY2F0aW9uQXJncyAxCiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToyNwogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICBjYWxsc3ViIHN0b3JlX2Fzc2V0cwogICAgaW50Y18wIC8vIDEKICAgIHJldHVybgoKbWFpbl9zdG9yZV9hcHBzX3JvdXRlQDc6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToyMwogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICB0eG4gT25Db21wbGV0aW9uCiAgICAhCiAgICBhc3NlcnQgLy8gT25Db21wbGV0aW9uIGlzIG5vdCBOb09wCiAgICB0eG4gQXBwbGljYXRpb25JRAogICAgYXNzZXJ0IC8vIGNhbiBvbmx5IGNhbGwgd2hlbiBub3QgY3JlYXRpbmcKICAgIC8vIGFyYzRfY29udmVyc2lvbnMvcmVmZXJlbmNlLnB5OjQKICAgIC8vIGNsYXNzIFJlZmVyZW5jZVJldHVybihhcmM0LkFSQzRDb250cmFjdCk6CiAgICB0eG5hIEFwcGxpY2F0aW9uQXJncyAxCiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToyMwogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICBjYWxsc3ViIHN0b3JlX2FwcHMKICAgIGludGNfMCAvLyAxCiAgICByZXR1cm4KCm1haW5fc3RvcmVfcm91dGVANjoKICAgIC8vIGFyYzRfY29udmVyc2lvbnMvcmVmZXJlbmNlLnB5OjE3CiAgICAvLyBAYXJjNC5hYmltZXRob2QKICAgIHR4biBPbkNvbXBsZXRpb24KICAgICEKICAgIGFzc2VydCAvLyBPbkNvbXBsZXRpb24gaXMgbm90IE5vT3AKICAgIHR4biBBcHBsaWNhdGlvbklECiAgICBhc3NlcnQgLy8gY2FuIG9ubHkgY2FsbCB3aGVuIG5vdCBjcmVhdGluZwogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6NAogICAgLy8gY2xhc3MgUmVmZXJlbmNlUmV0dXJuKGFyYzQuQVJDNENvbnRyYWN0KToKICAgIHR4bmEgQXBwbGljYXRpb25BcmdzIDEKICAgIGJ0b2kKICAgIHR4bmFzIEFjY291bnRzCiAgICB0eG5hIEFwcGxpY2F0aW9uQXJncyAyCiAgICBidG9pCiAgICB0eG5hcyBBcHBsaWNhdGlvbnMKICAgIHR4bmEgQXBwbGljYXRpb25BcmdzIDMKICAgIGJ0b2kKICAgIHR4bmFzIEFzc2V0cwogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6MTcKICAgIC8vIEBhcmM0LmFiaW1ldGhvZAogICAgY2FsbHN1YiBzdG9yZQogICAgaW50Y18wIC8vIDEKICAgIHJldHVybgoKbWFpbl9hcHBfcmV0X3JvdXRlQDU6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToxMwogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICB0eG4gT25Db21wbGV0aW9uCiAgICAhCiAgICBhc3NlcnQgLy8gT25Db21wbGV0aW9uIGlzIG5vdCBOb09wCiAgICB0eG4gQXBwbGljYXRpb25JRAogICAgYXNzZXJ0IC8vIGNhbiBvbmx5IGNhbGwgd2hlbiBub3QgY3JlYXRpbmcKICAgIGJ5dGVjXzEgLy8gMHgxNTFmN2M3NTAwMDAwMDAwMDAwMDA0ZDIKICAgIGxvZwogICAgaW50Y18wIC8vIDEKICAgIHJldHVybgoKbWFpbl9hc3NldF9yZXRfcm91dGVANDoKICAgIC8vIGFyYzRfY29udmVyc2lvbnMvcmVmZXJlbmNlLnB5OjkKICAgIC8vIEBhcmM0LmFiaW1ldGhvZAogICAgdHhuIE9uQ29tcGxldGlvbgogICAgIQogICAgYXNzZXJ0IC8vIE9uQ29tcGxldGlvbiBpcyBub3QgTm9PcAogICAgdHhuIEFwcGxpY2F0aW9uSUQKICAgIGFzc2VydCAvLyBjYW4gb25seSBjYWxsIHdoZW4gbm90IGNyZWF0aW5nCiAgICBieXRlY18xIC8vIDB4MTUxZjdjNzUwMDAwMDAwMDAwMDAwNGQyCiAgICBsb2cKICAgIGludGNfMCAvLyAxCiAgICByZXR1cm4KCm1haW5fYWNjX3JldF9yb3V0ZUAzOgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6NQogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICB0eG4gT25Db21wbGV0aW9uCiAgICAhCiAgICBhc3NlcnQgLy8gT25Db21wbGV0aW9uIGlzIG5vdCBOb09wCiAgICB0eG4gQXBwbGljYXRpb25JRAogICAgYXNzZXJ0IC8vIGNhbiBvbmx5IGNhbGwgd2hlbiBub3QgY3JlYXRpbmcKICAgIGNhbGxzdWIgYWNjX3JldAogICAgYnl0ZWNfMCAvLyAweDE1MWY3Yzc1CiAgICBzd2FwCiAgICBjb25jYXQKICAgIGxvZwogICAgaW50Y18wIC8vIDEKICAgIHJldHVybgoKbWFpbl9iYXJlX3JvdXRpbmdAMTU6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weTo0CiAgICAvLyBjbGFzcyBSZWZlcmVuY2VSZXR1cm4oYXJjNC5BUkM0Q29udHJhY3QpOgogICAgdHhuIE9uQ29tcGxldGlvbgogICAgYm56IG1haW5fYWZ0ZXJfaWZfZWxzZUAxOQogICAgdHhuIEFwcGxpY2F0aW9uSUQKICAgICEKICAgIGFzc2VydCAvLyBjYW4gb25seSBjYWxsIHdoZW4gY3JlYXRpbmcKICAgIGludGNfMCAvLyAxCiAgICByZXR1cm4KCgovLyB0ZXN0X2Nhc2VzLmFyYzRfY29udmVyc2lvbnMucmVmZXJlbmNlLlJlZmVyZW5jZVJldHVybi5hY2NfcmV0KCkgLT4gYnl0ZXM6CmFjY19yZXQ6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weTo3CiAgICAvLyByZXR1cm4gVHhuLnNlbmRlcgogICAgdHhuIFNlbmRlcgogICAgcmV0c3ViCgoKLy8gdGVzdF9jYXNlcy5hcmM0X2NvbnZlcnNpb25zLnJlZmVyZW5jZS5SZWZlcmVuY2VSZXR1cm4uc3RvcmUoYWNjOiBieXRlcywgYXBwOiB1aW50NjQsIGFzc2V0OiB1aW50NjQpIC0+IHZvaWQ6CnN0b3JlOgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6MTctMTgKICAgIC8vIEBhcmM0LmFiaW1ldGhvZAogICAgLy8gZGVmIHN0b3JlKHNlbGYsIGFjYzogQWNjb3VudCwgYXBwOiBBcHBsaWNhdGlvbiwgYXNzZXQ6IEFzc2V0KSAtPiBOb25lOgogICAgcHJvdG8gMyAwCiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToxOQogICAgLy8gc2VsZi5hY2MgPSBhY2MKICAgIHB1c2hieXRlcyAiYWNjIgogICAgZnJhbWVfZGlnIC0zCiAgICBhcHBfZ2xvYmFsX3B1dAogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6MjAKICAgIC8vIHNlbGYuYXNzZXQgPSBhc3NldAogICAgcHVzaGJ5dGVzICJhc3NldCIKICAgIGZyYW1lX2RpZyAtMQogICAgYXBwX2dsb2JhbF9wdXQKICAgIC8vIGFyYzRfY29udmVyc2lvbnMvcmVmZXJlbmNlLnB5OjIxCiAgICAvLyBzZWxmLmFwcCA9IGFwcAogICAgcHVzaGJ5dGVzICJhcHAiCiAgICBmcmFtZV9kaWcgLTIKICAgIGFwcF9nbG9iYWxfcHV0CiAgICByZXRzdWIKCgovLyB0ZXN0X2Nhc2VzLmFyYzRfY29udmVyc2lvbnMucmVmZXJlbmNlLlJlZmVyZW5jZVJldHVybi5zdG9yZV9hcHBzKGFwcHM6IGJ5dGVzKSAtPiB2b2lkOgpzdG9yZV9hcHBzOgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6MjMtMjQKICAgIC8vIEBhcmM0LmFiaW1ldGhvZAogICAgLy8gZGVmIHN0b3JlX2FwcHMoc2VsZiwgYXBwczogSW1tdXRhYmxlQXJyYXlbQXBwbGljYXRpb25dKSAtPiBOb25lOgogICAgcHJvdG8gMSAwCiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToyNQogICAgLy8gc2VsZi5hcHBzID0gYXBwcwogICAgYnl0ZWNfMiAvLyAiYXBwcyIKICAgIGZyYW1lX2RpZyAtMQogICAgYXBwX2dsb2JhbF9wdXQKICAgIHJldHN1YgoKCi8vIHRlc3RfY2FzZXMuYXJjNF9jb252ZXJzaW9ucy5yZWZlcmVuY2UuUmVmZXJlbmNlUmV0dXJuLnN0b3JlX2Fzc2V0cyhhc3NldHM6IGJ5dGVzKSAtPiB2b2lkOgpzdG9yZV9hc3NldHM6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToyNy0yOAogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICAvLyBkZWYgc3RvcmVfYXNzZXRzKHNlbGYsIGFzc2V0czogSW1tdXRhYmxlQXJyYXlbQXNzZXRdKSAtPiBOb25lOgogICAgcHJvdG8gMSAwCiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToyOQogICAgLy8gc2VsZi5hc3NldHMgPSBhc3NldHMKICAgIGJ5dGVjXzMgLy8gImFzc2V0cyIKICAgIGZyYW1lX2RpZyAtMQogICAgYXBwX2dsb2JhbF9wdXQKICAgIHJldHN1YgoKCi8vIHRlc3RfY2FzZXMuYXJjNF9jb252ZXJzaW9ucy5yZWZlcmVuY2UuUmVmZXJlbmNlUmV0dXJuLnN0b3JlX2FjY291bnRzKGFjY291bnRzOiBieXRlcykgLT4gdm9pZDoKc3RvcmVfYWNjb3VudHM6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weTozMS0zMgogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICAvLyBkZWYgc3RvcmVfYWNjb3VudHMoc2VsZiwgYWNjb3VudHM6IEltbXV0YWJsZUFycmF5W0FjY291bnRdKSAtPiBOb25lOgogICAgcHJvdG8gMSAwCiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weTozMwogICAgLy8gc2VsZi5hY2NvdW50cyA9IGFjY291bnRzCiAgICBieXRlYyA0IC8vICJhY2NvdW50cyIKICAgIGZyYW1lX2RpZyAtMQogICAgYXBwX2dsb2JhbF9wdXQKICAgIHJldHN1YgoKCi8vIHRlc3RfY2FzZXMuYXJjNF9jb252ZXJzaW9ucy5yZWZlcmVuY2UuUmVmZXJlbmNlUmV0dXJuLnJldHVybl9hcHBzKCkgLT4gYnl0ZXM6CnJldHVybl9hcHBzOgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6MzcKICAgIC8vIHJldHVybiBzZWxmLmFwcHMKICAgIGludGNfMSAvLyAwCiAgICBieXRlY18yIC8vICJhcHBzIgogICAgYXBwX2dsb2JhbF9nZXRfZXgKICAgIGFzc2VydCAvLyBjaGVjayBzZWxmLmFwcHMgZXhpc3RzCiAgICByZXRzdWIKCgovLyB0ZXN0X2Nhc2VzLmFyYzRfY29udmVyc2lvbnMucmVmZXJlbmNlLlJlZmVyZW5jZVJldHVybi5yZXR1cm5fYXNzZXRzKCkgLT4gYnl0ZXM6CnJldHVybl9hc3NldHM6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weTo0MQogICAgLy8gcmV0dXJuIHNlbGYuYXNzZXRzCiAgICBpbnRjXzEgLy8gMAogICAgYnl0ZWNfMyAvLyAiYXNzZXRzIgogICAgYXBwX2dsb2JhbF9nZXRfZXgKICAgIGFzc2VydCAvLyBjaGVjayBzZWxmLmFzc2V0cyBleGlzdHMKICAgIHJldHN1YgoKCi8vIHRlc3RfY2FzZXMuYXJjNF9jb252ZXJzaW9ucy5yZWZlcmVuY2UuUmVmZXJlbmNlUmV0dXJuLnJldHVybl9hY2NvdW50cygpIC0+IGJ5dGVzOgpyZXR1cm5fYWNjb3VudHM6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weTo0NQogICAgLy8gcmV0dXJuIHNlbGYuYWNjb3VudHMKICAgIGludGNfMSAvLyAwCiAgICBieXRlYyA0IC8vICJhY2NvdW50cyIKICAgIGFwcF9nbG9iYWxfZ2V0X2V4CiAgICBhc3NlcnQgLy8gY2hlY2sgc2VsZi5hY2NvdW50cyBleGlzdHMKICAgIHJldHN1Ygo=",
+        "clear": "I3ByYWdtYSB2ZXJzaW9uIDEwCiNwcmFnbWEgdHlwZXRyYWNrIGZhbHNlCgovLyBhbGdvcHkuYXJjNC5BUkM0Q29udHJhY3QuY2xlYXJfc3RhdGVfcHJvZ3JhbSgpIC0+IHVpbnQ2NDoKbWFpbjoKICAgIHB1c2hpbnQgMSAvLyAxCiAgICByZXR1cm4K"
+    },
+    "state": {
+        "global": {
+            "num_byte_slices": 4,
+            "num_uints": 2
+        },
+        "local": {
+            "num_byte_slices": 0,
+            "num_uints": 0
+        }
+    },
+    "schema": {
+        "global": {
+            "declared": {
+                "acc": {
+                    "type": "bytes",
+                    "key": "acc"
+                },
+                "accounts": {
+                    "type": "bytes",
+                    "key": "accounts"
+                },
+                "app": {
+                    "type": "uint64",
+                    "key": "app"
+                },
+                "apps": {
+                    "type": "bytes",
+                    "key": "apps"
+                },
+                "asset": {
+                    "type": "uint64",
+                    "key": "asset"
+                },
+                "assets": {
+                    "type": "bytes",
+                    "key": "assets"
+                }
+            },
+            "reserved": {}
+        },
+        "local": {
+            "declared": {},
+            "reserved": {}
+        }
+    },
+    "contract": {
+        "name": "ReferenceReturn",
+        "methods": [
+            {
+                "name": "acc_ret",
+                "args": [],
+                "readonly": false,
+                "returns": {
+                    "type": "address"
+                }
+            },
+            {
+                "name": "asset_ret",
+                "args": [],
+                "readonly": false,
+                "returns": {
+                    "type": "uint64"
+                }
+            },
+            {
+                "name": "app_ret",
+                "args": [],
+                "readonly": false,
+                "returns": {
+                    "type": "uint64"
+                }
+            },
+            {
+                "name": "store",
+                "args": [
+                    {
+                        "type": "account",
+                        "name": "acc"
+                    },
+                    {
+                        "type": "application",
+                        "name": "app"
+                    },
+                    {
+                        "type": "asset",
+                        "name": "asset"
+                    }
+                ],
+                "readonly": false,
+                "returns": {
+                    "type": "void"
+                }
+            },
+            {
+                "name": "store_apps",
+                "args": [
+                    {
+                        "type": "uint64[]",
+                        "name": "apps"
+                    }
+                ],
+                "readonly": false,
+                "returns": {
+                    "type": "void"
+                }
+            },
+            {
+                "name": "store_assets",
+                "args": [
+                    {
+                        "type": "uint64[]",
+                        "name": "assets"
+                    }
+                ],
+                "readonly": false,
+                "returns": {
+                    "type": "void"
+                }
+            },
+            {
+                "name": "store_accounts",
+                "args": [
+                    {
+                        "type": "address[]",
+                        "name": "accounts"
+                    }
+                ],
+                "readonly": false,
+                "returns": {
+                    "type": "void"
+                }
+            },
+            {
+                "name": "return_apps",
+                "args": [],
+                "readonly": false,
+                "returns": {
+                    "type": "uint64[]"
+                }
+            },
+            {
+                "name": "return_assets",
+                "args": [],
+                "readonly": false,
+                "returns": {
+                    "type": "uint64[]"
+                }
+            },
+            {
+                "name": "return_accounts",
+                "args": [],
+                "readonly": false,
+                "returns": {
+                    "type": "address[]"
+                }
+            }
+        ],
+        "networks": {}
+    },
+    "bare_call_config": {
+        "no_op": "CREATE"
+    }
+}

--- a/test_cases/arc4_conversions/out/ReferenceReturn.arc56.json
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.arc56.json
@@ -1,0 +1,341 @@
+{
+    "name": "ReferenceReturn",
+    "structs": {},
+    "methods": [
+        {
+            "name": "acc_ret",
+            "args": [],
+            "returns": {
+                "type": "address"
+            },
+            "actions": {
+                "create": [],
+                "call": [
+                    "NoOp"
+                ]
+            },
+            "readonly": false,
+            "events": [],
+            "recommendations": {}
+        },
+        {
+            "name": "asset_ret",
+            "args": [],
+            "returns": {
+                "type": "uint64"
+            },
+            "actions": {
+                "create": [],
+                "call": [
+                    "NoOp"
+                ]
+            },
+            "readonly": false,
+            "events": [],
+            "recommendations": {}
+        },
+        {
+            "name": "app_ret",
+            "args": [],
+            "returns": {
+                "type": "uint64"
+            },
+            "actions": {
+                "create": [],
+                "call": [
+                    "NoOp"
+                ]
+            },
+            "readonly": false,
+            "events": [],
+            "recommendations": {}
+        },
+        {
+            "name": "store",
+            "args": [
+                {
+                    "type": "account",
+                    "name": "acc"
+                },
+                {
+                    "type": "application",
+                    "name": "app"
+                },
+                {
+                    "type": "asset",
+                    "name": "asset"
+                }
+            ],
+            "returns": {
+                "type": "void"
+            },
+            "actions": {
+                "create": [],
+                "call": [
+                    "NoOp"
+                ]
+            },
+            "readonly": false,
+            "events": [],
+            "recommendations": {}
+        },
+        {
+            "name": "store_apps",
+            "args": [
+                {
+                    "type": "uint64[]",
+                    "name": "apps"
+                }
+            ],
+            "returns": {
+                "type": "void"
+            },
+            "actions": {
+                "create": [],
+                "call": [
+                    "NoOp"
+                ]
+            },
+            "readonly": false,
+            "events": [],
+            "recommendations": {}
+        },
+        {
+            "name": "store_assets",
+            "args": [
+                {
+                    "type": "uint64[]",
+                    "name": "assets"
+                }
+            ],
+            "returns": {
+                "type": "void"
+            },
+            "actions": {
+                "create": [],
+                "call": [
+                    "NoOp"
+                ]
+            },
+            "readonly": false,
+            "events": [],
+            "recommendations": {}
+        },
+        {
+            "name": "store_accounts",
+            "args": [
+                {
+                    "type": "address[]",
+                    "name": "accounts"
+                }
+            ],
+            "returns": {
+                "type": "void"
+            },
+            "actions": {
+                "create": [],
+                "call": [
+                    "NoOp"
+                ]
+            },
+            "readonly": false,
+            "events": [],
+            "recommendations": {}
+        },
+        {
+            "name": "return_apps",
+            "args": [],
+            "returns": {
+                "type": "uint64[]"
+            },
+            "actions": {
+                "create": [],
+                "call": [
+                    "NoOp"
+                ]
+            },
+            "readonly": false,
+            "events": [],
+            "recommendations": {}
+        },
+        {
+            "name": "return_assets",
+            "args": [],
+            "returns": {
+                "type": "uint64[]"
+            },
+            "actions": {
+                "create": [],
+                "call": [
+                    "NoOp"
+                ]
+            },
+            "readonly": false,
+            "events": [],
+            "recommendations": {}
+        },
+        {
+            "name": "return_accounts",
+            "args": [],
+            "returns": {
+                "type": "address[]"
+            },
+            "actions": {
+                "create": [],
+                "call": [
+                    "NoOp"
+                ]
+            },
+            "readonly": false,
+            "events": [],
+            "recommendations": {}
+        }
+    ],
+    "arcs": [
+        22,
+        28
+    ],
+    "networks": {},
+    "state": {
+        "schema": {
+            "global": {
+                "ints": 2,
+                "bytes": 4
+            },
+            "local": {
+                "ints": 0,
+                "bytes": 0
+            }
+        },
+        "keys": {
+            "global": {
+                "acc": {
+                    "keyType": "AVMString",
+                    "valueType": "address",
+                    "key": "YWNj"
+                },
+                "asset": {
+                    "keyType": "AVMString",
+                    "valueType": "AVMUint64",
+                    "key": "YXNzZXQ="
+                },
+                "app": {
+                    "keyType": "AVMString",
+                    "valueType": "AVMUint64",
+                    "key": "YXBw"
+                },
+                "apps": {
+                    "keyType": "AVMString",
+                    "valueType": "uint64[]",
+                    "key": "YXBwcw=="
+                },
+                "assets": {
+                    "keyType": "AVMString",
+                    "valueType": "uint64[]",
+                    "key": "YXNzZXRz"
+                },
+                "accounts": {
+                    "keyType": "AVMString",
+                    "valueType": "address[]",
+                    "key": "YWNjb3VudHM="
+                }
+            },
+            "local": {},
+            "box": {}
+        },
+        "maps": {
+            "global": {},
+            "local": {},
+            "box": {}
+        }
+    },
+    "bareActions": {
+        "create": [
+            "NoOp"
+        ],
+        "call": []
+    },
+    "sourceInfo": {
+        "approval": {
+            "sourceInfo": [
+                {
+                    "pc": [
+                        133,
+                        149,
+                        165,
+                        181,
+                        196,
+                        211,
+                        226,
+                        256,
+                        267,
+                        278
+                    ],
+                    "errorMessage": "OnCompletion is not NoOp"
+                },
+                {
+                    "pc": [
+                        299
+                    ],
+                    "errorMessage": "can only call when creating"
+                },
+                {
+                    "pc": [
+                        136,
+                        152,
+                        168,
+                        184,
+                        199,
+                        214,
+                        229,
+                        259,
+                        270,
+                        281
+                    ],
+                    "errorMessage": "can only call when not creating"
+                },
+                {
+                    "pc": [
+                        374
+                    ],
+                    "errorMessage": "check self.accounts exists"
+                },
+                {
+                    "pc": [
+                        363
+                    ],
+                    "errorMessage": "check self.apps exists"
+                },
+                {
+                    "pc": [
+                        368
+                    ],
+                    "errorMessage": "check self.assets exists"
+                }
+            ],
+            "pcOffsetMethod": "none"
+        },
+        "clear": {
+            "sourceInfo": [],
+            "pcOffsetMethod": "none"
+        }
+    },
+    "source": {
+        "approval": "I3ByYWdtYSB2ZXJzaW9uIDEwCiNwcmFnbWEgdHlwZXRyYWNrIGZhbHNlCgovLyBhbGdvcHkuYXJjNC5BUkM0Q29udHJhY3QuYXBwcm92YWxfcHJvZ3JhbSgpIC0+IHVpbnQ2NDoKbWFpbjoKICAgIGludGNibG9jayAxIDAKICAgIGJ5dGVjYmxvY2sgMHgxNTFmN2M3NSAweDE1MWY3Yzc1MDAwMDAwMDAwMDAwMDRkMiAiYXBwcyIgImFzc2V0cyIgImFjY291bnRzIgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6NAogICAgLy8gY2xhc3MgUmVmZXJlbmNlUmV0dXJuKGFyYzQuQVJDNENvbnRyYWN0KToKICAgIHR4biBOdW1BcHBBcmdzCiAgICBieiBtYWluX2JhcmVfcm91dGluZ0AxNQogICAgcHVzaGJ5dGVzcyAweDZjN2ExY2I1IDB4Yzg0ODBmMGMgMHgzN2MwY2JmMiAweDg2NDA4NmE3IDB4NjcyOGIxYTEgMHhjZTdlNmNkMyAweDBhMzdmNmUxIDB4NGM4OTRkN2UgMHg2MmViY2Y4OSAweDkyNGU3NzhjIC8vIG1ldGhvZCAiYWNjX3JldCgpYWRkcmVzcyIsIG1ldGhvZCAiYXNzZXRfcmV0KCl1aW50NjQiLCBtZXRob2QgImFwcF9yZXQoKXVpbnQ2NCIsIG1ldGhvZCAic3RvcmUoYWNjb3VudCxhcHBsaWNhdGlvbixhc3NldCl2b2lkIiwgbWV0aG9kICJzdG9yZV9hcHBzKHVpbnQ2NFtdKXZvaWQiLCBtZXRob2QgInN0b3JlX2Fzc2V0cyh1aW50NjRbXSl2b2lkIiwgbWV0aG9kICJzdG9yZV9hY2NvdW50cyhhZGRyZXNzW10pdm9pZCIsIG1ldGhvZCAicmV0dXJuX2FwcHMoKXVpbnQ2NFtdIiwgbWV0aG9kICJyZXR1cm5fYXNzZXRzKCl1aW50NjRbXSIsIG1ldGhvZCAicmV0dXJuX2FjY291bnRzKClhZGRyZXNzW10iCiAgICB0eG5hIEFwcGxpY2F0aW9uQXJncyAwCiAgICBtYXRjaCBtYWluX2FjY19yZXRfcm91dGVAMyBtYWluX2Fzc2V0X3JldF9yb3V0ZUA0IG1haW5fYXBwX3JldF9yb3V0ZUA1IG1haW5fc3RvcmVfcm91dGVANiBtYWluX3N0b3JlX2FwcHNfcm91dGVANyBtYWluX3N0b3JlX2Fzc2V0c19yb3V0ZUA4IG1haW5fc3RvcmVfYWNjb3VudHNfcm91dGVAOSBtYWluX3JldHVybl9hcHBzX3JvdXRlQDEwIG1haW5fcmV0dXJuX2Fzc2V0c19yb3V0ZUAxMSBtYWluX3JldHVybl9hY2NvdW50c19yb3V0ZUAxMgoKbWFpbl9hZnRlcl9pZl9lbHNlQDE5OgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6NAogICAgLy8gY2xhc3MgUmVmZXJlbmNlUmV0dXJuKGFyYzQuQVJDNENvbnRyYWN0KToKICAgIGludGNfMSAvLyAwCiAgICByZXR1cm4KCm1haW5fcmV0dXJuX2FjY291bnRzX3JvdXRlQDEyOgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6NDMKICAgIC8vIEBhcmM0LmFiaW1ldGhvZAogICAgdHhuIE9uQ29tcGxldGlvbgogICAgIQogICAgYXNzZXJ0IC8vIE9uQ29tcGxldGlvbiBpcyBub3QgTm9PcAogICAgdHhuIEFwcGxpY2F0aW9uSUQKICAgIGFzc2VydCAvLyBjYW4gb25seSBjYWxsIHdoZW4gbm90IGNyZWF0aW5nCiAgICBjYWxsc3ViIHJldHVybl9hY2NvdW50cwogICAgYnl0ZWNfMCAvLyAweDE1MWY3Yzc1CiAgICBzd2FwCiAgICBjb25jYXQKICAgIGxvZwogICAgaW50Y18wIC8vIDEKICAgIHJldHVybgoKbWFpbl9yZXR1cm5fYXNzZXRzX3JvdXRlQDExOgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6MzkKICAgIC8vIEBhcmM0LmFiaW1ldGhvZAogICAgdHhuIE9uQ29tcGxldGlvbgogICAgIQogICAgYXNzZXJ0IC8vIE9uQ29tcGxldGlvbiBpcyBub3QgTm9PcAogICAgdHhuIEFwcGxpY2F0aW9uSUQKICAgIGFzc2VydCAvLyBjYW4gb25seSBjYWxsIHdoZW4gbm90IGNyZWF0aW5nCiAgICBjYWxsc3ViIHJldHVybl9hc3NldHMKICAgIGJ5dGVjXzAgLy8gMHgxNTFmN2M3NQogICAgc3dhcAogICAgY29uY2F0CiAgICBsb2cKICAgIGludGNfMCAvLyAxCiAgICByZXR1cm4KCm1haW5fcmV0dXJuX2FwcHNfcm91dGVAMTA6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weTozNQogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICB0eG4gT25Db21wbGV0aW9uCiAgICAhCiAgICBhc3NlcnQgLy8gT25Db21wbGV0aW9uIGlzIG5vdCBOb09wCiAgICB0eG4gQXBwbGljYXRpb25JRAogICAgYXNzZXJ0IC8vIGNhbiBvbmx5IGNhbGwgd2hlbiBub3QgY3JlYXRpbmcKICAgIGNhbGxzdWIgcmV0dXJuX2FwcHMKICAgIGJ5dGVjXzAgLy8gMHgxNTFmN2M3NQogICAgc3dhcAogICAgY29uY2F0CiAgICBsb2cKICAgIGludGNfMCAvLyAxCiAgICByZXR1cm4KCm1haW5fc3RvcmVfYWNjb3VudHNfcm91dGVAOToKICAgIC8vIGFyYzRfY29udmVyc2lvbnMvcmVmZXJlbmNlLnB5OjMxCiAgICAvLyBAYXJjNC5hYmltZXRob2QKICAgIHR4biBPbkNvbXBsZXRpb24KICAgICEKICAgIGFzc2VydCAvLyBPbkNvbXBsZXRpb24gaXMgbm90IE5vT3AKICAgIHR4biBBcHBsaWNhdGlvbklECiAgICBhc3NlcnQgLy8gY2FuIG9ubHkgY2FsbCB3aGVuIG5vdCBjcmVhdGluZwogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6NAogICAgLy8gY2xhc3MgUmVmZXJlbmNlUmV0dXJuKGFyYzQuQVJDNENvbnRyYWN0KToKICAgIHR4bmEgQXBwbGljYXRpb25BcmdzIDEKICAgIC8vIGFyYzRfY29udmVyc2lvbnMvcmVmZXJlbmNlLnB5OjMxCiAgICAvLyBAYXJjNC5hYmltZXRob2QKICAgIGNhbGxzdWIgc3RvcmVfYWNjb3VudHMKICAgIGludGNfMCAvLyAxCiAgICByZXR1cm4KCm1haW5fc3RvcmVfYXNzZXRzX3JvdXRlQDg6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToyNwogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICB0eG4gT25Db21wbGV0aW9uCiAgICAhCiAgICBhc3NlcnQgLy8gT25Db21wbGV0aW9uIGlzIG5vdCBOb09wCiAgICB0eG4gQXBwbGljYXRpb25JRAogICAgYXNzZXJ0IC8vIGNhbiBvbmx5IGNhbGwgd2hlbiBub3QgY3JlYXRpbmcKICAgIC8vIGFyYzRfY29udmVyc2lvbnMvcmVmZXJlbmNlLnB5OjQKICAgIC8vIGNsYXNzIFJlZmVyZW5jZVJldHVybihhcmM0LkFSQzRDb250cmFjdCk6CiAgICB0eG5hIEFwcGxpY2F0aW9uQXJncyAxCiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToyNwogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICBjYWxsc3ViIHN0b3JlX2Fzc2V0cwogICAgaW50Y18wIC8vIDEKICAgIHJldHVybgoKbWFpbl9zdG9yZV9hcHBzX3JvdXRlQDc6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToyMwogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICB0eG4gT25Db21wbGV0aW9uCiAgICAhCiAgICBhc3NlcnQgLy8gT25Db21wbGV0aW9uIGlzIG5vdCBOb09wCiAgICB0eG4gQXBwbGljYXRpb25JRAogICAgYXNzZXJ0IC8vIGNhbiBvbmx5IGNhbGwgd2hlbiBub3QgY3JlYXRpbmcKICAgIC8vIGFyYzRfY29udmVyc2lvbnMvcmVmZXJlbmNlLnB5OjQKICAgIC8vIGNsYXNzIFJlZmVyZW5jZVJldHVybihhcmM0LkFSQzRDb250cmFjdCk6CiAgICB0eG5hIEFwcGxpY2F0aW9uQXJncyAxCiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToyMwogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICBjYWxsc3ViIHN0b3JlX2FwcHMKICAgIGludGNfMCAvLyAxCiAgICByZXR1cm4KCm1haW5fc3RvcmVfcm91dGVANjoKICAgIC8vIGFyYzRfY29udmVyc2lvbnMvcmVmZXJlbmNlLnB5OjE3CiAgICAvLyBAYXJjNC5hYmltZXRob2QKICAgIHR4biBPbkNvbXBsZXRpb24KICAgICEKICAgIGFzc2VydCAvLyBPbkNvbXBsZXRpb24gaXMgbm90IE5vT3AKICAgIHR4biBBcHBsaWNhdGlvbklECiAgICBhc3NlcnQgLy8gY2FuIG9ubHkgY2FsbCB3aGVuIG5vdCBjcmVhdGluZwogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6NAogICAgLy8gY2xhc3MgUmVmZXJlbmNlUmV0dXJuKGFyYzQuQVJDNENvbnRyYWN0KToKICAgIHR4bmEgQXBwbGljYXRpb25BcmdzIDEKICAgIGJ0b2kKICAgIHR4bmFzIEFjY291bnRzCiAgICB0eG5hIEFwcGxpY2F0aW9uQXJncyAyCiAgICBidG9pCiAgICB0eG5hcyBBcHBsaWNhdGlvbnMKICAgIHR4bmEgQXBwbGljYXRpb25BcmdzIDMKICAgIGJ0b2kKICAgIHR4bmFzIEFzc2V0cwogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6MTcKICAgIC8vIEBhcmM0LmFiaW1ldGhvZAogICAgY2FsbHN1YiBzdG9yZQogICAgaW50Y18wIC8vIDEKICAgIHJldHVybgoKbWFpbl9hcHBfcmV0X3JvdXRlQDU6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToxMwogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICB0eG4gT25Db21wbGV0aW9uCiAgICAhCiAgICBhc3NlcnQgLy8gT25Db21wbGV0aW9uIGlzIG5vdCBOb09wCiAgICB0eG4gQXBwbGljYXRpb25JRAogICAgYXNzZXJ0IC8vIGNhbiBvbmx5IGNhbGwgd2hlbiBub3QgY3JlYXRpbmcKICAgIGJ5dGVjXzEgLy8gMHgxNTFmN2M3NTAwMDAwMDAwMDAwMDA0ZDIKICAgIGxvZwogICAgaW50Y18wIC8vIDEKICAgIHJldHVybgoKbWFpbl9hc3NldF9yZXRfcm91dGVANDoKICAgIC8vIGFyYzRfY29udmVyc2lvbnMvcmVmZXJlbmNlLnB5OjkKICAgIC8vIEBhcmM0LmFiaW1ldGhvZAogICAgdHhuIE9uQ29tcGxldGlvbgogICAgIQogICAgYXNzZXJ0IC8vIE9uQ29tcGxldGlvbiBpcyBub3QgTm9PcAogICAgdHhuIEFwcGxpY2F0aW9uSUQKICAgIGFzc2VydCAvLyBjYW4gb25seSBjYWxsIHdoZW4gbm90IGNyZWF0aW5nCiAgICBieXRlY18xIC8vIDB4MTUxZjdjNzUwMDAwMDAwMDAwMDAwNGQyCiAgICBsb2cKICAgIGludGNfMCAvLyAxCiAgICByZXR1cm4KCm1haW5fYWNjX3JldF9yb3V0ZUAzOgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6NQogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICB0eG4gT25Db21wbGV0aW9uCiAgICAhCiAgICBhc3NlcnQgLy8gT25Db21wbGV0aW9uIGlzIG5vdCBOb09wCiAgICB0eG4gQXBwbGljYXRpb25JRAogICAgYXNzZXJ0IC8vIGNhbiBvbmx5IGNhbGwgd2hlbiBub3QgY3JlYXRpbmcKICAgIGNhbGxzdWIgYWNjX3JldAogICAgYnl0ZWNfMCAvLyAweDE1MWY3Yzc1CiAgICBzd2FwCiAgICBjb25jYXQKICAgIGxvZwogICAgaW50Y18wIC8vIDEKICAgIHJldHVybgoKbWFpbl9iYXJlX3JvdXRpbmdAMTU6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weTo0CiAgICAvLyBjbGFzcyBSZWZlcmVuY2VSZXR1cm4oYXJjNC5BUkM0Q29udHJhY3QpOgogICAgdHhuIE9uQ29tcGxldGlvbgogICAgYm56IG1haW5fYWZ0ZXJfaWZfZWxzZUAxOQogICAgdHhuIEFwcGxpY2F0aW9uSUQKICAgICEKICAgIGFzc2VydCAvLyBjYW4gb25seSBjYWxsIHdoZW4gY3JlYXRpbmcKICAgIGludGNfMCAvLyAxCiAgICByZXR1cm4KCgovLyB0ZXN0X2Nhc2VzLmFyYzRfY29udmVyc2lvbnMucmVmZXJlbmNlLlJlZmVyZW5jZVJldHVybi5hY2NfcmV0KCkgLT4gYnl0ZXM6CmFjY19yZXQ6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weTo3CiAgICAvLyByZXR1cm4gVHhuLnNlbmRlcgogICAgdHhuIFNlbmRlcgogICAgcmV0c3ViCgoKLy8gdGVzdF9jYXNlcy5hcmM0X2NvbnZlcnNpb25zLnJlZmVyZW5jZS5SZWZlcmVuY2VSZXR1cm4uc3RvcmUoYWNjOiBieXRlcywgYXBwOiB1aW50NjQsIGFzc2V0OiB1aW50NjQpIC0+IHZvaWQ6CnN0b3JlOgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6MTctMTgKICAgIC8vIEBhcmM0LmFiaW1ldGhvZAogICAgLy8gZGVmIHN0b3JlKHNlbGYsIGFjYzogQWNjb3VudCwgYXBwOiBBcHBsaWNhdGlvbiwgYXNzZXQ6IEFzc2V0KSAtPiBOb25lOgogICAgcHJvdG8gMyAwCiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToxOQogICAgLy8gc2VsZi5hY2MgPSBhY2MKICAgIHB1c2hieXRlcyAiYWNjIgogICAgZnJhbWVfZGlnIC0zCiAgICBhcHBfZ2xvYmFsX3B1dAogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6MjAKICAgIC8vIHNlbGYuYXNzZXQgPSBhc3NldAogICAgcHVzaGJ5dGVzICJhc3NldCIKICAgIGZyYW1lX2RpZyAtMQogICAgYXBwX2dsb2JhbF9wdXQKICAgIC8vIGFyYzRfY29udmVyc2lvbnMvcmVmZXJlbmNlLnB5OjIxCiAgICAvLyBzZWxmLmFwcCA9IGFwcAogICAgcHVzaGJ5dGVzICJhcHAiCiAgICBmcmFtZV9kaWcgLTIKICAgIGFwcF9nbG9iYWxfcHV0CiAgICByZXRzdWIKCgovLyB0ZXN0X2Nhc2VzLmFyYzRfY29udmVyc2lvbnMucmVmZXJlbmNlLlJlZmVyZW5jZVJldHVybi5zdG9yZV9hcHBzKGFwcHM6IGJ5dGVzKSAtPiB2b2lkOgpzdG9yZV9hcHBzOgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6MjMtMjQKICAgIC8vIEBhcmM0LmFiaW1ldGhvZAogICAgLy8gZGVmIHN0b3JlX2FwcHMoc2VsZiwgYXBwczogSW1tdXRhYmxlQXJyYXlbQXBwbGljYXRpb25dKSAtPiBOb25lOgogICAgcHJvdG8gMSAwCiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToyNQogICAgLy8gc2VsZi5hcHBzID0gYXBwcwogICAgYnl0ZWNfMiAvLyAiYXBwcyIKICAgIGZyYW1lX2RpZyAtMQogICAgYXBwX2dsb2JhbF9wdXQKICAgIHJldHN1YgoKCi8vIHRlc3RfY2FzZXMuYXJjNF9jb252ZXJzaW9ucy5yZWZlcmVuY2UuUmVmZXJlbmNlUmV0dXJuLnN0b3JlX2Fzc2V0cyhhc3NldHM6IGJ5dGVzKSAtPiB2b2lkOgpzdG9yZV9hc3NldHM6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToyNy0yOAogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICAvLyBkZWYgc3RvcmVfYXNzZXRzKHNlbGYsIGFzc2V0czogSW1tdXRhYmxlQXJyYXlbQXNzZXRdKSAtPiBOb25lOgogICAgcHJvdG8gMSAwCiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weToyOQogICAgLy8gc2VsZi5hc3NldHMgPSBhc3NldHMKICAgIGJ5dGVjXzMgLy8gImFzc2V0cyIKICAgIGZyYW1lX2RpZyAtMQogICAgYXBwX2dsb2JhbF9wdXQKICAgIHJldHN1YgoKCi8vIHRlc3RfY2FzZXMuYXJjNF9jb252ZXJzaW9ucy5yZWZlcmVuY2UuUmVmZXJlbmNlUmV0dXJuLnN0b3JlX2FjY291bnRzKGFjY291bnRzOiBieXRlcykgLT4gdm9pZDoKc3RvcmVfYWNjb3VudHM6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weTozMS0zMgogICAgLy8gQGFyYzQuYWJpbWV0aG9kCiAgICAvLyBkZWYgc3RvcmVfYWNjb3VudHMoc2VsZiwgYWNjb3VudHM6IEltbXV0YWJsZUFycmF5W0FjY291bnRdKSAtPiBOb25lOgogICAgcHJvdG8gMSAwCiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weTozMwogICAgLy8gc2VsZi5hY2NvdW50cyA9IGFjY291bnRzCiAgICBieXRlYyA0IC8vICJhY2NvdW50cyIKICAgIGZyYW1lX2RpZyAtMQogICAgYXBwX2dsb2JhbF9wdXQKICAgIHJldHN1YgoKCi8vIHRlc3RfY2FzZXMuYXJjNF9jb252ZXJzaW9ucy5yZWZlcmVuY2UuUmVmZXJlbmNlUmV0dXJuLnJldHVybl9hcHBzKCkgLT4gYnl0ZXM6CnJldHVybl9hcHBzOgogICAgLy8gYXJjNF9jb252ZXJzaW9ucy9yZWZlcmVuY2UucHk6MzcKICAgIC8vIHJldHVybiBzZWxmLmFwcHMKICAgIGludGNfMSAvLyAwCiAgICBieXRlY18yIC8vICJhcHBzIgogICAgYXBwX2dsb2JhbF9nZXRfZXgKICAgIGFzc2VydCAvLyBjaGVjayBzZWxmLmFwcHMgZXhpc3RzCiAgICByZXRzdWIKCgovLyB0ZXN0X2Nhc2VzLmFyYzRfY29udmVyc2lvbnMucmVmZXJlbmNlLlJlZmVyZW5jZVJldHVybi5yZXR1cm5fYXNzZXRzKCkgLT4gYnl0ZXM6CnJldHVybl9hc3NldHM6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weTo0MQogICAgLy8gcmV0dXJuIHNlbGYuYXNzZXRzCiAgICBpbnRjXzEgLy8gMAogICAgYnl0ZWNfMyAvLyAiYXNzZXRzIgogICAgYXBwX2dsb2JhbF9nZXRfZXgKICAgIGFzc2VydCAvLyBjaGVjayBzZWxmLmFzc2V0cyBleGlzdHMKICAgIHJldHN1YgoKCi8vIHRlc3RfY2FzZXMuYXJjNF9jb252ZXJzaW9ucy5yZWZlcmVuY2UuUmVmZXJlbmNlUmV0dXJuLnJldHVybl9hY2NvdW50cygpIC0+IGJ5dGVzOgpyZXR1cm5fYWNjb3VudHM6CiAgICAvLyBhcmM0X2NvbnZlcnNpb25zL3JlZmVyZW5jZS5weTo0NQogICAgLy8gcmV0dXJuIHNlbGYuYWNjb3VudHMKICAgIGludGNfMSAvLyAwCiAgICBieXRlYyA0IC8vICJhY2NvdW50cyIKICAgIGFwcF9nbG9iYWxfZ2V0X2V4CiAgICBhc3NlcnQgLy8gY2hlY2sgc2VsZi5hY2NvdW50cyBleGlzdHMKICAgIHJldHN1Ygo=",
+        "clear": "I3ByYWdtYSB2ZXJzaW9uIDEwCiNwcmFnbWEgdHlwZXRyYWNrIGZhbHNlCgovLyBhbGdvcHkuYXJjNC5BUkM0Q29udHJhY3QuY2xlYXJfc3RhdGVfcHJvZ3JhbSgpIC0+IHVpbnQ2NDoKbWFpbjoKICAgIHB1c2hpbnQgMSAvLyAxCiAgICByZXR1cm4K"
+    },
+    "byteCode": {
+        "approval": "CiACAQAmBQQVH3x1DBUffHUAAAAAAAAE0gRhcHBzBmFzc2V0cwhhY2NvdW50czEbQQDwggoEbHoctQTISA8MBDfAy/IEhkCGpwRnKLGhBM5+bNMECjf24QRMiU1+BGLrz4kEkk53jDYaAI4KAJMAiAB9AF8AUABBADIAIgASAAIjQzEZFEQxGESIAOYoTFCwIkMxGRREMRhEiADRKExQsCJDMRkURDEYRIgAvChMULAiQzEZFEQxGEQ2GgGIAKAiQzEZFEQxGEQ2GgGIAIkiQzEZFEQxGEQ2GgGIAHIiQzEZFEQxGEQ2GgEXwBw2GgIXwDI2GgMXwDCIADYiQzEZFEQxGEQpsCJDMRkURDEYRCmwIkMxGRREMRhEiAARKExQsCJDMRlA/1gxGBREIkMxAImKAwCAA2FjY4v9Z4AFYXNzZXSL/2eAA2FwcIv+Z4mKAQAqi/9niYoBACuL/2eJigEAJwSL/2eJIyplRIkjK2VEiSMnBGVEiQ==",
+        "clear": "CoEBQw=="
+    },
+    "compilerInfo": {
+        "compiler": "puya",
+        "compilerVersion": {
+            "major": 99,
+            "minor": 99,
+            "patch": 99
+        }
+    },
+    "events": [],
+    "templateVariables": {}
+}

--- a/test_cases/arc4_conversions/out/ReferenceReturn.clear.puya.map
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.clear.puya.map
@@ -1,0 +1,25 @@
+{
+  "version": 3,
+  "sources": [],
+  "mappings": ";;;",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "algopy.arc4.ARC4Contract.clear_state_program",
+      "params": {},
+      "block": "main",
+      "stack_in": [],
+      "op": "pushint 1 // 1",
+      "defined_out": [
+        "1"
+      ],
+      "stack_out": [
+        "1"
+      ]
+    },
+    "3": {
+      "op": "return",
+      "stack_out": []
+    }
+  }
+}

--- a/test_cases/arc4_conversions/out/ReferenceReturn.clear.teal
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.clear.teal
@@ -1,0 +1,7 @@
+#pragma version 10
+#pragma typetrack false
+
+// algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+main:
+    pushint 1 // 1
+    return

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.0.ssa.ir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.0.ssa.ir
@@ -1,0 +1,205 @@
+main algopy.arc4.ARC4Contract.approval_program:
+    block@0: // L1
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__()
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__() -> bool:
+    block@0: // L4
+        let tmp%0#0: uint64 = (txn NumAppArgs)
+        let tmp%1#0: bool = (!= tmp%0#0 0u)
+        goto tmp%1#0 ? block@1 : block@14
+    block@1: // abi_routing_L4
+        let tmp%2#0: bytes = (txna ApplicationArgs 0)
+        switch tmp%2#0 {method "acc_ret()address" => block@2, method "asset_ret()uint64" => block@3, method "app_ret()uint64" => block@4, method "store(account,application,asset)void" => block@5, method "store_apps(uint64[])void" => block@6, method "store_assets(uint64[])void" => block@7, method "store_accounts(address[])void" => block@8, method "return_apps()uint64[]" => block@9, method "return_assets()uint64[]" => block@10, method "return_accounts()address[]" => block@11, * => block@12}
+    block@2: // acc_ret_route_L5
+        let tmp%3#0: uint64 = (txn OnCompletion)
+        let tmp%4#0: bool = (== tmp%3#0 NoOp)
+        (assert tmp%4#0) // OnCompletion is not NoOp
+        let tmp%5#0: uint64 = (txn ApplicationID)
+        let tmp%6#0: bool = (!= tmp%5#0 0u)
+        (assert tmp%6#0) // can only call when not creating
+        let tmp%7#0: bytes[32] = test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret()
+        let tmp%8#0: bytes = (concat 0x151f7c75 tmp%7#0)
+        (log tmp%8#0)
+        return 1u
+    block@3: // asset_ret_route_L9
+        let tmp%9#0: uint64 = (txn OnCompletion)
+        let tmp%10#0: bool = (== tmp%9#0 NoOp)
+        (assert tmp%10#0) // OnCompletion is not NoOp
+        let tmp%11#0: uint64 = (txn ApplicationID)
+        let tmp%12#0: bool = (!= tmp%11#0 0u)
+        (assert tmp%12#0) // can only call when not creating
+        let to_encode%0#0: uint64 = test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret()
+        let val_as_bytes%0#0: bytes[8] = (itob to_encode%0#0)
+        let tmp%13#0: bytes = (concat 0x151f7c75 val_as_bytes%0#0)
+        (log tmp%13#0)
+        return 1u
+    block@4: // app_ret_route_L13
+        let tmp%14#0: uint64 = (txn OnCompletion)
+        let tmp%15#0: bool = (== tmp%14#0 NoOp)
+        (assert tmp%15#0) // OnCompletion is not NoOp
+        let tmp%16#0: uint64 = (txn ApplicationID)
+        let tmp%17#0: bool = (!= tmp%16#0 0u)
+        (assert tmp%17#0) // can only call when not creating
+        let to_encode%1#0: uint64 = test_cases.arc4_conversions.reference.ReferenceReturn.app_ret()
+        let val_as_bytes%1#0: bytes[8] = (itob to_encode%1#0)
+        let tmp%18#0: bytes = (concat 0x151f7c75 val_as_bytes%1#0)
+        (log tmp%18#0)
+        return 1u
+    block@5: // store_route_L17
+        let tmp%19#0: uint64 = (txn OnCompletion)
+        let tmp%20#0: bool = (== tmp%19#0 NoOp)
+        (assert tmp%20#0) // OnCompletion is not NoOp
+        let tmp%21#0: uint64 = (txn ApplicationID)
+        let tmp%22#0: bool = (!= tmp%21#0 0u)
+        (assert tmp%22#0) // can only call when not creating
+        let reinterpret_bytes[1]%0#0: bytes[1] = (txna ApplicationArgs 1)
+        let tmp%23#0: uint64 = (btoi reinterpret_bytes[1]%0#0)
+        let tmp%24#0: bytes[32] = ((txnas Accounts) tmp%23#0)
+        let reinterpret_bytes[1]%1#0: bytes[1] = (txna ApplicationArgs 2)
+        let tmp%25#0: uint64 = (btoi reinterpret_bytes[1]%1#0)
+        let tmp%26#0: uint64 = ((txnas Applications) tmp%25#0)
+        let reinterpret_bytes[1]%2#0: bytes[1] = (txna ApplicationArgs 3)
+        let tmp%27#0: uint64 = (btoi reinterpret_bytes[1]%2#0)
+        let tmp%28#0: uint64 = ((txnas Assets) tmp%27#0)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store(tmp%24#0, tmp%26#0, tmp%28#0)
+        return 1u
+    block@6: // store_apps_route_L23
+        let tmp%29#0: uint64 = (txn OnCompletion)
+        let tmp%30#0: bool = (== tmp%29#0 NoOp)
+        (assert tmp%30#0) // OnCompletion is not NoOp
+        let tmp%31#0: uint64 = (txn ApplicationID)
+        let tmp%32#0: bool = (!= tmp%31#0 0u)
+        (assert tmp%32#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%0#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(reinterpret_encoded_uint64[]%0#0)
+        return 1u
+    block@7: // store_assets_route_L27
+        let tmp%33#0: uint64 = (txn OnCompletion)
+        let tmp%34#0: bool = (== tmp%33#0 NoOp)
+        (assert tmp%34#0) // OnCompletion is not NoOp
+        let tmp%35#0: uint64 = (txn ApplicationID)
+        let tmp%36#0: bool = (!= tmp%35#0 0u)
+        (assert tmp%36#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%1#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(reinterpret_encoded_uint64[]%1#0)
+        return 1u
+    block@8: // store_accounts_route_L31
+        let tmp%37#0: uint64 = (txn OnCompletion)
+        let tmp%38#0: bool = (== tmp%37#0 NoOp)
+        (assert tmp%38#0) // OnCompletion is not NoOp
+        let tmp%39#0: uint64 = (txn ApplicationID)
+        let tmp%40#0: bool = (!= tmp%39#0 0u)
+        (assert tmp%40#0) // can only call when not creating
+        let reinterpret_bytes[32][]%0#0: bytes[32][] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(reinterpret_bytes[32][]%0#0)
+        return 1u
+    block@9: // return_apps_route_L35
+        let tmp%41#0: uint64 = (txn OnCompletion)
+        let tmp%42#0: bool = (== tmp%41#0 NoOp)
+        (assert tmp%42#0) // OnCompletion is not NoOp
+        let tmp%43#0: uint64 = (txn ApplicationID)
+        let tmp%44#0: bool = (!= tmp%43#0 0u)
+        (assert tmp%44#0) // can only call when not creating
+        let tmp%45#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_apps()
+        let tmp%46#0: bytes = (concat 0x151f7c75 tmp%45#0)
+        (log tmp%46#0)
+        return 1u
+    block@10: // return_assets_route_L39
+        let tmp%47#0: uint64 = (txn OnCompletion)
+        let tmp%48#0: bool = (== tmp%47#0 NoOp)
+        (assert tmp%48#0) // OnCompletion is not NoOp
+        let tmp%49#0: uint64 = (txn ApplicationID)
+        let tmp%50#0: bool = (!= tmp%49#0 0u)
+        (assert tmp%50#0) // can only call when not creating
+        let tmp%51#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_assets()
+        let tmp%52#0: bytes = (concat 0x151f7c75 tmp%51#0)
+        (log tmp%52#0)
+        return 1u
+    block@11: // return_accounts_route_L43
+        let tmp%53#0: uint64 = (txn OnCompletion)
+        let tmp%54#0: bool = (== tmp%53#0 NoOp)
+        (assert tmp%54#0) // OnCompletion is not NoOp
+        let tmp%55#0: uint64 = (txn ApplicationID)
+        let tmp%56#0: bool = (!= tmp%55#0 0u)
+        (assert tmp%56#0) // can only call when not creating
+        let tmp%57#0: bytes[32][] = test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts()
+        let tmp%58#0: bytes = (concat 0x151f7c75 tmp%57#0)
+        (log tmp%58#0)
+        return 1u
+    block@12: // switch_case_default_L4
+        goto block@13
+    block@13: // switch_case_next_L4
+        goto block@18
+    block@14: // bare_routing_L4
+        let tmp%59#0: uint64 = (txn OnCompletion)
+        switch tmp%59#0 {0u => block@15, * => block@16}
+    block@15: // __algopy_default_create_L1
+        let tmp%60#0: uint64 = (txn ApplicationID)
+        let tmp%61#0: bool = (== tmp%60#0 0u)
+        (assert tmp%61#0) // can only call when creating
+        test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create()
+        return 1u
+    block@16: // switch_case_default_L4
+        goto block@17
+    block@17: // switch_case_next_L4
+        goto block@18
+    block@18: // after_if_else_L4
+        return 0u
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes[32]:
+    block@0: // L5
+        let tmp%0#0: bytes[32] = (txn Sender)
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret() -> uint64:
+    block@0: // L9
+        return 1234u
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret() -> uint64:
+    block@0: // L13
+        return 1234u
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes[32], app: uint64, asset: uint64) -> void:
+    block@0: // L17
+        (app_global_put "acc" acc#0)
+        (app_global_put "asset" asset#0)
+        (app_global_put "app" app#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: encoded_uint64[]) -> void:
+    block@0: // L23
+        (app_global_put "apps" apps#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: encoded_uint64[]) -> void:
+    block@0: // L27
+        (app_global_put "assets" assets#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes[32][]) -> void:
+    block@0: // L31
+        (app_global_put "accounts" accounts#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> encoded_uint64[]:
+    block@0: // L35
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "apps")
+        (assert maybe_exists%0#0) // check self.apps exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> encoded_uint64[]:
+    block@0: // L39
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "assets")
+        (assert maybe_exists%0#0) // check self.assets exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes[32][]:
+    block@0: // L43
+        let (maybe_value%0#0: bytes[32][], maybe_exists%0#0: bool) = (app_global_get_ex 0u "accounts")
+        (assert maybe_exists%0#0) // check self.accounts exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create() -> void:
+    block@0: // L1
+        return 

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.1.ssa.opt.ir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.1.ssa.opt.ir
@@ -1,0 +1,207 @@
+main algopy.arc4.ARC4Contract.approval_program:
+    block@0: // L1
+        let tmp%0#1: uint64 = (txn NumAppArgs)
+        let tmp%1#0: bool = (!= tmp%0#1 0u)
+        goto tmp%0#1 ? block@2 : block@15
+    block@2: // abi_routing_L4
+        let tmp%2#0: bytes = (txna ApplicationArgs 0)
+        switch tmp%2#0 {method "acc_ret()address" => block@3, method "asset_ret()uint64" => block@4, method "app_ret()uint64" => block@5, method "store(account,application,asset)void" => block@6, method "store_apps(uint64[])void" => block@7, method "store_assets(uint64[])void" => block@8, method "store_accounts(address[])void" => block@9, method "return_apps()uint64[]" => block@10, method "return_assets()uint64[]" => block@11, method "return_accounts()address[]" => block@12, * => block@19}
+    block@3: // acc_ret_route_L5
+        let tmp%3#0: uint64 = (txn OnCompletion)
+        let tmp%4#0: bool = (! tmp%3#0)
+        (assert tmp%4#0) // OnCompletion is not NoOp
+        let tmp%5#0: uint64 = (txn ApplicationID)
+        let tmp%6#0: bool = (!= tmp%5#0 0u)
+        (assert tmp%5#0) // can only call when not creating
+        let tmp%7#0: bytes[32] = test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret()
+        let tmp%8#0: bytes = (concat 0x151f7c75 tmp%7#0)
+        (log tmp%8#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        goto block@20
+    block@4: // asset_ret_route_L9
+        let tmp%9#0: uint64 = (txn OnCompletion)
+        let tmp%10#0: bool = (! tmp%9#0)
+        (assert tmp%10#0) // OnCompletion is not NoOp
+        let tmp%11#0: uint64 = (txn ApplicationID)
+        let tmp%12#0: bool = (!= tmp%11#0 0u)
+        (assert tmp%11#0) // can only call when not creating
+        let to_encode%0#0: uint64 = test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret()
+        let val_as_bytes%0#0: bytes[8] = (itob to_encode%0#0)
+        let tmp%13#0: bytes = (concat 0x151f7c75 val_as_bytes%0#0)
+        (log tmp%13#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#1: bool = 1u
+        goto block@20
+    block@5: // app_ret_route_L13
+        let tmp%14#0: uint64 = (txn OnCompletion)
+        let tmp%15#0: bool = (! tmp%14#0)
+        (assert tmp%15#0) // OnCompletion is not NoOp
+        let tmp%16#0: uint64 = (txn ApplicationID)
+        let tmp%17#0: bool = (!= tmp%16#0 0u)
+        (assert tmp%16#0) // can only call when not creating
+        let to_encode%1#0: uint64 = test_cases.arc4_conversions.reference.ReferenceReturn.app_ret()
+        let val_as_bytes%1#0: bytes[8] = (itob to_encode%1#0)
+        let tmp%18#0: bytes = (concat 0x151f7c75 val_as_bytes%1#0)
+        (log tmp%18#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#2: bool = 1u
+        goto block@20
+    block@6: // store_route_L17
+        let tmp%19#0: uint64 = (txn OnCompletion)
+        let tmp%20#0: bool = (! tmp%19#0)
+        (assert tmp%20#0) // OnCompletion is not NoOp
+        let tmp%21#0: uint64 = (txn ApplicationID)
+        let tmp%22#0: bool = (!= tmp%21#0 0u)
+        (assert tmp%21#0) // can only call when not creating
+        let reinterpret_bytes[1]%0#0: bytes[1] = (txna ApplicationArgs 1)
+        let tmp%23#0: uint64 = (btoi reinterpret_bytes[1]%0#0)
+        let tmp%24#0: bytes[32] = ((txnas Accounts) tmp%23#0)
+        let reinterpret_bytes[1]%1#0: bytes[1] = (txna ApplicationArgs 2)
+        let tmp%25#0: uint64 = (btoi reinterpret_bytes[1]%1#0)
+        let tmp%26#0: uint64 = ((txnas Applications) tmp%25#0)
+        let reinterpret_bytes[1]%2#0: bytes[1] = (txna ApplicationArgs 3)
+        let tmp%27#0: uint64 = (btoi reinterpret_bytes[1]%2#0)
+        let tmp%28#0: uint64 = ((txnas Assets) tmp%27#0)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store(tmp%24#0, tmp%26#0, tmp%28#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#3: bool = 1u
+        goto block@20
+    block@7: // store_apps_route_L23
+        let tmp%29#0: uint64 = (txn OnCompletion)
+        let tmp%30#0: bool = (! tmp%29#0)
+        (assert tmp%30#0) // OnCompletion is not NoOp
+        let tmp%31#0: uint64 = (txn ApplicationID)
+        let tmp%32#0: bool = (!= tmp%31#0 0u)
+        (assert tmp%31#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%0#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(reinterpret_encoded_uint64[]%0#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#4: bool = 1u
+        goto block@20
+    block@8: // store_assets_route_L27
+        let tmp%33#0: uint64 = (txn OnCompletion)
+        let tmp%34#0: bool = (! tmp%33#0)
+        (assert tmp%34#0) // OnCompletion is not NoOp
+        let tmp%35#0: uint64 = (txn ApplicationID)
+        let tmp%36#0: bool = (!= tmp%35#0 0u)
+        (assert tmp%35#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%1#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(reinterpret_encoded_uint64[]%1#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#5: bool = 1u
+        goto block@20
+    block@9: // store_accounts_route_L31
+        let tmp%37#0: uint64 = (txn OnCompletion)
+        let tmp%38#0: bool = (! tmp%37#0)
+        (assert tmp%38#0) // OnCompletion is not NoOp
+        let tmp%39#0: uint64 = (txn ApplicationID)
+        let tmp%40#0: bool = (!= tmp%39#0 0u)
+        (assert tmp%39#0) // can only call when not creating
+        let reinterpret_bytes[32][]%0#0: bytes[32][] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(reinterpret_bytes[32][]%0#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#6: bool = 1u
+        goto block@20
+    block@10: // return_apps_route_L35
+        let tmp%41#0: uint64 = (txn OnCompletion)
+        let tmp%42#0: bool = (! tmp%41#0)
+        (assert tmp%42#0) // OnCompletion is not NoOp
+        let tmp%43#0: uint64 = (txn ApplicationID)
+        let tmp%44#0: bool = (!= tmp%43#0 0u)
+        (assert tmp%43#0) // can only call when not creating
+        let tmp%45#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_apps()
+        let tmp%46#0: bytes = (concat 0x151f7c75 tmp%45#0)
+        (log tmp%46#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#7: bool = 1u
+        goto block@20
+    block@11: // return_assets_route_L39
+        let tmp%47#0: uint64 = (txn OnCompletion)
+        let tmp%48#0: bool = (! tmp%47#0)
+        (assert tmp%48#0) // OnCompletion is not NoOp
+        let tmp%49#0: uint64 = (txn ApplicationID)
+        let tmp%50#0: bool = (!= tmp%49#0 0u)
+        (assert tmp%49#0) // can only call when not creating
+        let tmp%51#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_assets()
+        let tmp%52#0: bytes = (concat 0x151f7c75 tmp%51#0)
+        (log tmp%52#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#8: bool = 1u
+        goto block@20
+    block@12: // return_accounts_route_L43
+        let tmp%53#0: uint64 = (txn OnCompletion)
+        let tmp%54#0: bool = (! tmp%53#0)
+        (assert tmp%54#0) // OnCompletion is not NoOp
+        let tmp%55#0: uint64 = (txn ApplicationID)
+        let tmp%56#0: bool = (!= tmp%55#0 0u)
+        (assert tmp%55#0) // can only call when not creating
+        let tmp%57#0: bytes[32][] = test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts()
+        let tmp%58#0: bytes = (concat 0x151f7c75 tmp%57#0)
+        (log tmp%58#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#9: bool = 1u
+        goto block@20
+    block@15: // bare_routing_L4
+        let tmp%59#0: uint64 = (txn OnCompletion)
+        goto tmp%59#0 ? block@19 : block@16
+    block@16: // __algopy_default_create_L1
+        let tmp%60#0: uint64 = (txn ApplicationID)
+        let tmp%61#0: bool = (! tmp%60#0)
+        (assert tmp%61#0) // can only call when creating
+        test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create()
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#10: bool = 1u
+        goto block@20
+    block@19: // after_if_else_L4
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#11: bool = 0u
+        goto block@20
+    block@20: // after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router___L1
+        let tmp%0#0: bool = φ(test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 <- block@3, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#1 <- block@4, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#2 <- block@5, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#3 <- block@6, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#4 <- block@7, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#5 <- block@8, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#6 <- block@9, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#7 <- block@10, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#8 <- block@11, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#9 <- block@12, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#10 <- block@16, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#11 <- block@19)
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes[32]:
+    block@0: // L5
+        let tmp%0#0: bytes[32] = (txn Sender)
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret() -> uint64:
+    block@0: // L9
+        return 1234u
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret() -> uint64:
+    block@0: // L13
+        return 1234u
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes[32], app: uint64, asset: uint64) -> void:
+    block@0: // L17
+        (app_global_put "acc" acc#0)
+        (app_global_put "asset" asset#0)
+        (app_global_put "app" app#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: encoded_uint64[]) -> void:
+    block@0: // L23
+        (app_global_put "apps" apps#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: encoded_uint64[]) -> void:
+    block@0: // L27
+        (app_global_put "assets" assets#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes[32][]) -> void:
+    block@0: // L31
+        (app_global_put "accounts" accounts#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> encoded_uint64[]:
+    block@0: // L35
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "apps")
+        (assert maybe_exists%0#0) // check self.apps exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> encoded_uint64[]:
+    block@0: // L39
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "assets")
+        (assert maybe_exists%0#0) // check self.assets exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes[32][]:
+    block@0: // L43
+        let (maybe_value%0#0: bytes[32][], maybe_exists%0#0: bool) = (app_global_get_ex 0u "accounts")
+        (assert maybe_exists%0#0) // check self.accounts exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create() -> void:
+    block@0: // L1
+        return 

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.10.xstack.opt.mir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.10.xstack.opt.mir
@@ -1,0 +1,333 @@
+// Op                                                                                                 Stack (out)
+// algopy.arc4.ARC4Contract.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txn NumAppArgs                                                                                tmp%0#1
+        bz main_bare_routing@15 ; b main_abi_routing@2
+
+    main_abi_routing@2:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 0                                                                        tmp%2#0
+        method acc_ret()address                                                                       tmp%2#0,Method(acc_ret()address)
+        method asset_ret()uint64                                                                      tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64)
+        method app_ret()uint64                                                                        tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64)
+        method store(account,application,asset)void                                                   tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void)
+        method store_apps(uint64[])void                                                               tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void)
+        method store_assets(uint64[])void                                                             tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void)
+        method store_accounts(address[])void                                                          tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void)
+        method return_apps()uint64[]                                                                  tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[])
+        method return_assets()uint64[]                                                                tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[])
+        method return_accounts()address[]                                                             tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[]),Method(return_accounts()address[])
+        l-load tmp%2#0 10                                                                             Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[]),Method(return_accounts()address[]),tmp%2#0
+        match main_acc_ret_route@3 main_asset_ret_route@4 main_app_ret_route@5 main_store_route@6 main_store_apps_route@7 main_store_assets_route@8 main_store_accounts_route@9 main_return_apps_route@10 main_return_assets_route@11 main_return_accounts_route@12 ; b main_after_if_else@19 
+
+    main_acc_ret_route@3:
+        // arc4_conversions/reference.py:5
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%3#0
+        !                                                                                             tmp%4#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%5#0
+        assert // can only call when not creating
+        callsub acc_ret                                                                               tmp%7#0
+        byte 0x151f7c75                                                                               tmp%7#0,0x151f7c75
+        l-load tmp%7#0 1                                                                              0x151f7c75,tmp%7#0
+        concat                                                                                        tmp%8#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_asset_ret_route@4:
+        // arc4_conversions/reference.py:9
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%9#0
+        !                                                                                             tmp%10#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%11#0
+        assert // can only call when not creating
+        byte 0x151f7c7500000000000004d2                                                               0x151f7c7500000000000004d2
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_app_ret_route@5:
+        // arc4_conversions/reference.py:13
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%14#0
+        !                                                                                             tmp%15#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%16#0
+        assert // can only call when not creating
+        byte 0x151f7c7500000000000004d2                                                               0x151f7c7500000000000004d2
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_route@6:
+        // arc4_conversions/reference.py:17
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%19#0
+        !                                                                                             tmp%20#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%21#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_bytes[1]%0#0
+        btoi                                                                                          tmp%23#0
+        txnas Accounts                                                                                tmp%24#0
+        txna ApplicationArgs 2                                                                        tmp%24#0,reinterpret_bytes[1]%1#0
+        btoi                                                                                          tmp%24#0,tmp%25#0
+        txnas Applications                                                                            tmp%24#0,tmp%26#0
+        txna ApplicationArgs 3                                                                        tmp%24#0,tmp%26#0,reinterpret_bytes[1]%2#0
+        btoi                                                                                          tmp%24#0,tmp%26#0,tmp%27#0
+        txnas Assets                                                                                  tmp%24#0,tmp%26#0,tmp%28#0
+        // arc4_conversions/reference.py:17
+        // @arc4.abimethod
+        l-load tmp%24#0 2                                                                             tmp%26#0,tmp%28#0,tmp%24#0
+        l-load tmp%26#0 2                                                                             tmp%28#0,tmp%24#0,tmp%26#0
+        l-load tmp%28#0 2                                                                             tmp%24#0,tmp%26#0,tmp%28#0
+        callsub store
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_apps_route@7:
+        // arc4_conversions/reference.py:23
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%29#0
+        !                                                                                             tmp%30#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%31#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_encoded_uint64[]%0#0
+        // arc4_conversions/reference.py:23
+        // @arc4.abimethod
+        callsub store_apps
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_assets_route@8:
+        // arc4_conversions/reference.py:27
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%33#0
+        !                                                                                             tmp%34#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%35#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_encoded_uint64[]%1#0
+        // arc4_conversions/reference.py:27
+        // @arc4.abimethod
+        callsub store_assets
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_accounts_route@9:
+        // arc4_conversions/reference.py:31
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%37#0
+        !                                                                                             tmp%38#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%39#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_bytes[32][]%0#0
+        // arc4_conversions/reference.py:31
+        // @arc4.abimethod
+        callsub store_accounts
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_return_apps_route@10:
+        // arc4_conversions/reference.py:35
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%41#0
+        !                                                                                             tmp%42#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%43#0
+        assert // can only call when not creating
+        callsub return_apps                                                                           tmp%45#0
+        byte 0x151f7c75                                                                               tmp%45#0,0x151f7c75
+        l-load tmp%45#0 1                                                                             0x151f7c75,tmp%45#0
+        concat                                                                                        tmp%46#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_return_assets_route@11:
+        // arc4_conversions/reference.py:39
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%47#0
+        !                                                                                             tmp%48#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%49#0
+        assert // can only call when not creating
+        callsub return_assets                                                                         tmp%51#0
+        byte 0x151f7c75                                                                               tmp%51#0,0x151f7c75
+        l-load tmp%51#0 1                                                                             0x151f7c75,tmp%51#0
+        concat                                                                                        tmp%52#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_return_accounts_route@12:
+        // arc4_conversions/reference.py:43
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%53#0
+        !                                                                                             tmp%54#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%55#0
+        assert // can only call when not creating
+        callsub return_accounts                                                                       tmp%57#0
+        byte 0x151f7c75                                                                               tmp%57#0,0x151f7c75
+        l-load tmp%57#0 1                                                                             0x151f7c75,tmp%57#0
+        concat                                                                                        tmp%58#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_bare_routing@15:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txn OnCompletion                                                                              tmp%59#0
+        bz main___algopy_default_create@16 ; b main_after_if_else@19
+
+    main___algopy_default_create@16:
+        txn ApplicationID                                                                             tmp%60#0
+        !                                                                                             tmp%61#0
+        assert // can only call when creating
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_after_if_else@19:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        int 0                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: (𝕏) tmp%0#0 |
+        x-load tmp%0#0                                                                                tmp%0#0
+        return
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes:
+subroutine acc_ret:
+    acc_ret_block@0:
+        // arc4_conversions/reference.py:7
+        // return Txn.sender
+        txn Sender                                                                                    tmp%0#0
+        retsub                                                                                        tmp%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes, app: uint64, asset: uint64) -> void:
+subroutine store:
+    store_block@0:                                                                                    (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:19
+        // self.acc = acc
+        byte "acc"                                                                                    (𝕡) acc#0,app#0,asset#0 | "acc"
+        p-load acc#0                                                                                  (𝕡) acc#0,app#0,asset#0 | "acc",acc#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:20
+        // self.asset = asset
+        byte "asset"                                                                                  (𝕡) acc#0,app#0,asset#0 | "asset"
+        p-load asset#0                                                                                (𝕡) acc#0,app#0,asset#0 | "asset",asset#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:21
+        // self.app = app
+        byte "app"                                                                                    (𝕡) acc#0,app#0,asset#0 | "app"
+        p-load app#0                                                                                  (𝕡) acc#0,app#0,asset#0 | "app",app#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: bytes) -> void:
+subroutine store_apps:
+    store_apps_block@0:                                                                               (𝕡) apps#0 |
+        // arc4_conversions/reference.py:25
+        // self.apps = apps
+        byte "apps"                                                                                   (𝕡) apps#0 | "apps"
+        p-load apps#0                                                                                 (𝕡) apps#0 | "apps",apps#0 (copy)
+        app_global_put                                                                                (𝕡) apps#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: bytes) -> void:
+subroutine store_assets:
+    store_assets_block@0:                                                                             (𝕡) assets#0 |
+        // arc4_conversions/reference.py:29
+        // self.assets = assets
+        byte "assets"                                                                                 (𝕡) assets#0 | "assets"
+        p-load assets#0                                                                               (𝕡) assets#0 | "assets",assets#0 (copy)
+        app_global_put                                                                                (𝕡) assets#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes) -> void:
+subroutine store_accounts:
+    store_accounts_block@0:                                                                           (𝕡) accounts#0 |
+        // arc4_conversions/reference.py:33
+        // self.accounts = accounts
+        byte "accounts"                                                                               (𝕡) accounts#0 | "accounts"
+        p-load accounts#0                                                                             (𝕡) accounts#0 | "accounts",accounts#0 (copy)
+        app_global_put                                                                                (𝕡) accounts#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> bytes:
+subroutine return_apps:
+    return_apps_block@0:
+        // arc4_conversions/reference.py:37
+        // return self.apps
+        int 0                                                                                         0
+        byte "apps"                                                                                   0,"apps"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.apps exists                                                              maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> bytes:
+subroutine return_assets:
+    return_assets_block@0:
+        // arc4_conversions/reference.py:41
+        // return self.assets
+        int 0                                                                                         0
+        byte "assets"                                                                                 0,"assets"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.assets exists                                                            maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes:
+subroutine return_accounts:
+    return_accounts_block@0:
+        // arc4_conversions/reference.py:45
+        // return self.accounts
+        int 0                                                                                         0
+        byte "accounts"                                                                               0,"accounts"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.accounts exists                                                          maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.11.fstack.mir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.11.fstack.mir
@@ -1,0 +1,333 @@
+// Op                                                                                                 Stack (out)
+// algopy.arc4.ARC4Contract.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txn NumAppArgs                                                                                tmp%0#1
+        bz main_bare_routing@15 ; b main_abi_routing@2
+
+    main_abi_routing@2:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 0                                                                        tmp%2#0
+        method acc_ret()address                                                                       tmp%2#0,Method(acc_ret()address)
+        method asset_ret()uint64                                                                      tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64)
+        method app_ret()uint64                                                                        tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64)
+        method store(account,application,asset)void                                                   tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void)
+        method store_apps(uint64[])void                                                               tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void)
+        method store_assets(uint64[])void                                                             tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void)
+        method store_accounts(address[])void                                                          tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void)
+        method return_apps()uint64[]                                                                  tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[])
+        method return_assets()uint64[]                                                                tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[])
+        method return_accounts()address[]                                                             tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[]),Method(return_accounts()address[])
+        l-load tmp%2#0 10                                                                             Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[]),Method(return_accounts()address[]),tmp%2#0
+        match main_acc_ret_route@3 main_asset_ret_route@4 main_app_ret_route@5 main_store_route@6 main_store_apps_route@7 main_store_assets_route@8 main_store_accounts_route@9 main_return_apps_route@10 main_return_assets_route@11 main_return_accounts_route@12 ; b main_after_if_else@19 
+
+    main_acc_ret_route@3:
+        // arc4_conversions/reference.py:5
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%3#0
+        !                                                                                             tmp%4#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%5#0
+        assert // can only call when not creating
+        callsub acc_ret                                                                               tmp%7#0
+        byte 0x151f7c75                                                                               tmp%7#0,0x151f7c75
+        l-load tmp%7#0 1                                                                              0x151f7c75,tmp%7#0
+        concat                                                                                        tmp%8#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_asset_ret_route@4:
+        // arc4_conversions/reference.py:9
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%9#0
+        !                                                                                             tmp%10#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%11#0
+        assert // can only call when not creating
+        byte 0x151f7c7500000000000004d2                                                               0x151f7c7500000000000004d2
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_app_ret_route@5:
+        // arc4_conversions/reference.py:13
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%14#0
+        !                                                                                             tmp%15#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%16#0
+        assert // can only call when not creating
+        byte 0x151f7c7500000000000004d2                                                               0x151f7c7500000000000004d2
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_route@6:
+        // arc4_conversions/reference.py:17
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%19#0
+        !                                                                                             tmp%20#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%21#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_bytes[1]%0#0
+        btoi                                                                                          tmp%23#0
+        txnas Accounts                                                                                tmp%24#0
+        txna ApplicationArgs 2                                                                        tmp%24#0,reinterpret_bytes[1]%1#0
+        btoi                                                                                          tmp%24#0,tmp%25#0
+        txnas Applications                                                                            tmp%24#0,tmp%26#0
+        txna ApplicationArgs 3                                                                        tmp%24#0,tmp%26#0,reinterpret_bytes[1]%2#0
+        btoi                                                                                          tmp%24#0,tmp%26#0,tmp%27#0
+        txnas Assets                                                                                  tmp%24#0,tmp%26#0,tmp%28#0
+        // arc4_conversions/reference.py:17
+        // @arc4.abimethod
+        l-load tmp%24#0 2                                                                             tmp%26#0,tmp%28#0,tmp%24#0
+        l-load tmp%26#0 2                                                                             tmp%28#0,tmp%24#0,tmp%26#0
+        l-load tmp%28#0 2                                                                             tmp%24#0,tmp%26#0,tmp%28#0
+        callsub store
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_apps_route@7:
+        // arc4_conversions/reference.py:23
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%29#0
+        !                                                                                             tmp%30#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%31#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_encoded_uint64[]%0#0
+        // arc4_conversions/reference.py:23
+        // @arc4.abimethod
+        callsub store_apps
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_assets_route@8:
+        // arc4_conversions/reference.py:27
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%33#0
+        !                                                                                             tmp%34#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%35#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_encoded_uint64[]%1#0
+        // arc4_conversions/reference.py:27
+        // @arc4.abimethod
+        callsub store_assets
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_accounts_route@9:
+        // arc4_conversions/reference.py:31
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%37#0
+        !                                                                                             tmp%38#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%39#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_bytes[32][]%0#0
+        // arc4_conversions/reference.py:31
+        // @arc4.abimethod
+        callsub store_accounts
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_return_apps_route@10:
+        // arc4_conversions/reference.py:35
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%41#0
+        !                                                                                             tmp%42#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%43#0
+        assert // can only call when not creating
+        callsub return_apps                                                                           tmp%45#0
+        byte 0x151f7c75                                                                               tmp%45#0,0x151f7c75
+        l-load tmp%45#0 1                                                                             0x151f7c75,tmp%45#0
+        concat                                                                                        tmp%46#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_return_assets_route@11:
+        // arc4_conversions/reference.py:39
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%47#0
+        !                                                                                             tmp%48#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%49#0
+        assert // can only call when not creating
+        callsub return_assets                                                                         tmp%51#0
+        byte 0x151f7c75                                                                               tmp%51#0,0x151f7c75
+        l-load tmp%51#0 1                                                                             0x151f7c75,tmp%51#0
+        concat                                                                                        tmp%52#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_return_accounts_route@12:
+        // arc4_conversions/reference.py:43
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%53#0
+        !                                                                                             tmp%54#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%55#0
+        assert // can only call when not creating
+        callsub return_accounts                                                                       tmp%57#0
+        byte 0x151f7c75                                                                               tmp%57#0,0x151f7c75
+        l-load tmp%57#0 1                                                                             0x151f7c75,tmp%57#0
+        concat                                                                                        tmp%58#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_bare_routing@15:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txn OnCompletion                                                                              tmp%59#0
+        bz main___algopy_default_create@16 ; b main_after_if_else@19
+
+    main___algopy_default_create@16:
+        txn ApplicationID                                                                             tmp%60#0
+        !                                                                                             tmp%61#0
+        assert // can only call when creating
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_after_if_else@19:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        int 0                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: (𝕏) tmp%0#0 |
+        x-load tmp%0#0                                                                                tmp%0#0
+        return
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes:
+subroutine acc_ret:
+    acc_ret_block@0:
+        // arc4_conversions/reference.py:7
+        // return Txn.sender
+        txn Sender                                                                                    tmp%0#0
+        retsub                                                                                        tmp%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes, app: uint64, asset: uint64) -> void:
+subroutine store:
+    store_block@0:                                                                                    (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:19
+        // self.acc = acc
+        byte "acc"                                                                                    (𝕡) acc#0,app#0,asset#0 | "acc"
+        p-load acc#0                                                                                  (𝕡) acc#0,app#0,asset#0 | "acc",acc#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:20
+        // self.asset = asset
+        byte "asset"                                                                                  (𝕡) acc#0,app#0,asset#0 | "asset"
+        p-load asset#0                                                                                (𝕡) acc#0,app#0,asset#0 | "asset",asset#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:21
+        // self.app = app
+        byte "app"                                                                                    (𝕡) acc#0,app#0,asset#0 | "app"
+        p-load app#0                                                                                  (𝕡) acc#0,app#0,asset#0 | "app",app#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: bytes) -> void:
+subroutine store_apps:
+    store_apps_block@0:                                                                               (𝕡) apps#0 |
+        // arc4_conversions/reference.py:25
+        // self.apps = apps
+        byte "apps"                                                                                   (𝕡) apps#0 | "apps"
+        p-load apps#0                                                                                 (𝕡) apps#0 | "apps",apps#0 (copy)
+        app_global_put                                                                                (𝕡) apps#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: bytes) -> void:
+subroutine store_assets:
+    store_assets_block@0:                                                                             (𝕡) assets#0 |
+        // arc4_conversions/reference.py:29
+        // self.assets = assets
+        byte "assets"                                                                                 (𝕡) assets#0 | "assets"
+        p-load assets#0                                                                               (𝕡) assets#0 | "assets",assets#0 (copy)
+        app_global_put                                                                                (𝕡) assets#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes) -> void:
+subroutine store_accounts:
+    store_accounts_block@0:                                                                           (𝕡) accounts#0 |
+        // arc4_conversions/reference.py:33
+        // self.accounts = accounts
+        byte "accounts"                                                                               (𝕡) accounts#0 | "accounts"
+        p-load accounts#0                                                                             (𝕡) accounts#0 | "accounts",accounts#0 (copy)
+        app_global_put                                                                                (𝕡) accounts#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> bytes:
+subroutine return_apps:
+    return_apps_block@0:
+        // arc4_conversions/reference.py:37
+        // return self.apps
+        int 0                                                                                         0
+        byte "apps"                                                                                   0,"apps"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.apps exists                                                              maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> bytes:
+subroutine return_assets:
+    return_assets_block@0:
+        // arc4_conversions/reference.py:41
+        // return self.assets
+        int 0                                                                                         0
+        byte "assets"                                                                                 0,"assets"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.assets exists                                                            maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes:
+subroutine return_accounts:
+    return_accounts_block@0:
+        // arc4_conversions/reference.py:45
+        // return self.accounts
+        int 0                                                                                         0
+        byte "accounts"                                                                               0,"accounts"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.accounts exists                                                          maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.12.fstack.opt.mir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.12.fstack.opt.mir
@@ -1,0 +1,333 @@
+// Op                                                                                                 Stack (out)
+// algopy.arc4.ARC4Contract.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txn NumAppArgs                                                                                tmp%0#1
+        bz main_bare_routing@15 ; b main_abi_routing@2
+
+    main_abi_routing@2:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 0                                                                        tmp%2#0
+        method acc_ret()address                                                                       tmp%2#0,Method(acc_ret()address)
+        method asset_ret()uint64                                                                      tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64)
+        method app_ret()uint64                                                                        tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64)
+        method store(account,application,asset)void                                                   tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void)
+        method store_apps(uint64[])void                                                               tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void)
+        method store_assets(uint64[])void                                                             tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void)
+        method store_accounts(address[])void                                                          tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void)
+        method return_apps()uint64[]                                                                  tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[])
+        method return_assets()uint64[]                                                                tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[])
+        method return_accounts()address[]                                                             tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[]),Method(return_accounts()address[])
+        l-load tmp%2#0 10                                                                             Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[]),Method(return_accounts()address[]),tmp%2#0
+        match main_acc_ret_route@3 main_asset_ret_route@4 main_app_ret_route@5 main_store_route@6 main_store_apps_route@7 main_store_assets_route@8 main_store_accounts_route@9 main_return_apps_route@10 main_return_assets_route@11 main_return_accounts_route@12 ; b main_after_if_else@19 
+
+    main_acc_ret_route@3:
+        // arc4_conversions/reference.py:5
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%3#0
+        !                                                                                             tmp%4#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%5#0
+        assert // can only call when not creating
+        callsub acc_ret                                                                               tmp%7#0
+        byte 0x151f7c75                                                                               tmp%7#0,0x151f7c75
+        l-load tmp%7#0 1                                                                              0x151f7c75,tmp%7#0
+        concat                                                                                        tmp%8#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_asset_ret_route@4:
+        // arc4_conversions/reference.py:9
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%9#0
+        !                                                                                             tmp%10#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%11#0
+        assert // can only call when not creating
+        byte 0x151f7c7500000000000004d2                                                               0x151f7c7500000000000004d2
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_app_ret_route@5:
+        // arc4_conversions/reference.py:13
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%14#0
+        !                                                                                             tmp%15#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%16#0
+        assert // can only call when not creating
+        byte 0x151f7c7500000000000004d2                                                               0x151f7c7500000000000004d2
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_route@6:
+        // arc4_conversions/reference.py:17
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%19#0
+        !                                                                                             tmp%20#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%21#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_bytes[1]%0#0
+        btoi                                                                                          tmp%23#0
+        txnas Accounts                                                                                tmp%24#0
+        txna ApplicationArgs 2                                                                        tmp%24#0,reinterpret_bytes[1]%1#0
+        btoi                                                                                          tmp%24#0,tmp%25#0
+        txnas Applications                                                                            tmp%24#0,tmp%26#0
+        txna ApplicationArgs 3                                                                        tmp%24#0,tmp%26#0,reinterpret_bytes[1]%2#0
+        btoi                                                                                          tmp%24#0,tmp%26#0,tmp%27#0
+        txnas Assets                                                                                  tmp%24#0,tmp%26#0,tmp%28#0
+        // arc4_conversions/reference.py:17
+        // @arc4.abimethod
+        l-load tmp%24#0 2                                                                             tmp%26#0,tmp%28#0,tmp%24#0
+        l-load tmp%26#0 2                                                                             tmp%28#0,tmp%24#0,tmp%26#0
+        l-load tmp%28#0 2                                                                             tmp%24#0,tmp%26#0,tmp%28#0
+        callsub store
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_apps_route@7:
+        // arc4_conversions/reference.py:23
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%29#0
+        !                                                                                             tmp%30#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%31#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_encoded_uint64[]%0#0
+        // arc4_conversions/reference.py:23
+        // @arc4.abimethod
+        callsub store_apps
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_assets_route@8:
+        // arc4_conversions/reference.py:27
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%33#0
+        !                                                                                             tmp%34#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%35#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_encoded_uint64[]%1#0
+        // arc4_conversions/reference.py:27
+        // @arc4.abimethod
+        callsub store_assets
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_accounts_route@9:
+        // arc4_conversions/reference.py:31
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%37#0
+        !                                                                                             tmp%38#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%39#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_bytes[32][]%0#0
+        // arc4_conversions/reference.py:31
+        // @arc4.abimethod
+        callsub store_accounts
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_return_apps_route@10:
+        // arc4_conversions/reference.py:35
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%41#0
+        !                                                                                             tmp%42#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%43#0
+        assert // can only call when not creating
+        callsub return_apps                                                                           tmp%45#0
+        byte 0x151f7c75                                                                               tmp%45#0,0x151f7c75
+        l-load tmp%45#0 1                                                                             0x151f7c75,tmp%45#0
+        concat                                                                                        tmp%46#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_return_assets_route@11:
+        // arc4_conversions/reference.py:39
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%47#0
+        !                                                                                             tmp%48#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%49#0
+        assert // can only call when not creating
+        callsub return_assets                                                                         tmp%51#0
+        byte 0x151f7c75                                                                               tmp%51#0,0x151f7c75
+        l-load tmp%51#0 1                                                                             0x151f7c75,tmp%51#0
+        concat                                                                                        tmp%52#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_return_accounts_route@12:
+        // arc4_conversions/reference.py:43
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%53#0
+        !                                                                                             tmp%54#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%55#0
+        assert // can only call when not creating
+        callsub return_accounts                                                                       tmp%57#0
+        byte 0x151f7c75                                                                               tmp%57#0,0x151f7c75
+        l-load tmp%57#0 1                                                                             0x151f7c75,tmp%57#0
+        concat                                                                                        tmp%58#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_bare_routing@15:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txn OnCompletion                                                                              tmp%59#0
+        bz main___algopy_default_create@16 ; b main_after_if_else@19
+
+    main___algopy_default_create@16:
+        txn ApplicationID                                                                             tmp%60#0
+        !                                                                                             tmp%61#0
+        assert // can only call when creating
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_after_if_else@19:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        int 0                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: (𝕏) tmp%0#0 |
+        x-load tmp%0#0                                                                                tmp%0#0
+        return
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes:
+subroutine acc_ret:
+    acc_ret_block@0:
+        // arc4_conversions/reference.py:7
+        // return Txn.sender
+        txn Sender                                                                                    tmp%0#0
+        retsub                                                                                        tmp%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes, app: uint64, asset: uint64) -> void:
+subroutine store:
+    store_block@0:                                                                                    (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:19
+        // self.acc = acc
+        byte "acc"                                                                                    (𝕡) acc#0,app#0,asset#0 | "acc"
+        p-load acc#0                                                                                  (𝕡) acc#0,app#0,asset#0 | "acc",acc#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:20
+        // self.asset = asset
+        byte "asset"                                                                                  (𝕡) acc#0,app#0,asset#0 | "asset"
+        p-load asset#0                                                                                (𝕡) acc#0,app#0,asset#0 | "asset",asset#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:21
+        // self.app = app
+        byte "app"                                                                                    (𝕡) acc#0,app#0,asset#0 | "app"
+        p-load app#0                                                                                  (𝕡) acc#0,app#0,asset#0 | "app",app#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: bytes) -> void:
+subroutine store_apps:
+    store_apps_block@0:                                                                               (𝕡) apps#0 |
+        // arc4_conversions/reference.py:25
+        // self.apps = apps
+        byte "apps"                                                                                   (𝕡) apps#0 | "apps"
+        p-load apps#0                                                                                 (𝕡) apps#0 | "apps",apps#0 (copy)
+        app_global_put                                                                                (𝕡) apps#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: bytes) -> void:
+subroutine store_assets:
+    store_assets_block@0:                                                                             (𝕡) assets#0 |
+        // arc4_conversions/reference.py:29
+        // self.assets = assets
+        byte "assets"                                                                                 (𝕡) assets#0 | "assets"
+        p-load assets#0                                                                               (𝕡) assets#0 | "assets",assets#0 (copy)
+        app_global_put                                                                                (𝕡) assets#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes) -> void:
+subroutine store_accounts:
+    store_accounts_block@0:                                                                           (𝕡) accounts#0 |
+        // arc4_conversions/reference.py:33
+        // self.accounts = accounts
+        byte "accounts"                                                                               (𝕡) accounts#0 | "accounts"
+        p-load accounts#0                                                                             (𝕡) accounts#0 | "accounts",accounts#0 (copy)
+        app_global_put                                                                                (𝕡) accounts#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> bytes:
+subroutine return_apps:
+    return_apps_block@0:
+        // arc4_conversions/reference.py:37
+        // return self.apps
+        int 0                                                                                         0
+        byte "apps"                                                                                   0,"apps"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.apps exists                                                              maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> bytes:
+subroutine return_assets:
+    return_assets_block@0:
+        // arc4_conversions/reference.py:41
+        // return self.assets
+        int 0                                                                                         0
+        byte "assets"                                                                                 0,"assets"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.assets exists                                                            maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes:
+subroutine return_accounts:
+    return_accounts_block@0:
+        // arc4_conversions/reference.py:45
+        // return self.accounts
+        int 0                                                                                         0
+        byte "accounts"                                                                               0,"accounts"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.accounts exists                                                          maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.13.mir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.13.mir
@@ -1,0 +1,333 @@
+// Op                                                                                                 Stack (out)
+// algopy.arc4.ARC4Contract.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txn NumAppArgs                                                                                tmp%0#1
+        bz main_bare_routing@15 ; b main_abi_routing@2
+
+    main_abi_routing@2:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 0                                                                        tmp%2#0
+        method acc_ret()address                                                                       tmp%2#0,Method(acc_ret()address)
+        method asset_ret()uint64                                                                      tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64)
+        method app_ret()uint64                                                                        tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64)
+        method store(account,application,asset)void                                                   tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void)
+        method store_apps(uint64[])void                                                               tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void)
+        method store_assets(uint64[])void                                                             tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void)
+        method store_accounts(address[])void                                                          tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void)
+        method return_apps()uint64[]                                                                  tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[])
+        method return_assets()uint64[]                                                                tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[])
+        method return_accounts()address[]                                                             tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[]),Method(return_accounts()address[])
+        l-load tmp%2#0 10                                                                             Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[]),Method(return_accounts()address[]),tmp%2#0
+        match main_acc_ret_route@3 main_asset_ret_route@4 main_app_ret_route@5 main_store_route@6 main_store_apps_route@7 main_store_assets_route@8 main_store_accounts_route@9 main_return_apps_route@10 main_return_assets_route@11 main_return_accounts_route@12 ; b main_after_if_else@19 
+
+    main_acc_ret_route@3:
+        // arc4_conversions/reference.py:5
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%3#0
+        !                                                                                             tmp%4#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%5#0
+        assert // can only call when not creating
+        callsub acc_ret                                                                               tmp%7#0
+        byte 0x151f7c75                                                                               tmp%7#0,0x151f7c75
+        l-load tmp%7#0 1                                                                              0x151f7c75,tmp%7#0
+        concat                                                                                        tmp%8#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_asset_ret_route@4:
+        // arc4_conversions/reference.py:9
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%9#0
+        !                                                                                             tmp%10#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%11#0
+        assert // can only call when not creating
+        byte 0x151f7c7500000000000004d2                                                               0x151f7c7500000000000004d2
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_app_ret_route@5:
+        // arc4_conversions/reference.py:13
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%14#0
+        !                                                                                             tmp%15#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%16#0
+        assert // can only call when not creating
+        byte 0x151f7c7500000000000004d2                                                               0x151f7c7500000000000004d2
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_route@6:
+        // arc4_conversions/reference.py:17
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%19#0
+        !                                                                                             tmp%20#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%21#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_bytes[1]%0#0
+        btoi                                                                                          tmp%23#0
+        txnas Accounts                                                                                tmp%24#0
+        txna ApplicationArgs 2                                                                        tmp%24#0,reinterpret_bytes[1]%1#0
+        btoi                                                                                          tmp%24#0,tmp%25#0
+        txnas Applications                                                                            tmp%24#0,tmp%26#0
+        txna ApplicationArgs 3                                                                        tmp%24#0,tmp%26#0,reinterpret_bytes[1]%2#0
+        btoi                                                                                          tmp%24#0,tmp%26#0,tmp%27#0
+        txnas Assets                                                                                  tmp%24#0,tmp%26#0,tmp%28#0
+        // arc4_conversions/reference.py:17
+        // @arc4.abimethod
+        l-load tmp%24#0 2                                                                             tmp%26#0,tmp%28#0,tmp%24#0
+        l-load tmp%26#0 2                                                                             tmp%28#0,tmp%24#0,tmp%26#0
+        l-load tmp%28#0 2                                                                             tmp%24#0,tmp%26#0,tmp%28#0
+        callsub store
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_apps_route@7:
+        // arc4_conversions/reference.py:23
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%29#0
+        !                                                                                             tmp%30#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%31#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_encoded_uint64[]%0#0
+        // arc4_conversions/reference.py:23
+        // @arc4.abimethod
+        callsub store_apps
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_assets_route@8:
+        // arc4_conversions/reference.py:27
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%33#0
+        !                                                                                             tmp%34#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%35#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_encoded_uint64[]%1#0
+        // arc4_conversions/reference.py:27
+        // @arc4.abimethod
+        callsub store_assets
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_accounts_route@9:
+        // arc4_conversions/reference.py:31
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%37#0
+        !                                                                                             tmp%38#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%39#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_bytes[32][]%0#0
+        // arc4_conversions/reference.py:31
+        // @arc4.abimethod
+        callsub store_accounts
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_return_apps_route@10:
+        // arc4_conversions/reference.py:35
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%41#0
+        !                                                                                             tmp%42#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%43#0
+        assert // can only call when not creating
+        callsub return_apps                                                                           tmp%45#0
+        byte 0x151f7c75                                                                               tmp%45#0,0x151f7c75
+        l-load tmp%45#0 1                                                                             0x151f7c75,tmp%45#0
+        concat                                                                                        tmp%46#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_return_assets_route@11:
+        // arc4_conversions/reference.py:39
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%47#0
+        !                                                                                             tmp%48#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%49#0
+        assert // can only call when not creating
+        callsub return_assets                                                                         tmp%51#0
+        byte 0x151f7c75                                                                               tmp%51#0,0x151f7c75
+        l-load tmp%51#0 1                                                                             0x151f7c75,tmp%51#0
+        concat                                                                                        tmp%52#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_return_accounts_route@12:
+        // arc4_conversions/reference.py:43
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%53#0
+        !                                                                                             tmp%54#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%55#0
+        assert // can only call when not creating
+        callsub return_accounts                                                                       tmp%57#0
+        byte 0x151f7c75                                                                               tmp%57#0,0x151f7c75
+        l-load tmp%57#0 1                                                                             0x151f7c75,tmp%57#0
+        concat                                                                                        tmp%58#0
+        log
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_bare_routing@15:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txn OnCompletion                                                                              tmp%59#0
+        bz main___algopy_default_create@16 ; b main_after_if_else@19
+
+    main___algopy_default_create@16:
+        txn ApplicationID                                                                             tmp%60#0
+        !                                                                                             tmp%61#0
+        assert // can only call when creating
+        int 1                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_after_if_else@19:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        int 0                                                                                         tmp%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: (𝕏) tmp%0#0 |
+        x-load tmp%0#0                                                                                tmp%0#0
+        return
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes:
+subroutine acc_ret:
+    acc_ret_block@0:
+        // arc4_conversions/reference.py:7
+        // return Txn.sender
+        txn Sender                                                                                    tmp%0#0
+        retsub                                                                                        tmp%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes, app: uint64, asset: uint64) -> void:
+subroutine store:
+    store_block@0:                                                                                    (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:19
+        // self.acc = acc
+        byte "acc"                                                                                    (𝕡) acc#0,app#0,asset#0 | "acc"
+        p-load acc#0                                                                                  (𝕡) acc#0,app#0,asset#0 | "acc",acc#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:20
+        // self.asset = asset
+        byte "asset"                                                                                  (𝕡) acc#0,app#0,asset#0 | "asset"
+        p-load asset#0                                                                                (𝕡) acc#0,app#0,asset#0 | "asset",asset#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:21
+        // self.app = app
+        byte "app"                                                                                    (𝕡) acc#0,app#0,asset#0 | "app"
+        p-load app#0                                                                                  (𝕡) acc#0,app#0,asset#0 | "app",app#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: bytes) -> void:
+subroutine store_apps:
+    store_apps_block@0:                                                                               (𝕡) apps#0 |
+        // arc4_conversions/reference.py:25
+        // self.apps = apps
+        byte "apps"                                                                                   (𝕡) apps#0 | "apps"
+        p-load apps#0                                                                                 (𝕡) apps#0 | "apps",apps#0 (copy)
+        app_global_put                                                                                (𝕡) apps#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: bytes) -> void:
+subroutine store_assets:
+    store_assets_block@0:                                                                             (𝕡) assets#0 |
+        // arc4_conversions/reference.py:29
+        // self.assets = assets
+        byte "assets"                                                                                 (𝕡) assets#0 | "assets"
+        p-load assets#0                                                                               (𝕡) assets#0 | "assets",assets#0 (copy)
+        app_global_put                                                                                (𝕡) assets#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes) -> void:
+subroutine store_accounts:
+    store_accounts_block@0:                                                                           (𝕡) accounts#0 |
+        // arc4_conversions/reference.py:33
+        // self.accounts = accounts
+        byte "accounts"                                                                               (𝕡) accounts#0 | "accounts"
+        p-load accounts#0                                                                             (𝕡) accounts#0 | "accounts",accounts#0 (copy)
+        app_global_put                                                                                (𝕡) accounts#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> bytes:
+subroutine return_apps:
+    return_apps_block@0:
+        // arc4_conversions/reference.py:37
+        // return self.apps
+        int 0                                                                                         0
+        byte "apps"                                                                                   0,"apps"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.apps exists                                                              maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> bytes:
+subroutine return_assets:
+    return_assets_block@0:
+        // arc4_conversions/reference.py:41
+        // return self.assets
+        int 0                                                                                         0
+        byte "assets"                                                                                 0,"assets"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.assets exists                                                            maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes:
+subroutine return_accounts:
+    return_accounts_block@0:
+        // arc4_conversions/reference.py:45
+        // return self.accounts
+        int 0                                                                                         0
+        byte "accounts"                                                                               0,"accounts"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.accounts exists                                                          maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.2.ssa.opt.ir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.2.ssa.opt.ir
@@ -1,0 +1,181 @@
+main algopy.arc4.ARC4Contract.approval_program:
+    block@0: // L1
+        let tmp%0#1: uint64 = (txn NumAppArgs)
+        goto tmp%0#1 ? block@2 : block@15
+    block@2: // abi_routing_L4
+        let tmp%2#0: bytes = (txna ApplicationArgs 0)
+        switch tmp%2#0 {method "acc_ret()address" => block@3, method "asset_ret()uint64" => block@4, method "app_ret()uint64" => block@5, method "store(account,application,asset)void" => block@6, method "store_apps(uint64[])void" => block@7, method "store_assets(uint64[])void" => block@8, method "store_accounts(address[])void" => block@9, method "return_apps()uint64[]" => block@10, method "return_assets()uint64[]" => block@11, method "return_accounts()address[]" => block@12, * => block@19}
+    block@3: // acc_ret_route_L5
+        let tmp%3#0: uint64 = (txn OnCompletion)
+        let tmp%4#0: bool = (! tmp%3#0)
+        (assert tmp%4#0) // OnCompletion is not NoOp
+        let tmp%5#0: uint64 = (txn ApplicationID)
+        (assert tmp%5#0) // can only call when not creating
+        let tmp%7#0: bytes[32] = test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret()
+        let tmp%8#0: bytes = (concat 0x151f7c75 tmp%7#0)
+        (log tmp%8#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        goto block@20
+    block@4: // asset_ret_route_L9
+        let tmp%9#0: uint64 = (txn OnCompletion)
+        let tmp%10#0: bool = (! tmp%9#0)
+        (assert tmp%10#0) // OnCompletion is not NoOp
+        let tmp%11#0: uint64 = (txn ApplicationID)
+        (assert tmp%11#0) // can only call when not creating
+        let val_as_bytes%0#0: bytes[8] = (itob 1234u)
+        let tmp%13#0: bytes = 0x151f7c7500000000000004d2
+        (log 0x151f7c7500000000000004d2)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#1: bool = 1u
+        goto block@20
+    block@5: // app_ret_route_L13
+        let tmp%14#0: uint64 = (txn OnCompletion)
+        let tmp%15#0: bool = (! tmp%14#0)
+        (assert tmp%15#0) // OnCompletion is not NoOp
+        let tmp%16#0: uint64 = (txn ApplicationID)
+        (assert tmp%16#0) // can only call when not creating
+        let val_as_bytes%1#0: bytes[8] = (itob 1234u)
+        let tmp%18#0: bytes = 0x151f7c7500000000000004d2
+        (log 0x151f7c7500000000000004d2)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#2: bool = 1u
+        goto block@20
+    block@6: // store_route_L17
+        let tmp%19#0: uint64 = (txn OnCompletion)
+        let tmp%20#0: bool = (! tmp%19#0)
+        (assert tmp%20#0) // OnCompletion is not NoOp
+        let tmp%21#0: uint64 = (txn ApplicationID)
+        (assert tmp%21#0) // can only call when not creating
+        let reinterpret_bytes[1]%0#0: bytes[1] = (txna ApplicationArgs 1)
+        let tmp%23#0: uint64 = (btoi reinterpret_bytes[1]%0#0)
+        let tmp%24#0: bytes[32] = ((txnas Accounts) tmp%23#0)
+        let reinterpret_bytes[1]%1#0: bytes[1] = (txna ApplicationArgs 2)
+        let tmp%25#0: uint64 = (btoi reinterpret_bytes[1]%1#0)
+        let tmp%26#0: uint64 = ((txnas Applications) tmp%25#0)
+        let reinterpret_bytes[1]%2#0: bytes[1] = (txna ApplicationArgs 3)
+        let tmp%27#0: uint64 = (btoi reinterpret_bytes[1]%2#0)
+        let tmp%28#0: uint64 = ((txnas Assets) tmp%27#0)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store(tmp%24#0, tmp%26#0, tmp%28#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#3: bool = 1u
+        goto block@20
+    block@7: // store_apps_route_L23
+        let tmp%29#0: uint64 = (txn OnCompletion)
+        let tmp%30#0: bool = (! tmp%29#0)
+        (assert tmp%30#0) // OnCompletion is not NoOp
+        let tmp%31#0: uint64 = (txn ApplicationID)
+        (assert tmp%31#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%0#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(reinterpret_encoded_uint64[]%0#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#4: bool = 1u
+        goto block@20
+    block@8: // store_assets_route_L27
+        let tmp%33#0: uint64 = (txn OnCompletion)
+        let tmp%34#0: bool = (! tmp%33#0)
+        (assert tmp%34#0) // OnCompletion is not NoOp
+        let tmp%35#0: uint64 = (txn ApplicationID)
+        (assert tmp%35#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%1#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(reinterpret_encoded_uint64[]%1#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#5: bool = 1u
+        goto block@20
+    block@9: // store_accounts_route_L31
+        let tmp%37#0: uint64 = (txn OnCompletion)
+        let tmp%38#0: bool = (! tmp%37#0)
+        (assert tmp%38#0) // OnCompletion is not NoOp
+        let tmp%39#0: uint64 = (txn ApplicationID)
+        (assert tmp%39#0) // can only call when not creating
+        let reinterpret_bytes[32][]%0#0: bytes[32][] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(reinterpret_bytes[32][]%0#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#6: bool = 1u
+        goto block@20
+    block@10: // return_apps_route_L35
+        let tmp%41#0: uint64 = (txn OnCompletion)
+        let tmp%42#0: bool = (! tmp%41#0)
+        (assert tmp%42#0) // OnCompletion is not NoOp
+        let tmp%43#0: uint64 = (txn ApplicationID)
+        (assert tmp%43#0) // can only call when not creating
+        let tmp%45#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_apps()
+        let tmp%46#0: bytes = (concat 0x151f7c75 tmp%45#0)
+        (log tmp%46#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#7: bool = 1u
+        goto block@20
+    block@11: // return_assets_route_L39
+        let tmp%47#0: uint64 = (txn OnCompletion)
+        let tmp%48#0: bool = (! tmp%47#0)
+        (assert tmp%48#0) // OnCompletion is not NoOp
+        let tmp%49#0: uint64 = (txn ApplicationID)
+        (assert tmp%49#0) // can only call when not creating
+        let tmp%51#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_assets()
+        let tmp%52#0: bytes = (concat 0x151f7c75 tmp%51#0)
+        (log tmp%52#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#8: bool = 1u
+        goto block@20
+    block@12: // return_accounts_route_L43
+        let tmp%53#0: uint64 = (txn OnCompletion)
+        let tmp%54#0: bool = (! tmp%53#0)
+        (assert tmp%54#0) // OnCompletion is not NoOp
+        let tmp%55#0: uint64 = (txn ApplicationID)
+        (assert tmp%55#0) // can only call when not creating
+        let tmp%57#0: bytes[32][] = test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts()
+        let tmp%58#0: bytes = (concat 0x151f7c75 tmp%57#0)
+        (log tmp%58#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#9: bool = 1u
+        goto block@20
+    block@15: // bare_routing_L4
+        let tmp%59#0: uint64 = (txn OnCompletion)
+        goto tmp%59#0 ? block@19 : block@16
+    block@16: // __algopy_default_create_L1
+        let tmp%60#0: uint64 = (txn ApplicationID)
+        let tmp%61#0: bool = (! tmp%60#0)
+        (assert tmp%61#0) // can only call when creating
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#10: bool = 1u
+        goto block@20
+    block@19: // after_if_else_L4
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#11: bool = 0u
+        goto block@20
+    block@20: // after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router___L1
+        let tmp%0#0: bool = φ(test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 <- block@3, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#1 <- block@4, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#2 <- block@5, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#3 <- block@6, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#4 <- block@7, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#5 <- block@8, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#6 <- block@9, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#7 <- block@10, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#8 <- block@11, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#9 <- block@12, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#10 <- block@16, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#11 <- block@19)
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes[32]:
+    block@0: // L5
+        let tmp%0#0: bytes[32] = (txn Sender)
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes[32], app: uint64, asset: uint64) -> void:
+    block@0: // L17
+        (app_global_put "acc" acc#0)
+        (app_global_put "asset" asset#0)
+        (app_global_put "app" app#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: encoded_uint64[]) -> void:
+    block@0: // L23
+        (app_global_put "apps" apps#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: encoded_uint64[]) -> void:
+    block@0: // L27
+        (app_global_put "assets" assets#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes[32][]) -> void:
+    block@0: // L31
+        (app_global_put "accounts" accounts#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> encoded_uint64[]:
+    block@0: // L35
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "apps")
+        (assert maybe_exists%0#0) // check self.apps exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> encoded_uint64[]:
+    block@0: // L39
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "assets")
+        (assert maybe_exists%0#0) // check self.assets exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes[32][]:
+    block@0: // L43
+        let (maybe_value%0#0: bytes[32][], maybe_exists%0#0: bool) = (app_global_get_ex 0u "accounts")
+        (assert maybe_exists%0#0) // check self.accounts exists
+        return maybe_value%0#0

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.3.ssa.opt.ir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.3.ssa.opt.ir
@@ -1,0 +1,177 @@
+main algopy.arc4.ARC4Contract.approval_program:
+    block@0: // L1
+        let tmp%0#1: uint64 = (txn NumAppArgs)
+        goto tmp%0#1 ? block@2 : block@15
+    block@2: // abi_routing_L4
+        let tmp%2#0: bytes = (txna ApplicationArgs 0)
+        switch tmp%2#0 {method "acc_ret()address" => block@3, method "asset_ret()uint64" => block@4, method "app_ret()uint64" => block@5, method "store(account,application,asset)void" => block@6, method "store_apps(uint64[])void" => block@7, method "store_assets(uint64[])void" => block@8, method "store_accounts(address[])void" => block@9, method "return_apps()uint64[]" => block@10, method "return_assets()uint64[]" => block@11, method "return_accounts()address[]" => block@12, * => block@19}
+    block@3: // acc_ret_route_L5
+        let tmp%3#0: uint64 = (txn OnCompletion)
+        let tmp%4#0: bool = (! tmp%3#0)
+        (assert tmp%4#0) // OnCompletion is not NoOp
+        let tmp%5#0: uint64 = (txn ApplicationID)
+        (assert tmp%5#0) // can only call when not creating
+        let tmp%7#0: bytes[32] = test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret()
+        let tmp%8#0: bytes = (concat 0x151f7c75 tmp%7#0)
+        (log tmp%8#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        goto block@20
+    block@4: // asset_ret_route_L9
+        let tmp%9#0: uint64 = (txn OnCompletion)
+        let tmp%10#0: bool = (! tmp%9#0)
+        (assert tmp%10#0) // OnCompletion is not NoOp
+        let tmp%11#0: uint64 = (txn ApplicationID)
+        (assert tmp%11#0) // can only call when not creating
+        (log 0x151f7c7500000000000004d2)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#1: bool = 1u
+        goto block@20
+    block@5: // app_ret_route_L13
+        let tmp%14#0: uint64 = (txn OnCompletion)
+        let tmp%15#0: bool = (! tmp%14#0)
+        (assert tmp%15#0) // OnCompletion is not NoOp
+        let tmp%16#0: uint64 = (txn ApplicationID)
+        (assert tmp%16#0) // can only call when not creating
+        (log 0x151f7c7500000000000004d2)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#2: bool = 1u
+        goto block@20
+    block@6: // store_route_L17
+        let tmp%19#0: uint64 = (txn OnCompletion)
+        let tmp%20#0: bool = (! tmp%19#0)
+        (assert tmp%20#0) // OnCompletion is not NoOp
+        let tmp%21#0: uint64 = (txn ApplicationID)
+        (assert tmp%21#0) // can only call when not creating
+        let reinterpret_bytes[1]%0#0: bytes[1] = (txna ApplicationArgs 1)
+        let tmp%23#0: uint64 = (btoi reinterpret_bytes[1]%0#0)
+        let tmp%24#0: bytes[32] = ((txnas Accounts) tmp%23#0)
+        let reinterpret_bytes[1]%1#0: bytes[1] = (txna ApplicationArgs 2)
+        let tmp%25#0: uint64 = (btoi reinterpret_bytes[1]%1#0)
+        let tmp%26#0: uint64 = ((txnas Applications) tmp%25#0)
+        let reinterpret_bytes[1]%2#0: bytes[1] = (txna ApplicationArgs 3)
+        let tmp%27#0: uint64 = (btoi reinterpret_bytes[1]%2#0)
+        let tmp%28#0: uint64 = ((txnas Assets) tmp%27#0)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store(tmp%24#0, tmp%26#0, tmp%28#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#3: bool = 1u
+        goto block@20
+    block@7: // store_apps_route_L23
+        let tmp%29#0: uint64 = (txn OnCompletion)
+        let tmp%30#0: bool = (! tmp%29#0)
+        (assert tmp%30#0) // OnCompletion is not NoOp
+        let tmp%31#0: uint64 = (txn ApplicationID)
+        (assert tmp%31#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%0#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(reinterpret_encoded_uint64[]%0#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#4: bool = 1u
+        goto block@20
+    block@8: // store_assets_route_L27
+        let tmp%33#0: uint64 = (txn OnCompletion)
+        let tmp%34#0: bool = (! tmp%33#0)
+        (assert tmp%34#0) // OnCompletion is not NoOp
+        let tmp%35#0: uint64 = (txn ApplicationID)
+        (assert tmp%35#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%1#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(reinterpret_encoded_uint64[]%1#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#5: bool = 1u
+        goto block@20
+    block@9: // store_accounts_route_L31
+        let tmp%37#0: uint64 = (txn OnCompletion)
+        let tmp%38#0: bool = (! tmp%37#0)
+        (assert tmp%38#0) // OnCompletion is not NoOp
+        let tmp%39#0: uint64 = (txn ApplicationID)
+        (assert tmp%39#0) // can only call when not creating
+        let reinterpret_bytes[32][]%0#0: bytes[32][] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(reinterpret_bytes[32][]%0#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#6: bool = 1u
+        goto block@20
+    block@10: // return_apps_route_L35
+        let tmp%41#0: uint64 = (txn OnCompletion)
+        let tmp%42#0: bool = (! tmp%41#0)
+        (assert tmp%42#0) // OnCompletion is not NoOp
+        let tmp%43#0: uint64 = (txn ApplicationID)
+        (assert tmp%43#0) // can only call when not creating
+        let tmp%45#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_apps()
+        let tmp%46#0: bytes = (concat 0x151f7c75 tmp%45#0)
+        (log tmp%46#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#7: bool = 1u
+        goto block@20
+    block@11: // return_assets_route_L39
+        let tmp%47#0: uint64 = (txn OnCompletion)
+        let tmp%48#0: bool = (! tmp%47#0)
+        (assert tmp%48#0) // OnCompletion is not NoOp
+        let tmp%49#0: uint64 = (txn ApplicationID)
+        (assert tmp%49#0) // can only call when not creating
+        let tmp%51#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_assets()
+        let tmp%52#0: bytes = (concat 0x151f7c75 tmp%51#0)
+        (log tmp%52#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#8: bool = 1u
+        goto block@20
+    block@12: // return_accounts_route_L43
+        let tmp%53#0: uint64 = (txn OnCompletion)
+        let tmp%54#0: bool = (! tmp%53#0)
+        (assert tmp%54#0) // OnCompletion is not NoOp
+        let tmp%55#0: uint64 = (txn ApplicationID)
+        (assert tmp%55#0) // can only call when not creating
+        let tmp%57#0: bytes[32][] = test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts()
+        let tmp%58#0: bytes = (concat 0x151f7c75 tmp%57#0)
+        (log tmp%58#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#9: bool = 1u
+        goto block@20
+    block@15: // bare_routing_L4
+        let tmp%59#0: uint64 = (txn OnCompletion)
+        goto tmp%59#0 ? block@19 : block@16
+    block@16: // __algopy_default_create_L1
+        let tmp%60#0: uint64 = (txn ApplicationID)
+        let tmp%61#0: bool = (! tmp%60#0)
+        (assert tmp%61#0) // can only call when creating
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#10: bool = 1u
+        goto block@20
+    block@19: // after_if_else_L4
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#11: bool = 0u
+        goto block@20
+    block@20: // after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router___L1
+        let tmp%0#0: bool = φ(test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 <- block@3, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#1 <- block@4, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#2 <- block@5, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#3 <- block@6, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#4 <- block@7, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#5 <- block@8, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#6 <- block@9, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#7 <- block@10, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#8 <- block@11, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#9 <- block@12, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#10 <- block@16, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#11 <- block@19)
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes[32]:
+    block@0: // L5
+        let tmp%0#0: bytes[32] = (txn Sender)
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes[32], app: uint64, asset: uint64) -> void:
+    block@0: // L17
+        (app_global_put "acc" acc#0)
+        (app_global_put "asset" asset#0)
+        (app_global_put "app" app#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: encoded_uint64[]) -> void:
+    block@0: // L23
+        (app_global_put "apps" apps#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: encoded_uint64[]) -> void:
+    block@0: // L27
+        (app_global_put "assets" assets#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes[32][]) -> void:
+    block@0: // L31
+        (app_global_put "accounts" accounts#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> encoded_uint64[]:
+    block@0: // L35
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "apps")
+        (assert maybe_exists%0#0) // check self.apps exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> encoded_uint64[]:
+    block@0: // L39
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "assets")
+        (assert maybe_exists%0#0) // check self.assets exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes[32][]:
+    block@0: // L43
+        let (maybe_value%0#0: bytes[32][], maybe_exists%0#0: bool) = (app_global_get_ex 0u "accounts")
+        (assert maybe_exists%0#0) // check self.accounts exists
+        return maybe_value%0#0

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.4.ssa.array.ir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.4.ssa.array.ir
@@ -1,0 +1,177 @@
+main algopy.arc4.ARC4Contract.approval_program:
+    block@0: // L1
+        let tmp%0#1: uint64 = (txn NumAppArgs)
+        goto tmp%0#1 ? block@2 : block@15
+    block@2: // abi_routing_L4
+        let tmp%2#0: bytes = (txna ApplicationArgs 0)
+        switch tmp%2#0 {method "acc_ret()address" => block@3, method "asset_ret()uint64" => block@4, method "app_ret()uint64" => block@5, method "store(account,application,asset)void" => block@6, method "store_apps(uint64[])void" => block@7, method "store_assets(uint64[])void" => block@8, method "store_accounts(address[])void" => block@9, method "return_apps()uint64[]" => block@10, method "return_assets()uint64[]" => block@11, method "return_accounts()address[]" => block@12, * => block@19}
+    block@3: // acc_ret_route_L5
+        let tmp%3#0: uint64 = (txn OnCompletion)
+        let tmp%4#0: bool = (! tmp%3#0)
+        (assert tmp%4#0) // OnCompletion is not NoOp
+        let tmp%5#0: uint64 = (txn ApplicationID)
+        (assert tmp%5#0) // can only call when not creating
+        let tmp%7#0: bytes[32] = test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret()
+        let tmp%8#0: bytes = (concat 0x151f7c75 tmp%7#0)
+        (log tmp%8#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        goto block@20
+    block@4: // asset_ret_route_L9
+        let tmp%9#0: uint64 = (txn OnCompletion)
+        let tmp%10#0: bool = (! tmp%9#0)
+        (assert tmp%10#0) // OnCompletion is not NoOp
+        let tmp%11#0: uint64 = (txn ApplicationID)
+        (assert tmp%11#0) // can only call when not creating
+        (log 0x151f7c7500000000000004d2)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#1: bool = 1u
+        goto block@20
+    block@5: // app_ret_route_L13
+        let tmp%14#0: uint64 = (txn OnCompletion)
+        let tmp%15#0: bool = (! tmp%14#0)
+        (assert tmp%15#0) // OnCompletion is not NoOp
+        let tmp%16#0: uint64 = (txn ApplicationID)
+        (assert tmp%16#0) // can only call when not creating
+        (log 0x151f7c7500000000000004d2)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#2: bool = 1u
+        goto block@20
+    block@6: // store_route_L17
+        let tmp%19#0: uint64 = (txn OnCompletion)
+        let tmp%20#0: bool = (! tmp%19#0)
+        (assert tmp%20#0) // OnCompletion is not NoOp
+        let tmp%21#0: uint64 = (txn ApplicationID)
+        (assert tmp%21#0) // can only call when not creating
+        let reinterpret_bytes[1]%0#0: bytes[1] = (txna ApplicationArgs 1)
+        let tmp%23#0: uint64 = (btoi reinterpret_bytes[1]%0#0)
+        let tmp%24#0: bytes[32] = ((txnas Accounts) tmp%23#0)
+        let reinterpret_bytes[1]%1#0: bytes[1] = (txna ApplicationArgs 2)
+        let tmp%25#0: uint64 = (btoi reinterpret_bytes[1]%1#0)
+        let tmp%26#0: uint64 = ((txnas Applications) tmp%25#0)
+        let reinterpret_bytes[1]%2#0: bytes[1] = (txna ApplicationArgs 3)
+        let tmp%27#0: uint64 = (btoi reinterpret_bytes[1]%2#0)
+        let tmp%28#0: uint64 = ((txnas Assets) tmp%27#0)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store(tmp%24#0, tmp%26#0, tmp%28#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#3: bool = 1u
+        goto block@20
+    block@7: // store_apps_route_L23
+        let tmp%29#0: uint64 = (txn OnCompletion)
+        let tmp%30#0: bool = (! tmp%29#0)
+        (assert tmp%30#0) // OnCompletion is not NoOp
+        let tmp%31#0: uint64 = (txn ApplicationID)
+        (assert tmp%31#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%0#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(reinterpret_encoded_uint64[]%0#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#4: bool = 1u
+        goto block@20
+    block@8: // store_assets_route_L27
+        let tmp%33#0: uint64 = (txn OnCompletion)
+        let tmp%34#0: bool = (! tmp%33#0)
+        (assert tmp%34#0) // OnCompletion is not NoOp
+        let tmp%35#0: uint64 = (txn ApplicationID)
+        (assert tmp%35#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%1#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(reinterpret_encoded_uint64[]%1#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#5: bool = 1u
+        goto block@20
+    block@9: // store_accounts_route_L31
+        let tmp%37#0: uint64 = (txn OnCompletion)
+        let tmp%38#0: bool = (! tmp%37#0)
+        (assert tmp%38#0) // OnCompletion is not NoOp
+        let tmp%39#0: uint64 = (txn ApplicationID)
+        (assert tmp%39#0) // can only call when not creating
+        let reinterpret_bytes[32][]%0#0: bytes[32][] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(reinterpret_bytes[32][]%0#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#6: bool = 1u
+        goto block@20
+    block@10: // return_apps_route_L35
+        let tmp%41#0: uint64 = (txn OnCompletion)
+        let tmp%42#0: bool = (! tmp%41#0)
+        (assert tmp%42#0) // OnCompletion is not NoOp
+        let tmp%43#0: uint64 = (txn ApplicationID)
+        (assert tmp%43#0) // can only call when not creating
+        let tmp%45#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_apps()
+        let tmp%46#0: bytes = (concat 0x151f7c75 tmp%45#0)
+        (log tmp%46#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#7: bool = 1u
+        goto block@20
+    block@11: // return_assets_route_L39
+        let tmp%47#0: uint64 = (txn OnCompletion)
+        let tmp%48#0: bool = (! tmp%47#0)
+        (assert tmp%48#0) // OnCompletion is not NoOp
+        let tmp%49#0: uint64 = (txn ApplicationID)
+        (assert tmp%49#0) // can only call when not creating
+        let tmp%51#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_assets()
+        let tmp%52#0: bytes = (concat 0x151f7c75 tmp%51#0)
+        (log tmp%52#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#8: bool = 1u
+        goto block@20
+    block@12: // return_accounts_route_L43
+        let tmp%53#0: uint64 = (txn OnCompletion)
+        let tmp%54#0: bool = (! tmp%53#0)
+        (assert tmp%54#0) // OnCompletion is not NoOp
+        let tmp%55#0: uint64 = (txn ApplicationID)
+        (assert tmp%55#0) // can only call when not creating
+        let tmp%57#0: bytes[32][] = test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts()
+        let tmp%58#0: bytes = (concat 0x151f7c75 tmp%57#0)
+        (log tmp%58#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#9: bool = 1u
+        goto block@20
+    block@15: // bare_routing_L4
+        let tmp%59#0: uint64 = (txn OnCompletion)
+        goto tmp%59#0 ? block@19 : block@16
+    block@16: // __algopy_default_create_L1
+        let tmp%60#0: uint64 = (txn ApplicationID)
+        let tmp%61#0: bool = (! tmp%60#0)
+        (assert tmp%61#0) // can only call when creating
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#10: bool = 1u
+        goto block@20
+    block@19: // after_if_else_L4
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#11: bool = 0u
+        goto block@20
+    block@20: // after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router___L1
+        let tmp%0#0: bool = φ(test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 <- block@3, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#1 <- block@4, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#2 <- block@5, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#3 <- block@6, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#4 <- block@7, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#5 <- block@8, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#6 <- block@9, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#7 <- block@10, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#8 <- block@11, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#9 <- block@12, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#10 <- block@16, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#11 <- block@19)
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes[32]:
+    block@0: // L5
+        let tmp%0#0: bytes[32] = (txn Sender)
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes[32], app: uint64, asset: uint64) -> void:
+    block@0: // L17
+        (app_global_put "acc" acc#0)
+        (app_global_put "asset" asset#0)
+        (app_global_put "app" app#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: encoded_uint64[]) -> void:
+    block@0: // L23
+        (app_global_put "apps" apps#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: encoded_uint64[]) -> void:
+    block@0: // L27
+        (app_global_put "assets" assets#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes[32][]) -> void:
+    block@0: // L31
+        (app_global_put "accounts" accounts#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> encoded_uint64[]:
+    block@0: // L35
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "apps")
+        (assert maybe_exists%0#0) // check self.apps exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> encoded_uint64[]:
+    block@0: // L39
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "assets")
+        (assert maybe_exists%0#0) // check self.assets exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes[32][]:
+    block@0: // L43
+        let (maybe_value%0#0: bytes[32][], maybe_exists%0#0: bool) = (app_global_get_ex 0u "accounts")
+        (assert maybe_exists%0#0) // check self.accounts exists
+        return maybe_value%0#0

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.5.ssa.slot.ir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.5.ssa.slot.ir
@@ -1,0 +1,177 @@
+main algopy.arc4.ARC4Contract.approval_program:
+    block@0: // L1
+        let tmp%0#1: uint64 = (txn NumAppArgs)
+        goto tmp%0#1 ? block@2 : block@15
+    block@2: // abi_routing_L4
+        let tmp%2#0: bytes = (txna ApplicationArgs 0)
+        switch tmp%2#0 {method "acc_ret()address" => block@3, method "asset_ret()uint64" => block@4, method "app_ret()uint64" => block@5, method "store(account,application,asset)void" => block@6, method "store_apps(uint64[])void" => block@7, method "store_assets(uint64[])void" => block@8, method "store_accounts(address[])void" => block@9, method "return_apps()uint64[]" => block@10, method "return_assets()uint64[]" => block@11, method "return_accounts()address[]" => block@12, * => block@19}
+    block@3: // acc_ret_route_L5
+        let tmp%3#0: uint64 = (txn OnCompletion)
+        let tmp%4#0: bool = (! tmp%3#0)
+        (assert tmp%4#0) // OnCompletion is not NoOp
+        let tmp%5#0: uint64 = (txn ApplicationID)
+        (assert tmp%5#0) // can only call when not creating
+        let tmp%7#0: bytes[32] = test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret()
+        let tmp%8#0: bytes = (concat 0x151f7c75 tmp%7#0)
+        (log tmp%8#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        goto block@20
+    block@4: // asset_ret_route_L9
+        let tmp%9#0: uint64 = (txn OnCompletion)
+        let tmp%10#0: bool = (! tmp%9#0)
+        (assert tmp%10#0) // OnCompletion is not NoOp
+        let tmp%11#0: uint64 = (txn ApplicationID)
+        (assert tmp%11#0) // can only call when not creating
+        (log 0x151f7c7500000000000004d2)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#1: bool = 1u
+        goto block@20
+    block@5: // app_ret_route_L13
+        let tmp%14#0: uint64 = (txn OnCompletion)
+        let tmp%15#0: bool = (! tmp%14#0)
+        (assert tmp%15#0) // OnCompletion is not NoOp
+        let tmp%16#0: uint64 = (txn ApplicationID)
+        (assert tmp%16#0) // can only call when not creating
+        (log 0x151f7c7500000000000004d2)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#2: bool = 1u
+        goto block@20
+    block@6: // store_route_L17
+        let tmp%19#0: uint64 = (txn OnCompletion)
+        let tmp%20#0: bool = (! tmp%19#0)
+        (assert tmp%20#0) // OnCompletion is not NoOp
+        let tmp%21#0: uint64 = (txn ApplicationID)
+        (assert tmp%21#0) // can only call when not creating
+        let reinterpret_bytes[1]%0#0: bytes[1] = (txna ApplicationArgs 1)
+        let tmp%23#0: uint64 = (btoi reinterpret_bytes[1]%0#0)
+        let tmp%24#0: bytes[32] = ((txnas Accounts) tmp%23#0)
+        let reinterpret_bytes[1]%1#0: bytes[1] = (txna ApplicationArgs 2)
+        let tmp%25#0: uint64 = (btoi reinterpret_bytes[1]%1#0)
+        let tmp%26#0: uint64 = ((txnas Applications) tmp%25#0)
+        let reinterpret_bytes[1]%2#0: bytes[1] = (txna ApplicationArgs 3)
+        let tmp%27#0: uint64 = (btoi reinterpret_bytes[1]%2#0)
+        let tmp%28#0: uint64 = ((txnas Assets) tmp%27#0)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store(tmp%24#0, tmp%26#0, tmp%28#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#3: bool = 1u
+        goto block@20
+    block@7: // store_apps_route_L23
+        let tmp%29#0: uint64 = (txn OnCompletion)
+        let tmp%30#0: bool = (! tmp%29#0)
+        (assert tmp%30#0) // OnCompletion is not NoOp
+        let tmp%31#0: uint64 = (txn ApplicationID)
+        (assert tmp%31#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%0#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(reinterpret_encoded_uint64[]%0#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#4: bool = 1u
+        goto block@20
+    block@8: // store_assets_route_L27
+        let tmp%33#0: uint64 = (txn OnCompletion)
+        let tmp%34#0: bool = (! tmp%33#0)
+        (assert tmp%34#0) // OnCompletion is not NoOp
+        let tmp%35#0: uint64 = (txn ApplicationID)
+        (assert tmp%35#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%1#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(reinterpret_encoded_uint64[]%1#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#5: bool = 1u
+        goto block@20
+    block@9: // store_accounts_route_L31
+        let tmp%37#0: uint64 = (txn OnCompletion)
+        let tmp%38#0: bool = (! tmp%37#0)
+        (assert tmp%38#0) // OnCompletion is not NoOp
+        let tmp%39#0: uint64 = (txn ApplicationID)
+        (assert tmp%39#0) // can only call when not creating
+        let reinterpret_bytes[32][]%0#0: bytes[32][] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(reinterpret_bytes[32][]%0#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#6: bool = 1u
+        goto block@20
+    block@10: // return_apps_route_L35
+        let tmp%41#0: uint64 = (txn OnCompletion)
+        let tmp%42#0: bool = (! tmp%41#0)
+        (assert tmp%42#0) // OnCompletion is not NoOp
+        let tmp%43#0: uint64 = (txn ApplicationID)
+        (assert tmp%43#0) // can only call when not creating
+        let tmp%45#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_apps()
+        let tmp%46#0: bytes = (concat 0x151f7c75 tmp%45#0)
+        (log tmp%46#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#7: bool = 1u
+        goto block@20
+    block@11: // return_assets_route_L39
+        let tmp%47#0: uint64 = (txn OnCompletion)
+        let tmp%48#0: bool = (! tmp%47#0)
+        (assert tmp%48#0) // OnCompletion is not NoOp
+        let tmp%49#0: uint64 = (txn ApplicationID)
+        (assert tmp%49#0) // can only call when not creating
+        let tmp%51#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_assets()
+        let tmp%52#0: bytes = (concat 0x151f7c75 tmp%51#0)
+        (log tmp%52#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#8: bool = 1u
+        goto block@20
+    block@12: // return_accounts_route_L43
+        let tmp%53#0: uint64 = (txn OnCompletion)
+        let tmp%54#0: bool = (! tmp%53#0)
+        (assert tmp%54#0) // OnCompletion is not NoOp
+        let tmp%55#0: uint64 = (txn ApplicationID)
+        (assert tmp%55#0) // can only call when not creating
+        let tmp%57#0: bytes[32][] = test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts()
+        let tmp%58#0: bytes = (concat 0x151f7c75 tmp%57#0)
+        (log tmp%58#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#9: bool = 1u
+        goto block@20
+    block@15: // bare_routing_L4
+        let tmp%59#0: uint64 = (txn OnCompletion)
+        goto tmp%59#0 ? block@19 : block@16
+    block@16: // __algopy_default_create_L1
+        let tmp%60#0: uint64 = (txn ApplicationID)
+        let tmp%61#0: bool = (! tmp%60#0)
+        (assert tmp%61#0) // can only call when creating
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#10: bool = 1u
+        goto block@20
+    block@19: // after_if_else_L4
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#11: bool = 0u
+        goto block@20
+    block@20: // after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router___L1
+        let tmp%0#0: bool = φ(test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 <- block@3, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#1 <- block@4, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#2 <- block@5, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#3 <- block@6, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#4 <- block@7, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#5 <- block@8, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#6 <- block@9, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#7 <- block@10, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#8 <- block@11, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#9 <- block@12, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#10 <- block@16, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#11 <- block@19)
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes[32]:
+    block@0: // L5
+        let tmp%0#0: bytes[32] = (txn Sender)
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes[32], app: uint64, asset: uint64) -> void:
+    block@0: // L17
+        (app_global_put "acc" acc#0)
+        (app_global_put "asset" asset#0)
+        (app_global_put "app" app#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: encoded_uint64[]) -> void:
+    block@0: // L23
+        (app_global_put "apps" apps#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: encoded_uint64[]) -> void:
+    block@0: // L27
+        (app_global_put "assets" assets#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes[32][]) -> void:
+    block@0: // L31
+        (app_global_put "accounts" accounts#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> encoded_uint64[]:
+    block@0: // L35
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "apps")
+        (assert maybe_exists%0#0) // check self.apps exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> encoded_uint64[]:
+    block@0: // L39
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "assets")
+        (assert maybe_exists%0#0) // check self.assets exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes[32][]:
+    block@0: // L43
+        let (maybe_value%0#0: bytes[32][], maybe_exists%0#0: bool) = (app_global_get_ex 0u "accounts")
+        (assert maybe_exists%0#0) // check self.accounts exists
+        return maybe_value%0#0

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.6.destructured.ir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.6.destructured.ir
@@ -1,0 +1,188 @@
+main algopy.arc4.ARC4Contract.approval_program:
+    block@0: // L1
+        let tmp%0#1: uint64 = (txn NumAppArgs)
+        goto tmp%0#1 ? block@2 : block@15
+    block@2: // abi_routing_L4
+        let tmp%2#0: bytes = (txna ApplicationArgs 0)
+        switch tmp%2#0 {method "acc_ret()address" => block@3, method "asset_ret()uint64" => block@4, method "app_ret()uint64" => block@5, method "store(account,application,asset)void" => block@6, method "store_apps(uint64[])void" => block@7, method "store_assets(uint64[])void" => block@8, method "store_accounts(address[])void" => block@9, method "return_apps()uint64[]" => block@10, method "return_assets()uint64[]" => block@11, method "return_accounts()address[]" => block@12, * => block@19}
+    block@3: // acc_ret_route_L5
+        let tmp%3#0: uint64 = (txn OnCompletion)
+        let tmp%4#0: bool = (! tmp%3#0)
+        (assert tmp%4#0) // OnCompletion is not NoOp
+        let tmp%5#0: uint64 = (txn ApplicationID)
+        (assert tmp%5#0) // can only call when not creating
+        let tmp%7#0: bytes[32] = test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret()
+        let tmp%8#0: bytes = (concat 0x151f7c75 tmp%7#0)
+        (log tmp%8#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@4: // asset_ret_route_L9
+        let tmp%9#0: uint64 = (txn OnCompletion)
+        let tmp%10#0: bool = (! tmp%9#0)
+        (assert tmp%10#0) // OnCompletion is not NoOp
+        let tmp%11#0: uint64 = (txn ApplicationID)
+        (assert tmp%11#0) // can only call when not creating
+        (log 0x151f7c7500000000000004d2)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@5: // app_ret_route_L13
+        let tmp%14#0: uint64 = (txn OnCompletion)
+        let tmp%15#0: bool = (! tmp%14#0)
+        (assert tmp%15#0) // OnCompletion is not NoOp
+        let tmp%16#0: uint64 = (txn ApplicationID)
+        (assert tmp%16#0) // can only call when not creating
+        (log 0x151f7c7500000000000004d2)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@6: // store_route_L17
+        let tmp%19#0: uint64 = (txn OnCompletion)
+        let tmp%20#0: bool = (! tmp%19#0)
+        (assert tmp%20#0) // OnCompletion is not NoOp
+        let tmp%21#0: uint64 = (txn ApplicationID)
+        (assert tmp%21#0) // can only call when not creating
+        let reinterpret_bytes[1]%0#0: bytes[1] = (txna ApplicationArgs 1)
+        let tmp%23#0: uint64 = (btoi reinterpret_bytes[1]%0#0)
+        let tmp%24#0: bytes[32] = ((txnas Accounts) tmp%23#0)
+        let reinterpret_bytes[1]%1#0: bytes[1] = (txna ApplicationArgs 2)
+        let tmp%25#0: uint64 = (btoi reinterpret_bytes[1]%1#0)
+        let tmp%26#0: uint64 = ((txnas Applications) tmp%25#0)
+        let reinterpret_bytes[1]%2#0: bytes[1] = (txna ApplicationArgs 3)
+        let tmp%27#0: uint64 = (btoi reinterpret_bytes[1]%2#0)
+        let tmp%28#0: uint64 = ((txnas Assets) tmp%27#0)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store(tmp%24#0, tmp%26#0, tmp%28#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@7: // store_apps_route_L23
+        let tmp%29#0: uint64 = (txn OnCompletion)
+        let tmp%30#0: bool = (! tmp%29#0)
+        (assert tmp%30#0) // OnCompletion is not NoOp
+        let tmp%31#0: uint64 = (txn ApplicationID)
+        (assert tmp%31#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%0#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(reinterpret_encoded_uint64[]%0#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@8: // store_assets_route_L27
+        let tmp%33#0: uint64 = (txn OnCompletion)
+        let tmp%34#0: bool = (! tmp%33#0)
+        (assert tmp%34#0) // OnCompletion is not NoOp
+        let tmp%35#0: uint64 = (txn ApplicationID)
+        (assert tmp%35#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%1#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(reinterpret_encoded_uint64[]%1#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@9: // store_accounts_route_L31
+        let tmp%37#0: uint64 = (txn OnCompletion)
+        let tmp%38#0: bool = (! tmp%37#0)
+        (assert tmp%38#0) // OnCompletion is not NoOp
+        let tmp%39#0: uint64 = (txn ApplicationID)
+        (assert tmp%39#0) // can only call when not creating
+        let reinterpret_bytes[32][]%0#0: bytes[32][] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(reinterpret_bytes[32][]%0#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@10: // return_apps_route_L35
+        let tmp%41#0: uint64 = (txn OnCompletion)
+        let tmp%42#0: bool = (! tmp%41#0)
+        (assert tmp%42#0) // OnCompletion is not NoOp
+        let tmp%43#0: uint64 = (txn ApplicationID)
+        (assert tmp%43#0) // can only call when not creating
+        let tmp%45#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_apps()
+        let tmp%46#0: bytes = (concat 0x151f7c75 tmp%45#0)
+        (log tmp%46#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@11: // return_assets_route_L39
+        let tmp%47#0: uint64 = (txn OnCompletion)
+        let tmp%48#0: bool = (! tmp%47#0)
+        (assert tmp%48#0) // OnCompletion is not NoOp
+        let tmp%49#0: uint64 = (txn ApplicationID)
+        (assert tmp%49#0) // can only call when not creating
+        let tmp%51#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_assets()
+        let tmp%52#0: bytes = (concat 0x151f7c75 tmp%51#0)
+        (log tmp%52#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@12: // return_accounts_route_L43
+        let tmp%53#0: uint64 = (txn OnCompletion)
+        let tmp%54#0: bool = (! tmp%53#0)
+        (assert tmp%54#0) // OnCompletion is not NoOp
+        let tmp%55#0: uint64 = (txn ApplicationID)
+        (assert tmp%55#0) // can only call when not creating
+        let tmp%57#0: bytes[32][] = test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts()
+        let tmp%58#0: bytes = (concat 0x151f7c75 tmp%57#0)
+        (log tmp%58#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@15: // bare_routing_L4
+        let tmp%59#0: uint64 = (txn OnCompletion)
+        goto tmp%59#0 ? block@19 : block@16
+    block@16: // __algopy_default_create_L1
+        let tmp%60#0: uint64 = (txn ApplicationID)
+        let tmp%61#0: bool = (! tmp%60#0)
+        (assert tmp%61#0) // can only call when creating
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@19: // after_if_else_L4
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 0u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@20: // after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router___L1
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes[32]:
+    block@0: // L5
+        let tmp%0#0: bytes[32] = (txn Sender)
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes[32], app: uint64, asset: uint64) -> void:
+    block@0: // L17
+        (app_global_put "acc" acc#0)
+        (app_global_put "asset" asset#0)
+        (app_global_put "app" app#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: encoded_uint64[]) -> void:
+    block@0: // L23
+        (app_global_put "apps" apps#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: encoded_uint64[]) -> void:
+    block@0: // L27
+        (app_global_put "assets" assets#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes[32][]) -> void:
+    block@0: // L31
+        (app_global_put "accounts" accounts#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> encoded_uint64[]:
+    block@0: // L35
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "apps")
+        (assert maybe_exists%0#0) // check self.apps exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> encoded_uint64[]:
+    block@0: // L39
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "assets")
+        (assert maybe_exists%0#0) // check self.assets exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes[32][]:
+    block@0: // L43
+        let (maybe_value%0#0: bytes[32][], maybe_exists%0#0: bool) = (app_global_get_ex 0u "accounts")
+        (assert maybe_exists%0#0) // check self.accounts exists
+        return maybe_value%0#0

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.7.lstack.mir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.7.lstack.mir
@@ -1,0 +1,408 @@
+// Op                                                                                                 Stack (out)
+// algopy.arc4.ARC4Contract.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txn NumAppArgs                                                                                tmp%0#1
+        l-load tmp%0#1 0                                                                              tmp%0#1
+        bz main_bare_routing@15 ; b main_abi_routing@2
+
+    main_abi_routing@2:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 0                                                                        tmp%2#0
+        method acc_ret()address                                                                       tmp%2#0,Method(acc_ret()address)
+        method asset_ret()uint64                                                                      tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64)
+        method app_ret()uint64                                                                        tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64)
+        method store(account,application,asset)void                                                   tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void)
+        method store_apps(uint64[])void                                                               tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void)
+        method store_assets(uint64[])void                                                             tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void)
+        method store_accounts(address[])void                                                          tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void)
+        method return_apps()uint64[]                                                                  tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[])
+        method return_assets()uint64[]                                                                tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[])
+        method return_accounts()address[]                                                             tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[]),Method(return_accounts()address[])
+        l-load tmp%2#0 10                                                                             Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[]),Method(return_accounts()address[]),tmp%2#0
+        match main_acc_ret_route@3 main_asset_ret_route@4 main_app_ret_route@5 main_store_route@6 main_store_apps_route@7 main_store_assets_route@8 main_store_accounts_route@9 main_return_apps_route@10 main_return_assets_route@11 main_return_accounts_route@12 ; b main_after_if_else@19 
+
+    main_acc_ret_route@3:
+        // arc4_conversions/reference.py:5
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%3#0
+        l-load tmp%3#0 0                                                                              tmp%3#0
+        !                                                                                             tmp%4#0
+        l-load tmp%4#0 0                                                                              tmp%4#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%5#0
+        l-load tmp%5#0 0                                                                              tmp%5#0
+        assert // can only call when not creating
+        callsub acc_ret                                                                               tmp%7#0
+        byte 0x151f7c75                                                                               tmp%7#0,0x151f7c75
+        l-load tmp%7#0 1                                                                              0x151f7c75,tmp%7#0
+        concat                                                                                        tmp%8#0
+        l-load tmp%8#0 0                                                                              tmp%8#0
+        log
+        int 1                                                                                         1
+        l-store test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_asset_ret_route@4:
+        // arc4_conversions/reference.py:9
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%9#0
+        l-load tmp%9#0 0                                                                              tmp%9#0
+        !                                                                                             tmp%10#0
+        l-load tmp%10#0 0                                                                             tmp%10#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%11#0
+        l-load tmp%11#0 0                                                                             tmp%11#0
+        assert // can only call when not creating
+        byte 0x151f7c7500000000000004d2                                                               0x151f7c7500000000000004d2
+        log
+        int 1                                                                                         1
+        l-store test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_app_ret_route@5:
+        // arc4_conversions/reference.py:13
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%14#0
+        l-load tmp%14#0 0                                                                             tmp%14#0
+        !                                                                                             tmp%15#0
+        l-load tmp%15#0 0                                                                             tmp%15#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%16#0
+        l-load tmp%16#0 0                                                                             tmp%16#0
+        assert // can only call when not creating
+        byte 0x151f7c7500000000000004d2                                                               0x151f7c7500000000000004d2
+        log
+        int 1                                                                                         1
+        l-store test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_store_route@6:
+        // arc4_conversions/reference.py:17
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%19#0
+        l-load tmp%19#0 0                                                                             tmp%19#0
+        !                                                                                             tmp%20#0
+        l-load tmp%20#0 0                                                                             tmp%20#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%21#0
+        l-load tmp%21#0 0                                                                             tmp%21#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_bytes[1]%0#0
+        l-load reinterpret_bytes[1]%0#0 0                                                             reinterpret_bytes[1]%0#0
+        btoi                                                                                          tmp%23#0
+        l-load tmp%23#0 0                                                                             tmp%23#0
+        txnas Accounts                                                                                tmp%24#0
+        txna ApplicationArgs 2                                                                        tmp%24#0,reinterpret_bytes[1]%1#0
+        l-load reinterpret_bytes[1]%1#0 0                                                             tmp%24#0,reinterpret_bytes[1]%1#0
+        btoi                                                                                          tmp%24#0,tmp%25#0
+        l-load tmp%25#0 0                                                                             tmp%24#0,tmp%25#0
+        txnas Applications                                                                            tmp%24#0,tmp%26#0
+        txna ApplicationArgs 3                                                                        tmp%24#0,tmp%26#0,reinterpret_bytes[1]%2#0
+        l-load reinterpret_bytes[1]%2#0 0                                                             tmp%24#0,tmp%26#0,reinterpret_bytes[1]%2#0
+        btoi                                                                                          tmp%24#0,tmp%26#0,tmp%27#0
+        l-load tmp%27#0 0                                                                             tmp%24#0,tmp%26#0,tmp%27#0
+        txnas Assets                                                                                  tmp%24#0,tmp%26#0,tmp%28#0
+        // arc4_conversions/reference.py:17
+        // @arc4.abimethod
+        l-load tmp%24#0 2                                                                             tmp%26#0,tmp%28#0,tmp%24#0
+        l-load tmp%26#0 2                                                                             tmp%28#0,tmp%24#0,tmp%26#0
+        l-load tmp%28#0 2                                                                             tmp%24#0,tmp%26#0,tmp%28#0
+        callsub store
+        int 1                                                                                         1
+        l-store test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_store_apps_route@7:
+        // arc4_conversions/reference.py:23
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%29#0
+        l-load tmp%29#0 0                                                                             tmp%29#0
+        !                                                                                             tmp%30#0
+        l-load tmp%30#0 0                                                                             tmp%30#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%31#0
+        l-load tmp%31#0 0                                                                             tmp%31#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_encoded_uint64[]%0#0
+        // arc4_conversions/reference.py:23
+        // @arc4.abimethod
+        l-load reinterpret_encoded_uint64[]%0#0 0                                                     reinterpret_encoded_uint64[]%0#0
+        callsub store_apps
+        int 1                                                                                         1
+        l-store test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_store_assets_route@8:
+        // arc4_conversions/reference.py:27
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%33#0
+        l-load tmp%33#0 0                                                                             tmp%33#0
+        !                                                                                             tmp%34#0
+        l-load tmp%34#0 0                                                                             tmp%34#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%35#0
+        l-load tmp%35#0 0                                                                             tmp%35#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_encoded_uint64[]%1#0
+        // arc4_conversions/reference.py:27
+        // @arc4.abimethod
+        l-load reinterpret_encoded_uint64[]%1#0 0                                                     reinterpret_encoded_uint64[]%1#0
+        callsub store_assets
+        int 1                                                                                         1
+        l-store test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_store_accounts_route@9:
+        // arc4_conversions/reference.py:31
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%37#0
+        l-load tmp%37#0 0                                                                             tmp%37#0
+        !                                                                                             tmp%38#0
+        l-load tmp%38#0 0                                                                             tmp%38#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%39#0
+        l-load tmp%39#0 0                                                                             tmp%39#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_bytes[32][]%0#0
+        // arc4_conversions/reference.py:31
+        // @arc4.abimethod
+        l-load reinterpret_bytes[32][]%0#0 0                                                          reinterpret_bytes[32][]%0#0
+        callsub store_accounts
+        int 1                                                                                         1
+        l-store test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_return_apps_route@10:
+        // arc4_conversions/reference.py:35
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%41#0
+        l-load tmp%41#0 0                                                                             tmp%41#0
+        !                                                                                             tmp%42#0
+        l-load tmp%42#0 0                                                                             tmp%42#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%43#0
+        l-load tmp%43#0 0                                                                             tmp%43#0
+        assert // can only call when not creating
+        callsub return_apps                                                                           tmp%45#0
+        byte 0x151f7c75                                                                               tmp%45#0,0x151f7c75
+        l-load tmp%45#0 1                                                                             0x151f7c75,tmp%45#0
+        concat                                                                                        tmp%46#0
+        l-load tmp%46#0 0                                                                             tmp%46#0
+        log
+        int 1                                                                                         1
+        l-store test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_return_assets_route@11:
+        // arc4_conversions/reference.py:39
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%47#0
+        l-load tmp%47#0 0                                                                             tmp%47#0
+        !                                                                                             tmp%48#0
+        l-load tmp%48#0 0                                                                             tmp%48#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%49#0
+        l-load tmp%49#0 0                                                                             tmp%49#0
+        assert // can only call when not creating
+        callsub return_assets                                                                         tmp%51#0
+        byte 0x151f7c75                                                                               tmp%51#0,0x151f7c75
+        l-load tmp%51#0 1                                                                             0x151f7c75,tmp%51#0
+        concat                                                                                        tmp%52#0
+        l-load tmp%52#0 0                                                                             tmp%52#0
+        log
+        int 1                                                                                         1
+        l-store test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_return_accounts_route@12:
+        // arc4_conversions/reference.py:43
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%53#0
+        l-load tmp%53#0 0                                                                             tmp%53#0
+        !                                                                                             tmp%54#0
+        l-load tmp%54#0 0                                                                             tmp%54#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%55#0
+        l-load tmp%55#0 0                                                                             tmp%55#0
+        assert // can only call when not creating
+        callsub return_accounts                                                                       tmp%57#0
+        byte 0x151f7c75                                                                               tmp%57#0,0x151f7c75
+        l-load tmp%57#0 1                                                                             0x151f7c75,tmp%57#0
+        concat                                                                                        tmp%58#0
+        l-load tmp%58#0 0                                                                             tmp%58#0
+        log
+        int 1                                                                                         1
+        l-store test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_bare_routing@15:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txn OnCompletion                                                                              tmp%59#0
+        l-load tmp%59#0 0                                                                             tmp%59#0
+        bz main___algopy_default_create@16 ; b main_after_if_else@19
+
+    main___algopy_default_create@16:
+        txn ApplicationID                                                                             tmp%60#0
+        l-load tmp%60#0 0                                                                             tmp%60#0
+        !                                                                                             tmp%61#0
+        l-load tmp%61#0 0                                                                             tmp%61#0
+        assert // can only call when creating
+        int 1                                                                                         1
+        l-store test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_after_if_else@19:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        int 0                                                                                         0
+        l-store test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0 test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20:
+        v-load tmp%0#0                                                                                tmp%0#0
+        return
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes:
+subroutine acc_ret:
+    acc_ret_block@0:
+        // arc4_conversions/reference.py:7
+        // return Txn.sender
+        txn Sender                                                                                    tmp%0#0
+        l-load tmp%0#0 0                                                                              tmp%0#0
+        retsub                                                                                        tmp%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes, app: uint64, asset: uint64) -> void:
+subroutine store:
+    store_block@0:                                                                                    (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:19
+        // self.acc = acc
+        byte "acc"                                                                                    (𝕡) acc#0,app#0,asset#0 | "acc"
+        p-load acc#0                                                                                  (𝕡) acc#0,app#0,asset#0 | "acc",acc#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:20
+        // self.asset = asset
+        byte "asset"                                                                                  (𝕡) acc#0,app#0,asset#0 | "asset"
+        p-load asset#0                                                                                (𝕡) acc#0,app#0,asset#0 | "asset",asset#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:21
+        // self.app = app
+        byte "app"                                                                                    (𝕡) acc#0,app#0,asset#0 | "app"
+        p-load app#0                                                                                  (𝕡) acc#0,app#0,asset#0 | "app",app#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: bytes) -> void:
+subroutine store_apps:
+    store_apps_block@0:                                                                               (𝕡) apps#0 |
+        // arc4_conversions/reference.py:25
+        // self.apps = apps
+        byte "apps"                                                                                   (𝕡) apps#0 | "apps"
+        p-load apps#0                                                                                 (𝕡) apps#0 | "apps",apps#0 (copy)
+        app_global_put                                                                                (𝕡) apps#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: bytes) -> void:
+subroutine store_assets:
+    store_assets_block@0:                                                                             (𝕡) assets#0 |
+        // arc4_conversions/reference.py:29
+        // self.assets = assets
+        byte "assets"                                                                                 (𝕡) assets#0 | "assets"
+        p-load assets#0                                                                               (𝕡) assets#0 | "assets",assets#0 (copy)
+        app_global_put                                                                                (𝕡) assets#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes) -> void:
+subroutine store_accounts:
+    store_accounts_block@0:                                                                           (𝕡) accounts#0 |
+        // arc4_conversions/reference.py:33
+        // self.accounts = accounts
+        byte "accounts"                                                                               (𝕡) accounts#0 | "accounts"
+        p-load accounts#0                                                                             (𝕡) accounts#0 | "accounts",accounts#0 (copy)
+        app_global_put                                                                                (𝕡) accounts#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> bytes:
+subroutine return_apps:
+    return_apps_block@0:
+        // arc4_conversions/reference.py:37
+        // return self.apps
+        int 0                                                                                         0
+        byte "apps"                                                                                   0,"apps"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        l-load maybe_exists%0#0 0                                                                     maybe_value%0#0,maybe_exists%0#0
+        assert // check self.apps exists                                                              maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> bytes:
+subroutine return_assets:
+    return_assets_block@0:
+        // arc4_conversions/reference.py:41
+        // return self.assets
+        int 0                                                                                         0
+        byte "assets"                                                                                 0,"assets"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        l-load maybe_exists%0#0 0                                                                     maybe_value%0#0,maybe_exists%0#0
+        assert // check self.assets exists                                                            maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes:
+subroutine return_accounts:
+    return_accounts_block@0:
+        // arc4_conversions/reference.py:45
+        // return self.accounts
+        int 0                                                                                         0
+        byte "accounts"                                                                               0,"accounts"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        l-load maybe_exists%0#0 0                                                                     maybe_value%0#0,maybe_exists%0#0
+        assert // check self.accounts exists                                                          maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.8.lstack.opt.mir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.8.lstack.opt.mir
@@ -1,0 +1,333 @@
+// Op                                                                                                 Stack (out)
+// algopy.arc4.ARC4Contract.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txn NumAppArgs                                                                                tmp%0#1
+        bz main_bare_routing@15 ; b main_abi_routing@2
+
+    main_abi_routing@2:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 0                                                                        tmp%2#0
+        method acc_ret()address                                                                       tmp%2#0,Method(acc_ret()address)
+        method asset_ret()uint64                                                                      tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64)
+        method app_ret()uint64                                                                        tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64)
+        method store(account,application,asset)void                                                   tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void)
+        method store_apps(uint64[])void                                                               tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void)
+        method store_assets(uint64[])void                                                             tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void)
+        method store_accounts(address[])void                                                          tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void)
+        method return_apps()uint64[]                                                                  tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[])
+        method return_assets()uint64[]                                                                tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[])
+        method return_accounts()address[]                                                             tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[]),Method(return_accounts()address[])
+        l-load tmp%2#0 10                                                                             Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[]),Method(return_accounts()address[]),tmp%2#0
+        match main_acc_ret_route@3 main_asset_ret_route@4 main_app_ret_route@5 main_store_route@6 main_store_apps_route@7 main_store_assets_route@8 main_store_accounts_route@9 main_return_apps_route@10 main_return_assets_route@11 main_return_accounts_route@12 ; b main_after_if_else@19 
+
+    main_acc_ret_route@3:
+        // arc4_conversions/reference.py:5
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%3#0
+        !                                                                                             tmp%4#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%5#0
+        assert // can only call when not creating
+        callsub acc_ret                                                                               tmp%7#0
+        byte 0x151f7c75                                                                               tmp%7#0,0x151f7c75
+        l-load tmp%7#0 1                                                                              0x151f7c75,tmp%7#0
+        concat                                                                                        tmp%8#0
+        log
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_asset_ret_route@4:
+        // arc4_conversions/reference.py:9
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%9#0
+        !                                                                                             tmp%10#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%11#0
+        assert // can only call when not creating
+        byte 0x151f7c7500000000000004d2                                                               0x151f7c7500000000000004d2
+        log
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_app_ret_route@5:
+        // arc4_conversions/reference.py:13
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%14#0
+        !                                                                                             tmp%15#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%16#0
+        assert // can only call when not creating
+        byte 0x151f7c7500000000000004d2                                                               0x151f7c7500000000000004d2
+        log
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_store_route@6:
+        // arc4_conversions/reference.py:17
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%19#0
+        !                                                                                             tmp%20#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%21#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_bytes[1]%0#0
+        btoi                                                                                          tmp%23#0
+        txnas Accounts                                                                                tmp%24#0
+        txna ApplicationArgs 2                                                                        tmp%24#0,reinterpret_bytes[1]%1#0
+        btoi                                                                                          tmp%24#0,tmp%25#0
+        txnas Applications                                                                            tmp%24#0,tmp%26#0
+        txna ApplicationArgs 3                                                                        tmp%24#0,tmp%26#0,reinterpret_bytes[1]%2#0
+        btoi                                                                                          tmp%24#0,tmp%26#0,tmp%27#0
+        txnas Assets                                                                                  tmp%24#0,tmp%26#0,tmp%28#0
+        // arc4_conversions/reference.py:17
+        // @arc4.abimethod
+        l-load tmp%24#0 2                                                                             tmp%26#0,tmp%28#0,tmp%24#0
+        l-load tmp%26#0 2                                                                             tmp%28#0,tmp%24#0,tmp%26#0
+        l-load tmp%28#0 2                                                                             tmp%24#0,tmp%26#0,tmp%28#0
+        callsub store
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_store_apps_route@7:
+        // arc4_conversions/reference.py:23
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%29#0
+        !                                                                                             tmp%30#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%31#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_encoded_uint64[]%0#0
+        // arc4_conversions/reference.py:23
+        // @arc4.abimethod
+        callsub store_apps
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_store_assets_route@8:
+        // arc4_conversions/reference.py:27
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%33#0
+        !                                                                                             tmp%34#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%35#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_encoded_uint64[]%1#0
+        // arc4_conversions/reference.py:27
+        // @arc4.abimethod
+        callsub store_assets
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_store_accounts_route@9:
+        // arc4_conversions/reference.py:31
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%37#0
+        !                                                                                             tmp%38#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%39#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_bytes[32][]%0#0
+        // arc4_conversions/reference.py:31
+        // @arc4.abimethod
+        callsub store_accounts
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_return_apps_route@10:
+        // arc4_conversions/reference.py:35
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%41#0
+        !                                                                                             tmp%42#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%43#0
+        assert // can only call when not creating
+        callsub return_apps                                                                           tmp%45#0
+        byte 0x151f7c75                                                                               tmp%45#0,0x151f7c75
+        l-load tmp%45#0 1                                                                             0x151f7c75,tmp%45#0
+        concat                                                                                        tmp%46#0
+        log
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_return_assets_route@11:
+        // arc4_conversions/reference.py:39
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%47#0
+        !                                                                                             tmp%48#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%49#0
+        assert // can only call when not creating
+        callsub return_assets                                                                         tmp%51#0
+        byte 0x151f7c75                                                                               tmp%51#0,0x151f7c75
+        l-load tmp%51#0 1                                                                             0x151f7c75,tmp%51#0
+        concat                                                                                        tmp%52#0
+        log
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_return_accounts_route@12:
+        // arc4_conversions/reference.py:43
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%53#0
+        !                                                                                             tmp%54#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%55#0
+        assert // can only call when not creating
+        callsub return_accounts                                                                       tmp%57#0
+        byte 0x151f7c75                                                                               tmp%57#0,0x151f7c75
+        l-load tmp%57#0 1                                                                             0x151f7c75,tmp%57#0
+        concat                                                                                        tmp%58#0
+        log
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_bare_routing@15:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txn OnCompletion                                                                              tmp%59#0
+        bz main___algopy_default_create@16 ; b main_after_if_else@19
+
+    main___algopy_default_create@16:
+        txn ApplicationID                                                                             tmp%60#0
+        !                                                                                             tmp%61#0
+        assert // can only call when creating
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_after_if_else@19:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        int 0                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        v-store tmp%0#0
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 
+
+    main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20:
+        v-load tmp%0#0                                                                                tmp%0#0
+        return
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes:
+subroutine acc_ret:
+    acc_ret_block@0:
+        // arc4_conversions/reference.py:7
+        // return Txn.sender
+        txn Sender                                                                                    tmp%0#0
+        retsub                                                                                        tmp%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes, app: uint64, asset: uint64) -> void:
+subroutine store:
+    store_block@0:                                                                                    (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:19
+        // self.acc = acc
+        byte "acc"                                                                                    (𝕡) acc#0,app#0,asset#0 | "acc"
+        p-load acc#0                                                                                  (𝕡) acc#0,app#0,asset#0 | "acc",acc#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:20
+        // self.asset = asset
+        byte "asset"                                                                                  (𝕡) acc#0,app#0,asset#0 | "asset"
+        p-load asset#0                                                                                (𝕡) acc#0,app#0,asset#0 | "asset",asset#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:21
+        // self.app = app
+        byte "app"                                                                                    (𝕡) acc#0,app#0,asset#0 | "app"
+        p-load app#0                                                                                  (𝕡) acc#0,app#0,asset#0 | "app",app#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: bytes) -> void:
+subroutine store_apps:
+    store_apps_block@0:                                                                               (𝕡) apps#0 |
+        // arc4_conversions/reference.py:25
+        // self.apps = apps
+        byte "apps"                                                                                   (𝕡) apps#0 | "apps"
+        p-load apps#0                                                                                 (𝕡) apps#0 | "apps",apps#0 (copy)
+        app_global_put                                                                                (𝕡) apps#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: bytes) -> void:
+subroutine store_assets:
+    store_assets_block@0:                                                                             (𝕡) assets#0 |
+        // arc4_conversions/reference.py:29
+        // self.assets = assets
+        byte "assets"                                                                                 (𝕡) assets#0 | "assets"
+        p-load assets#0                                                                               (𝕡) assets#0 | "assets",assets#0 (copy)
+        app_global_put                                                                                (𝕡) assets#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes) -> void:
+subroutine store_accounts:
+    store_accounts_block@0:                                                                           (𝕡) accounts#0 |
+        // arc4_conversions/reference.py:33
+        // self.accounts = accounts
+        byte "accounts"                                                                               (𝕡) accounts#0 | "accounts"
+        p-load accounts#0                                                                             (𝕡) accounts#0 | "accounts",accounts#0 (copy)
+        app_global_put                                                                                (𝕡) accounts#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> bytes:
+subroutine return_apps:
+    return_apps_block@0:
+        // arc4_conversions/reference.py:37
+        // return self.apps
+        int 0                                                                                         0
+        byte "apps"                                                                                   0,"apps"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.apps exists                                                              maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> bytes:
+subroutine return_assets:
+    return_assets_block@0:
+        // arc4_conversions/reference.py:41
+        // return self.assets
+        int 0                                                                                         0
+        byte "assets"                                                                                 0,"assets"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.assets exists                                                            maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes:
+subroutine return_accounts:
+    return_accounts_block@0:
+        // arc4_conversions/reference.py:45
+        // return self.accounts
+        int 0                                                                                         0
+        byte "accounts"                                                                               0,"accounts"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.accounts exists                                                          maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.9.xstack.mir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.9.xstack.mir
@@ -1,0 +1,333 @@
+// Op                                                                                                 Stack (out)
+// algopy.arc4.ARC4Contract.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txn NumAppArgs                                                                                tmp%0#1
+        bz main_bare_routing@15 ; b main_abi_routing@2
+
+    main_abi_routing@2:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 0                                                                        tmp%2#0
+        method acc_ret()address                                                                       tmp%2#0,Method(acc_ret()address)
+        method asset_ret()uint64                                                                      tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64)
+        method app_ret()uint64                                                                        tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64)
+        method store(account,application,asset)void                                                   tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void)
+        method store_apps(uint64[])void                                                               tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void)
+        method store_assets(uint64[])void                                                             tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void)
+        method store_accounts(address[])void                                                          tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void)
+        method return_apps()uint64[]                                                                  tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[])
+        method return_assets()uint64[]                                                                tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[])
+        method return_accounts()address[]                                                             tmp%2#0,Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[]),Method(return_accounts()address[])
+        l-load tmp%2#0 10                                                                             Method(acc_ret()address),Method(asset_ret()uint64),Method(app_ret()uint64),Method(store(account,application,asset)void),Method(store_apps(uint64[])void),Method(store_assets(uint64[])void),Method(store_accounts(address[])void),Method(return_apps()uint64[]),Method(return_assets()uint64[]),Method(return_accounts()address[]),tmp%2#0
+        match main_acc_ret_route@3 main_asset_ret_route@4 main_app_ret_route@5 main_store_route@6 main_store_apps_route@7 main_store_assets_route@8 main_store_accounts_route@9 main_return_apps_route@10 main_return_assets_route@11 main_return_accounts_route@12 ; b main_after_if_else@19 
+
+    main_acc_ret_route@3:
+        // arc4_conversions/reference.py:5
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%3#0
+        !                                                                                             tmp%4#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%5#0
+        assert // can only call when not creating
+        callsub acc_ret                                                                               tmp%7#0
+        byte 0x151f7c75                                                                               tmp%7#0,0x151f7c75
+        l-load tmp%7#0 1                                                                              0x151f7c75,tmp%7#0
+        concat                                                                                        tmp%8#0
+        log
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_asset_ret_route@4:
+        // arc4_conversions/reference.py:9
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%9#0
+        !                                                                                             tmp%10#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%11#0
+        assert // can only call when not creating
+        byte 0x151f7c7500000000000004d2                                                               0x151f7c7500000000000004d2
+        log
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_app_ret_route@5:
+        // arc4_conversions/reference.py:13
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%14#0
+        !                                                                                             tmp%15#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%16#0
+        assert // can only call when not creating
+        byte 0x151f7c7500000000000004d2                                                               0x151f7c7500000000000004d2
+        log
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_route@6:
+        // arc4_conversions/reference.py:17
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%19#0
+        !                                                                                             tmp%20#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%21#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_bytes[1]%0#0
+        btoi                                                                                          tmp%23#0
+        txnas Accounts                                                                                tmp%24#0
+        txna ApplicationArgs 2                                                                        tmp%24#0,reinterpret_bytes[1]%1#0
+        btoi                                                                                          tmp%24#0,tmp%25#0
+        txnas Applications                                                                            tmp%24#0,tmp%26#0
+        txna ApplicationArgs 3                                                                        tmp%24#0,tmp%26#0,reinterpret_bytes[1]%2#0
+        btoi                                                                                          tmp%24#0,tmp%26#0,tmp%27#0
+        txnas Assets                                                                                  tmp%24#0,tmp%26#0,tmp%28#0
+        // arc4_conversions/reference.py:17
+        // @arc4.abimethod
+        l-load tmp%24#0 2                                                                             tmp%26#0,tmp%28#0,tmp%24#0
+        l-load tmp%26#0 2                                                                             tmp%28#0,tmp%24#0,tmp%26#0
+        l-load tmp%28#0 2                                                                             tmp%24#0,tmp%26#0,tmp%28#0
+        callsub store
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_apps_route@7:
+        // arc4_conversions/reference.py:23
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%29#0
+        !                                                                                             tmp%30#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%31#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_encoded_uint64[]%0#0
+        // arc4_conversions/reference.py:23
+        // @arc4.abimethod
+        callsub store_apps
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_assets_route@8:
+        // arc4_conversions/reference.py:27
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%33#0
+        !                                                                                             tmp%34#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%35#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_encoded_uint64[]%1#0
+        // arc4_conversions/reference.py:27
+        // @arc4.abimethod
+        callsub store_assets
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_store_accounts_route@9:
+        // arc4_conversions/reference.py:31
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%37#0
+        !                                                                                             tmp%38#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%39#0
+        assert // can only call when not creating
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txna ApplicationArgs 1                                                                        reinterpret_bytes[32][]%0#0
+        // arc4_conversions/reference.py:31
+        // @arc4.abimethod
+        callsub store_accounts
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_return_apps_route@10:
+        // arc4_conversions/reference.py:35
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%41#0
+        !                                                                                             tmp%42#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%43#0
+        assert // can only call when not creating
+        callsub return_apps                                                                           tmp%45#0
+        byte 0x151f7c75                                                                               tmp%45#0,0x151f7c75
+        l-load tmp%45#0 1                                                                             0x151f7c75,tmp%45#0
+        concat                                                                                        tmp%46#0
+        log
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_return_assets_route@11:
+        // arc4_conversions/reference.py:39
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%47#0
+        !                                                                                             tmp%48#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%49#0
+        assert // can only call when not creating
+        callsub return_assets                                                                         tmp%51#0
+        byte 0x151f7c75                                                                               tmp%51#0,0x151f7c75
+        l-load tmp%51#0 1                                                                             0x151f7c75,tmp%51#0
+        concat                                                                                        tmp%52#0
+        log
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_return_accounts_route@12:
+        // arc4_conversions/reference.py:43
+        // @arc4.abimethod
+        txn OnCompletion                                                                              tmp%53#0
+        !                                                                                             tmp%54#0
+        assert // OnCompletion is not NoOp
+        txn ApplicationID                                                                             tmp%55#0
+        assert // can only call when not creating
+        callsub return_accounts                                                                       tmp%57#0
+        byte 0x151f7c75                                                                               tmp%57#0,0x151f7c75
+        l-load tmp%57#0 1                                                                             0x151f7c75,tmp%57#0
+        concat                                                                                        tmp%58#0
+        log
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_bare_routing@15:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        txn OnCompletion                                                                              tmp%59#0
+        bz main___algopy_default_create@16 ; b main_after_if_else@19
+
+    main___algopy_default_create@16:
+        txn ApplicationID                                                                             tmp%60#0
+        !                                                                                             tmp%61#0
+        assert // can only call when creating
+        int 1                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_after_if_else@19:
+        // arc4_conversions/reference.py:4
+        // class ReferenceReturn(arc4.ARC4Contract):
+        int 0                                                                                         test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        x-store tmp%0#0                                                                               (𝕏) tmp%0#0 |
+        b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 (𝕏) tmp%0#0 | 
+
+    main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: (𝕏) tmp%0#0 |
+        x-load tmp%0#0                                                                                tmp%0#0
+        return
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes:
+subroutine acc_ret:
+    acc_ret_block@0:
+        // arc4_conversions/reference.py:7
+        // return Txn.sender
+        txn Sender                                                                                    tmp%0#0
+        retsub                                                                                        tmp%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes, app: uint64, asset: uint64) -> void:
+subroutine store:
+    store_block@0:                                                                                    (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:19
+        // self.acc = acc
+        byte "acc"                                                                                    (𝕡) acc#0,app#0,asset#0 | "acc"
+        p-load acc#0                                                                                  (𝕡) acc#0,app#0,asset#0 | "acc",acc#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:20
+        // self.asset = asset
+        byte "asset"                                                                                  (𝕡) acc#0,app#0,asset#0 | "asset"
+        p-load asset#0                                                                                (𝕡) acc#0,app#0,asset#0 | "asset",asset#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        // arc4_conversions/reference.py:21
+        // self.app = app
+        byte "app"                                                                                    (𝕡) acc#0,app#0,asset#0 | "app"
+        p-load app#0                                                                                  (𝕡) acc#0,app#0,asset#0 | "app",app#0 (copy)
+        app_global_put                                                                                (𝕡) acc#0,app#0,asset#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: bytes) -> void:
+subroutine store_apps:
+    store_apps_block@0:                                                                               (𝕡) apps#0 |
+        // arc4_conversions/reference.py:25
+        // self.apps = apps
+        byte "apps"                                                                                   (𝕡) apps#0 | "apps"
+        p-load apps#0                                                                                 (𝕡) apps#0 | "apps",apps#0 (copy)
+        app_global_put                                                                                (𝕡) apps#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: bytes) -> void:
+subroutine store_assets:
+    store_assets_block@0:                                                                             (𝕡) assets#0 |
+        // arc4_conversions/reference.py:29
+        // self.assets = assets
+        byte "assets"                                                                                 (𝕡) assets#0 | "assets"
+        p-load assets#0                                                                               (𝕡) assets#0 | "assets",assets#0 (copy)
+        app_global_put                                                                                (𝕡) assets#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes) -> void:
+subroutine store_accounts:
+    store_accounts_block@0:                                                                           (𝕡) accounts#0 |
+        // arc4_conversions/reference.py:33
+        // self.accounts = accounts
+        byte "accounts"                                                                               (𝕡) accounts#0 | "accounts"
+        p-load accounts#0                                                                             (𝕡) accounts#0 | "accounts",accounts#0 (copy)
+        app_global_put                                                                                (𝕡) accounts#0 |
+        retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> bytes:
+subroutine return_apps:
+    return_apps_block@0:
+        // arc4_conversions/reference.py:37
+        // return self.apps
+        int 0                                                                                         0
+        byte "apps"                                                                                   0,"apps"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.apps exists                                                              maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> bytes:
+subroutine return_assets:
+    return_assets_block@0:
+        // arc4_conversions/reference.py:41
+        // return self.assets
+        int 0                                                                                         0
+        byte "assets"                                                                                 0,"assets"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.assets exists                                                            maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes:
+subroutine return_accounts:
+    return_accounts_block@0:
+        // arc4_conversions/reference.py:45
+        // return self.accounts
+        int 0                                                                                         0
+        byte "accounts"                                                                               0,"accounts"
+        app_global_get_ex                                                                             maybe_value%0#0,maybe_exists%0#0
+        assert // check self.accounts exists                                                          maybe_value%0#0
+        l-load maybe_value%0#0 0                                                                      maybe_value%0#0
+        retsub                                                                                        maybe_value%0#0
+
+

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.0.ssa.ir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.0.ssa.ir
@@ -1,0 +1,3 @@
+main algopy.arc4.ARC4Contract.clear_state_program:
+    block@0: // L1
+        return 1u

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.1.ssa.array.ir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.1.ssa.array.ir
@@ -1,0 +1,3 @@
+main algopy.arc4.ARC4Contract.clear_state_program:
+    block@0: // L1
+        return 1u

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.10.mir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.10.mir
@@ -1,0 +1,8 @@
+// Op             Stack (out)
+// algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        int 1     1
+        return
+
+

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.2.ssa.slot.ir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.2.ssa.slot.ir
@@ -1,0 +1,3 @@
+main algopy.arc4.ARC4Contract.clear_state_program:
+    block@0: // L1
+        return 1u

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.3.destructured.ir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.3.destructured.ir
@@ -1,0 +1,3 @@
+main algopy.arc4.ARC4Contract.clear_state_program:
+    block@0: // L1
+        return 1u

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.4.lstack.mir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.4.lstack.mir
@@ -1,0 +1,8 @@
+// Op             Stack (out)
+// algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        int 1     1
+        return
+
+

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.5.lstack.opt.mir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.5.lstack.opt.mir
@@ -1,0 +1,8 @@
+// Op             Stack (out)
+// algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        int 1     1
+        return
+
+

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.6.xstack.mir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.6.xstack.mir
@@ -1,0 +1,8 @@
+// Op             Stack (out)
+// algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        int 1     1
+        return
+
+

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.7.xstack.opt.mir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.7.xstack.opt.mir
@@ -1,0 +1,8 @@
+// Op             Stack (out)
+// algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        int 1     1
+        return
+
+

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.8.fstack.mir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.8.fstack.mir
@@ -1,0 +1,8 @@
+// Op             Stack (out)
+// algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        int 1     1
+        return
+
+

--- a/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.9.fstack.opt.mir
+++ b/test_cases/arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.9.fstack.opt.mir
@@ -1,0 +1,8 @@
+// Op             Stack (out)
+// algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        int 1     1
+        return
+
+

--- a/test_cases/arc4_conversions/out/client_ReferenceReturn.py
+++ b/test_cases/arc4_conversions/out/client_ReferenceReturn.py
@@ -1,0 +1,64 @@
+# This file is auto-generated, do not modify
+# flake8: noqa
+# fmt: off
+import typing
+
+import algopy
+
+
+class ReferenceReturn(algopy.arc4.ARC4Client, typing.Protocol):
+    @algopy.arc4.abimethod
+    def acc_ret(
+        self,
+    ) -> algopy.arc4.Address: ...
+
+    @algopy.arc4.abimethod
+    def asset_ret(
+        self,
+    ) -> algopy.arc4.UIntN[typing.Literal[64]]: ...
+
+    @algopy.arc4.abimethod
+    def app_ret(
+        self,
+    ) -> algopy.arc4.UIntN[typing.Literal[64]]: ...
+
+    @algopy.arc4.abimethod
+    def store(
+        self,
+        acc: algopy.Account,
+        app: algopy.Application,
+        asset: algopy.Asset,
+    ) -> None: ...
+
+    @algopy.arc4.abimethod
+    def store_apps(
+        self,
+        apps: algopy.arc4.DynamicArray[algopy.arc4.UIntN[typing.Literal[64]]],
+    ) -> None: ...
+
+    @algopy.arc4.abimethod
+    def store_assets(
+        self,
+        assets: algopy.arc4.DynamicArray[algopy.arc4.UIntN[typing.Literal[64]]],
+    ) -> None: ...
+
+    @algopy.arc4.abimethod
+    def store_accounts(
+        self,
+        accounts: algopy.arc4.DynamicArray[algopy.arc4.Address],
+    ) -> None: ...
+
+    @algopy.arc4.abimethod
+    def return_apps(
+        self,
+    ) -> algopy.arc4.DynamicArray[algopy.arc4.UIntN[typing.Literal[64]]]: ...
+
+    @algopy.arc4.abimethod
+    def return_assets(
+        self,
+    ) -> algopy.arc4.DynamicArray[algopy.arc4.UIntN[typing.Literal[64]]]: ...
+
+    @algopy.arc4.abimethod
+    def return_accounts(
+        self,
+    ) -> algopy.arc4.DynamicArray[algopy.arc4.Address]: ...

--- a/test_cases/arc4_conversions/out/module.awst
+++ b/test_cases/arc4_conversions/out/module.awst
@@ -1,3 +1,84 @@
+contract ReferenceReturn
+{
+  method_resolution_order: (
+    algopy.arc4.ARC4Contract,
+  )
+  globals {
+    ['acc']: account
+    ['asset']: asset
+    ['app']: application
+    ['apps']: stack_array<application>
+    ['assets']: stack_array<asset>
+    ['accounts']: stack_array<account>
+  }
+  
+  subroutine algopy.arc4.ARC4Contract.approval_program(): bool
+  {
+    return arc4_router()
+  }
+  
+  subroutine algopy.arc4.ARC4Contract.clear_state_program(): bool
+  {
+    return true
+  }
+  
+  abimethod test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret(): account
+  {
+    return txn<Sender>()
+  }
+  
+  abimethod test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret(): asset
+  {
+    return reinterpret_cast<asset>(1234u)
+  }
+  
+  abimethod test_cases.arc4_conversions.reference.ReferenceReturn.app_ret(): application
+  {
+    return reinterpret_cast<application>(1234u)
+  }
+  
+  abimethod test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: account, app: application, asset: asset): void
+  {
+    GlobalState['acc']: account = acc
+    GlobalState['asset']: asset = asset
+    GlobalState['app']: application = app
+  }
+  
+  abimethod test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: stack_array<application>): void
+  {
+    GlobalState['apps']: stack_array<application> = apps
+  }
+  
+  abimethod test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: stack_array<asset>): void
+  {
+    GlobalState['assets']: stack_array<asset> = assets
+  }
+  
+  abimethod test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: stack_array<account>): void
+  {
+    GlobalState['accounts']: stack_array<account> = accounts
+  }
+  
+  abimethod test_cases.arc4_conversions.reference.ReferenceReturn.return_apps(): stack_array<application>
+  {
+    return GlobalState['apps']
+  }
+  
+  abimethod test_cases.arc4_conversions.reference.ReferenceReturn.return_assets(): stack_array<asset>
+  {
+    return GlobalState['assets']
+  }
+  
+  abimethod test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts(): stack_array<account>
+  {
+    return GlobalState['accounts']
+  }
+  
+  baremethod test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create(): void
+  {
+  }
+}
+
 contract TestContract
 {
   method_resolution_order: (

--- a/test_cases/arc4_conversions/out_O2/ReferenceReturn.approval.puya.map
+++ b/test_cases/arc4_conversions/out_O2/ReferenceReturn.approval.puya.map
@@ -1,0 +1,1196 @@
+{
+  "version": 3,
+  "sources": [
+    "../reference.py"
+  ],
+  "mappings": ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAGA;;AAAA;;;AAAA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA;;;AAAA;;;;;;;;;;;;;;;;;;;;;;AAAA;;AAuCK;;AAAA;AAAA;AAAA;;AAAA;AAEU;AAAA;AAAA;AAAA;AAFV;AAAA;AAAA;AAAA;AAAA;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AAEU;AAAA;AAAA;AAAA;AAFV;AAAA;AAAA;AAAA;AAAA;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AAEU;AAAA;AAAA;AAAA;AAFV;AAAA;AAAA;AAAA;AAAA;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AAEG;AA7BR;;;AA6BQ;AAFH;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AAEG;AAzBR;;;AAyBQ;AAFH;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AAEG;AArBR;;;AAqBQ;AAFH;;AANA;;AAAA;AAAA;AAAA;;AAAA;AAbL;;;AAAA;AAAA;;AAAA;;;AAAA;AAAA;;AAAA;;;AAAA;AAAA;;AAeQ;;;;;AAAA;;AAAA;AACA;;;;;;;AAAA;AAAA;AACA;;;;;AAAA;AAAA;AAJH;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AAAA;;AAAA;AAAA;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AAAA;;AAAA;AAAA;;AAJA;;AAAA;AAAA;AAAA;;AAAA;AAAA;AAEU;;AAFV;AAAA;AAAA;;AADL;;AAAA;;;;;;;;",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "algopy.arc4.ARC4Contract.approval_program",
+      "params": {},
+      "block": "main",
+      "stack_in": [],
+      "op": "intcblock 1 0"
+    },
+    "5": {
+      "op": "bytecblock 0x151f7c75 \"accounts\" \"assets\" \"apps\" 0x151f7c7500000000000004d2"
+    },
+    "46": {
+      "op": "txn NumAppArgs",
+      "defined_out": [
+        "tmp%0#1"
+      ],
+      "stack_out": [
+        "tmp%0#1"
+      ]
+    },
+    "48": {
+      "op": "bz main_bare_routing@15",
+      "stack_out": []
+    },
+    "51": {
+      "op": "pushbytess 0x6c7a1cb5 0xc8480f0c 0x37c0cbf2 0x864086a7 0x6728b1a1 0xce7e6cd3 0x0a37f6e1 0x4c894d7e 0x62ebcf89 0x924e778c // method \"acc_ret()address\", method \"asset_ret()uint64\", method \"app_ret()uint64\", method \"store(account,application,asset)void\", method \"store_apps(uint64[])void\", method \"store_assets(uint64[])void\", method \"store_accounts(address[])void\", method \"return_apps()uint64[]\", method \"return_assets()uint64[]\", method \"return_accounts()address[]\"",
+      "defined_out": [
+        "Method(acc_ret()address)",
+        "Method(app_ret()uint64)",
+        "Method(asset_ret()uint64)",
+        "Method(return_accounts()address[])",
+        "Method(return_apps()uint64[])",
+        "Method(return_assets()uint64[])",
+        "Method(store(account,application,asset)void)",
+        "Method(store_accounts(address[])void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)"
+      ],
+      "stack_out": [
+        "Method(acc_ret()address)",
+        "Method(asset_ret()uint64)",
+        "Method(app_ret()uint64)",
+        "Method(store(account,application,asset)void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "Method(store_accounts(address[])void)",
+        "Method(return_apps()uint64[])",
+        "Method(return_assets()uint64[])",
+        "Method(return_accounts()address[])"
+      ]
+    },
+    "103": {
+      "op": "txna ApplicationArgs 0",
+      "defined_out": [
+        "Method(acc_ret()address)",
+        "Method(app_ret()uint64)",
+        "Method(asset_ret()uint64)",
+        "Method(return_accounts()address[])",
+        "Method(return_apps()uint64[])",
+        "Method(return_assets()uint64[])",
+        "Method(store(account,application,asset)void)",
+        "Method(store_accounts(address[])void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "tmp%2#0"
+      ],
+      "stack_out": [
+        "Method(acc_ret()address)",
+        "Method(asset_ret()uint64)",
+        "Method(app_ret()uint64)",
+        "Method(store(account,application,asset)void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "Method(store_accounts(address[])void)",
+        "Method(return_apps()uint64[])",
+        "Method(return_assets()uint64[])",
+        "Method(return_accounts()address[])",
+        "tmp%2#0"
+      ]
+    },
+    "106": {
+      "op": "match main_acc_ret_route@3 main_asset_ret_route@4 main_app_ret_route@5 main_store_route@6 main_store_apps_route@7 main_store_assets_route@8 main_store_accounts_route@9 main_return_apps_route@10 main_return_assets_route@11 main_return_accounts_route@12",
+      "stack_out": []
+    },
+    "128": {
+      "block": "main_after_if_else@19",
+      "stack_in": [],
+      "op": "intc_1 // 0",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "129": {
+      "op": "return",
+      "stack_out": []
+    },
+    "130": {
+      "block": "main_return_accounts_route@12",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%53#0"
+      ],
+      "stack_out": [
+        "tmp%53#0"
+      ]
+    },
+    "132": {
+      "op": "!",
+      "defined_out": [
+        "tmp%54#0"
+      ],
+      "stack_out": [
+        "tmp%54#0"
+      ]
+    },
+    "133": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "134": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%55#0"
+      ],
+      "stack_out": [
+        "tmp%55#0"
+      ]
+    },
+    "136": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "137": {
+      "op": "intc_1 // 0",
+      "defined_out": [
+        "0"
+      ],
+      "stack_out": [
+        "0"
+      ]
+    },
+    "138": {
+      "op": "bytec_1 // \"accounts\"",
+      "defined_out": [
+        "\"accounts\"",
+        "0"
+      ],
+      "stack_out": [
+        "0",
+        "\"accounts\""
+      ]
+    },
+    "139": {
+      "op": "app_global_get_ex",
+      "defined_out": [
+        "maybe_exists%0#0",
+        "maybe_value%0#0"
+      ],
+      "stack_out": [
+        "maybe_value%0#0",
+        "maybe_exists%0#0"
+      ]
+    },
+    "140": {
+      "error": "check self.accounts exists",
+      "op": "assert // check self.accounts exists",
+      "stack_out": [
+        "maybe_value%0#0"
+      ]
+    },
+    "141": {
+      "op": "bytec_0 // 0x151f7c75",
+      "defined_out": [
+        "0x151f7c75",
+        "maybe_value%0#0"
+      ],
+      "stack_out": [
+        "maybe_value%0#0",
+        "0x151f7c75"
+      ]
+    },
+    "142": {
+      "op": "swap",
+      "stack_out": [
+        "0x151f7c75",
+        "maybe_value%0#0"
+      ]
+    },
+    "143": {
+      "op": "concat",
+      "defined_out": [
+        "tmp%58#0"
+      ],
+      "stack_out": [
+        "tmp%58#0"
+      ]
+    },
+    "144": {
+      "op": "log",
+      "stack_out": []
+    },
+    "145": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "146": {
+      "op": "return",
+      "stack_out": []
+    },
+    "147": {
+      "block": "main_return_assets_route@11",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%47#0"
+      ],
+      "stack_out": [
+        "tmp%47#0"
+      ]
+    },
+    "149": {
+      "op": "!",
+      "defined_out": [
+        "tmp%48#0"
+      ],
+      "stack_out": [
+        "tmp%48#0"
+      ]
+    },
+    "150": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "151": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%49#0"
+      ],
+      "stack_out": [
+        "tmp%49#0"
+      ]
+    },
+    "153": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "154": {
+      "op": "intc_1 // 0",
+      "defined_out": [
+        "0"
+      ],
+      "stack_out": [
+        "0"
+      ]
+    },
+    "155": {
+      "op": "bytec_2 // \"assets\"",
+      "defined_out": [
+        "\"assets\"",
+        "0"
+      ],
+      "stack_out": [
+        "0",
+        "\"assets\""
+      ]
+    },
+    "156": {
+      "op": "app_global_get_ex",
+      "defined_out": [
+        "maybe_exists%0#0",
+        "maybe_value%0#1"
+      ],
+      "stack_out": [
+        "maybe_value%0#1",
+        "maybe_exists%0#0"
+      ]
+    },
+    "157": {
+      "error": "check self.assets exists",
+      "op": "assert // check self.assets exists",
+      "stack_out": [
+        "maybe_value%0#1"
+      ]
+    },
+    "158": {
+      "op": "bytec_0 // 0x151f7c75",
+      "defined_out": [
+        "0x151f7c75",
+        "maybe_value%0#1"
+      ],
+      "stack_out": [
+        "maybe_value%0#1",
+        "0x151f7c75"
+      ]
+    },
+    "159": {
+      "op": "swap",
+      "stack_out": [
+        "0x151f7c75",
+        "maybe_value%0#1"
+      ]
+    },
+    "160": {
+      "op": "concat",
+      "defined_out": [
+        "tmp%52#0"
+      ],
+      "stack_out": [
+        "tmp%52#0"
+      ]
+    },
+    "161": {
+      "op": "log",
+      "stack_out": []
+    },
+    "162": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "163": {
+      "op": "return",
+      "stack_out": []
+    },
+    "164": {
+      "block": "main_return_apps_route@10",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%41#0"
+      ],
+      "stack_out": [
+        "tmp%41#0"
+      ]
+    },
+    "166": {
+      "op": "!",
+      "defined_out": [
+        "tmp%42#0"
+      ],
+      "stack_out": [
+        "tmp%42#0"
+      ]
+    },
+    "167": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "168": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%43#0"
+      ],
+      "stack_out": [
+        "tmp%43#0"
+      ]
+    },
+    "170": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "171": {
+      "op": "intc_1 // 0",
+      "defined_out": [
+        "0"
+      ],
+      "stack_out": [
+        "0"
+      ]
+    },
+    "172": {
+      "op": "bytec_3 // \"apps\"",
+      "defined_out": [
+        "\"apps\"",
+        "0"
+      ],
+      "stack_out": [
+        "0",
+        "\"apps\""
+      ]
+    },
+    "173": {
+      "op": "app_global_get_ex",
+      "defined_out": [
+        "maybe_exists%0#0",
+        "maybe_value%0#1"
+      ],
+      "stack_out": [
+        "maybe_value%0#1",
+        "maybe_exists%0#0"
+      ]
+    },
+    "174": {
+      "error": "check self.apps exists",
+      "op": "assert // check self.apps exists",
+      "stack_out": [
+        "maybe_value%0#1"
+      ]
+    },
+    "175": {
+      "op": "bytec_0 // 0x151f7c75",
+      "defined_out": [
+        "0x151f7c75",
+        "maybe_value%0#1"
+      ],
+      "stack_out": [
+        "maybe_value%0#1",
+        "0x151f7c75"
+      ]
+    },
+    "176": {
+      "op": "swap",
+      "stack_out": [
+        "0x151f7c75",
+        "maybe_value%0#1"
+      ]
+    },
+    "177": {
+      "op": "concat",
+      "defined_out": [
+        "tmp%46#0"
+      ],
+      "stack_out": [
+        "tmp%46#0"
+      ]
+    },
+    "178": {
+      "op": "log",
+      "stack_out": []
+    },
+    "179": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "180": {
+      "op": "return",
+      "stack_out": []
+    },
+    "181": {
+      "block": "main_store_accounts_route@9",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%37#0"
+      ],
+      "stack_out": [
+        "tmp%37#0"
+      ]
+    },
+    "183": {
+      "op": "!",
+      "defined_out": [
+        "tmp%38#0"
+      ],
+      "stack_out": [
+        "tmp%38#0"
+      ]
+    },
+    "184": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "185": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%39#0"
+      ],
+      "stack_out": [
+        "tmp%39#0"
+      ]
+    },
+    "187": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "188": {
+      "op": "bytec_1 // \"accounts\"",
+      "defined_out": [
+        "\"accounts\""
+      ],
+      "stack_out": [
+        "\"accounts\""
+      ]
+    },
+    "189": {
+      "op": "txna ApplicationArgs 1",
+      "defined_out": [
+        "\"accounts\"",
+        "accounts#0"
+      ],
+      "stack_out": [
+        "\"accounts\"",
+        "accounts#0"
+      ]
+    },
+    "192": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "193": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "194": {
+      "op": "return",
+      "stack_out": []
+    },
+    "195": {
+      "block": "main_store_assets_route@8",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%33#0"
+      ],
+      "stack_out": [
+        "tmp%33#0"
+      ]
+    },
+    "197": {
+      "op": "!",
+      "defined_out": [
+        "tmp%34#0"
+      ],
+      "stack_out": [
+        "tmp%34#0"
+      ]
+    },
+    "198": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "199": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%35#0"
+      ],
+      "stack_out": [
+        "tmp%35#0"
+      ]
+    },
+    "201": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "202": {
+      "op": "bytec_2 // \"assets\"",
+      "defined_out": [
+        "\"assets\""
+      ],
+      "stack_out": [
+        "\"assets\""
+      ]
+    },
+    "203": {
+      "op": "txna ApplicationArgs 1",
+      "defined_out": [
+        "\"assets\"",
+        "assets#0"
+      ],
+      "stack_out": [
+        "\"assets\"",
+        "assets#0"
+      ]
+    },
+    "206": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "207": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "208": {
+      "op": "return",
+      "stack_out": []
+    },
+    "209": {
+      "block": "main_store_apps_route@7",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%29#0"
+      ],
+      "stack_out": [
+        "tmp%29#0"
+      ]
+    },
+    "211": {
+      "op": "!",
+      "defined_out": [
+        "tmp%30#0"
+      ],
+      "stack_out": [
+        "tmp%30#0"
+      ]
+    },
+    "212": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "213": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%31#0"
+      ],
+      "stack_out": [
+        "tmp%31#0"
+      ]
+    },
+    "215": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "216": {
+      "op": "bytec_3 // \"apps\"",
+      "defined_out": [
+        "\"apps\""
+      ],
+      "stack_out": [
+        "\"apps\""
+      ]
+    },
+    "217": {
+      "op": "txna ApplicationArgs 1",
+      "defined_out": [
+        "\"apps\"",
+        "apps#0"
+      ],
+      "stack_out": [
+        "\"apps\"",
+        "apps#0"
+      ]
+    },
+    "220": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "221": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "222": {
+      "op": "return",
+      "stack_out": []
+    },
+    "223": {
+      "block": "main_store_route@6",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%19#0"
+      ],
+      "stack_out": [
+        "tmp%19#0"
+      ]
+    },
+    "225": {
+      "op": "!",
+      "defined_out": [
+        "tmp%20#0"
+      ],
+      "stack_out": [
+        "tmp%20#0"
+      ]
+    },
+    "226": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "227": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%21#0"
+      ],
+      "stack_out": [
+        "tmp%21#0"
+      ]
+    },
+    "229": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "230": {
+      "op": "txna ApplicationArgs 1",
+      "defined_out": [
+        "reinterpret_bytes[1]%0#0"
+      ],
+      "stack_out": [
+        "reinterpret_bytes[1]%0#0"
+      ]
+    },
+    "233": {
+      "op": "btoi",
+      "defined_out": [
+        "tmp%23#0"
+      ],
+      "stack_out": [
+        "tmp%23#0"
+      ]
+    },
+    "234": {
+      "op": "txnas Accounts",
+      "defined_out": [
+        "acc#0"
+      ],
+      "stack_out": [
+        "acc#0"
+      ]
+    },
+    "236": {
+      "op": "txna ApplicationArgs 2",
+      "defined_out": [
+        "acc#0",
+        "reinterpret_bytes[1]%1#0"
+      ],
+      "stack_out": [
+        "acc#0",
+        "reinterpret_bytes[1]%1#0"
+      ]
+    },
+    "239": {
+      "op": "btoi",
+      "defined_out": [
+        "acc#0",
+        "tmp%25#0"
+      ],
+      "stack_out": [
+        "acc#0",
+        "tmp%25#0"
+      ]
+    },
+    "240": {
+      "op": "txnas Applications",
+      "defined_out": [
+        "acc#0",
+        "app#0"
+      ],
+      "stack_out": [
+        "acc#0",
+        "app#0"
+      ]
+    },
+    "242": {
+      "op": "txna ApplicationArgs 3",
+      "defined_out": [
+        "acc#0",
+        "app#0",
+        "reinterpret_bytes[1]%2#0"
+      ],
+      "stack_out": [
+        "acc#0",
+        "app#0",
+        "reinterpret_bytes[1]%2#0"
+      ]
+    },
+    "245": {
+      "op": "btoi",
+      "defined_out": [
+        "acc#0",
+        "app#0",
+        "tmp%27#0"
+      ],
+      "stack_out": [
+        "acc#0",
+        "app#0",
+        "tmp%27#0"
+      ]
+    },
+    "246": {
+      "op": "txnas Assets",
+      "defined_out": [
+        "acc#0",
+        "app#0",
+        "asset#0"
+      ],
+      "stack_out": [
+        "acc#0",
+        "app#0",
+        "asset#0"
+      ]
+    },
+    "248": {
+      "op": "pushbytes \"acc\"",
+      "defined_out": [
+        "\"acc\"",
+        "acc#0",
+        "app#0",
+        "asset#0"
+      ],
+      "stack_out": [
+        "acc#0",
+        "app#0",
+        "asset#0",
+        "\"acc\""
+      ]
+    },
+    "253": {
+      "op": "uncover 3",
+      "stack_out": [
+        "app#0",
+        "asset#0",
+        "\"acc\"",
+        "acc#0"
+      ]
+    },
+    "255": {
+      "op": "app_global_put",
+      "stack_out": [
+        "app#0",
+        "asset#0"
+      ]
+    },
+    "256": {
+      "op": "pushbytes \"asset\"",
+      "defined_out": [
+        "\"asset\"",
+        "app#0",
+        "asset#0"
+      ],
+      "stack_out": [
+        "app#0",
+        "asset#0",
+        "\"asset\""
+      ]
+    },
+    "263": {
+      "op": "swap",
+      "stack_out": [
+        "app#0",
+        "\"asset\"",
+        "asset#0"
+      ]
+    },
+    "264": {
+      "op": "app_global_put",
+      "stack_out": [
+        "app#0"
+      ]
+    },
+    "265": {
+      "op": "pushbytes \"app\"",
+      "defined_out": [
+        "\"app\"",
+        "app#0"
+      ],
+      "stack_out": [
+        "app#0",
+        "\"app\""
+      ]
+    },
+    "270": {
+      "op": "swap",
+      "stack_out": [
+        "\"app\"",
+        "app#0"
+      ]
+    },
+    "271": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "272": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "273": {
+      "op": "return",
+      "stack_out": []
+    },
+    "274": {
+      "block": "main_app_ret_route@5",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%14#0"
+      ],
+      "stack_out": [
+        "tmp%14#0"
+      ]
+    },
+    "276": {
+      "op": "!",
+      "defined_out": [
+        "tmp%15#0"
+      ],
+      "stack_out": [
+        "tmp%15#0"
+      ]
+    },
+    "277": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "278": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%16#0"
+      ],
+      "stack_out": [
+        "tmp%16#0"
+      ]
+    },
+    "280": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "281": {
+      "op": "bytec 4 // 0x151f7c7500000000000004d2",
+      "defined_out": [
+        "0x151f7c7500000000000004d2"
+      ],
+      "stack_out": [
+        "0x151f7c7500000000000004d2"
+      ]
+    },
+    "283": {
+      "op": "log",
+      "stack_out": []
+    },
+    "284": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "285": {
+      "op": "return",
+      "stack_out": []
+    },
+    "286": {
+      "block": "main_asset_ret_route@4",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%9#0"
+      ],
+      "stack_out": [
+        "tmp%9#0"
+      ]
+    },
+    "288": {
+      "op": "!",
+      "defined_out": [
+        "tmp%10#0"
+      ],
+      "stack_out": [
+        "tmp%10#0"
+      ]
+    },
+    "289": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "290": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%11#0"
+      ],
+      "stack_out": [
+        "tmp%11#0"
+      ]
+    },
+    "292": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "293": {
+      "op": "bytec 4 // 0x151f7c7500000000000004d2",
+      "defined_out": [
+        "0x151f7c7500000000000004d2"
+      ],
+      "stack_out": [
+        "0x151f7c7500000000000004d2"
+      ]
+    },
+    "295": {
+      "op": "log",
+      "stack_out": []
+    },
+    "296": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "297": {
+      "op": "return",
+      "stack_out": []
+    },
+    "298": {
+      "block": "main_acc_ret_route@3",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%3#0"
+      ],
+      "stack_out": [
+        "tmp%3#0"
+      ]
+    },
+    "300": {
+      "op": "!",
+      "defined_out": [
+        "tmp%4#0"
+      ],
+      "stack_out": [
+        "tmp%4#0"
+      ]
+    },
+    "301": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "302": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%5#0"
+      ],
+      "stack_out": [
+        "tmp%5#0"
+      ]
+    },
+    "304": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "305": {
+      "op": "bytec_0 // 0x151f7c75",
+      "defined_out": [
+        "0x151f7c75"
+      ],
+      "stack_out": [
+        "0x151f7c75"
+      ]
+    },
+    "306": {
+      "op": "txn Sender",
+      "defined_out": [
+        "0x151f7c75",
+        "tmp%0#2"
+      ],
+      "stack_out": [
+        "0x151f7c75",
+        "tmp%0#2"
+      ]
+    },
+    "308": {
+      "op": "concat",
+      "defined_out": [
+        "tmp%8#0"
+      ],
+      "stack_out": [
+        "tmp%8#0"
+      ]
+    },
+    "309": {
+      "op": "log",
+      "stack_out": []
+    },
+    "310": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "311": {
+      "op": "return",
+      "stack_out": []
+    },
+    "312": {
+      "block": "main_bare_routing@15",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%59#0"
+      ],
+      "stack_out": [
+        "tmp%59#0"
+      ]
+    },
+    "314": {
+      "op": "bnz main_after_if_else@19",
+      "stack_out": []
+    },
+    "317": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%60#0"
+      ],
+      "stack_out": [
+        "tmp%60#0"
+      ]
+    },
+    "319": {
+      "op": "!",
+      "defined_out": [
+        "tmp%61#0"
+      ],
+      "stack_out": [
+        "tmp%61#0"
+      ]
+    },
+    "320": {
+      "error": "can only call when creating",
+      "op": "assert // can only call when creating",
+      "stack_out": []
+    },
+    "321": {
+      "op": "intc_0 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "322": {
+      "op": "return",
+      "stack_out": []
+    }
+  }
+}

--- a/test_cases/arc4_conversions/out_O2/ReferenceReturn.approval.teal
+++ b/test_cases/arc4_conversions/out_O2/ReferenceReturn.approval.teal
@@ -1,0 +1,174 @@
+#pragma version 10
+#pragma typetrack false
+
+// algopy.arc4.ARC4Contract.approval_program() -> uint64:
+main:
+    intcblock 1 0
+    bytecblock 0x151f7c75 "accounts" "assets" "apps" 0x151f7c7500000000000004d2
+    txn NumAppArgs
+    bz main_bare_routing@15
+    pushbytess 0x6c7a1cb5 0xc8480f0c 0x37c0cbf2 0x864086a7 0x6728b1a1 0xce7e6cd3 0x0a37f6e1 0x4c894d7e 0x62ebcf89 0x924e778c // method "acc_ret()address", method "asset_ret()uint64", method "app_ret()uint64", method "store(account,application,asset)void", method "store_apps(uint64[])void", method "store_assets(uint64[])void", method "store_accounts(address[])void", method "return_apps()uint64[]", method "return_assets()uint64[]", method "return_accounts()address[]"
+    txna ApplicationArgs 0
+    match main_acc_ret_route@3 main_asset_ret_route@4 main_app_ret_route@5 main_store_route@6 main_store_apps_route@7 main_store_assets_route@8 main_store_accounts_route@9 main_return_apps_route@10 main_return_assets_route@11 main_return_accounts_route@12
+
+main_after_if_else@19:
+    intc_1 // 0
+    return
+
+main_return_accounts_route@12:
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    intc_1 // 0
+    bytec_1 // "accounts"
+    app_global_get_ex
+    assert // check self.accounts exists
+    bytec_0 // 0x151f7c75
+    swap
+    concat
+    log
+    intc_0 // 1
+    return
+
+main_return_assets_route@11:
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    intc_1 // 0
+    bytec_2 // "assets"
+    app_global_get_ex
+    assert // check self.assets exists
+    bytec_0 // 0x151f7c75
+    swap
+    concat
+    log
+    intc_0 // 1
+    return
+
+main_return_apps_route@10:
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    intc_1 // 0
+    bytec_3 // "apps"
+    app_global_get_ex
+    assert // check self.apps exists
+    bytec_0 // 0x151f7c75
+    swap
+    concat
+    log
+    intc_0 // 1
+    return
+
+main_store_accounts_route@9:
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    bytec_1 // "accounts"
+    txna ApplicationArgs 1
+    app_global_put
+    intc_0 // 1
+    return
+
+main_store_assets_route@8:
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    bytec_2 // "assets"
+    txna ApplicationArgs 1
+    app_global_put
+    intc_0 // 1
+    return
+
+main_store_apps_route@7:
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    bytec_3 // "apps"
+    txna ApplicationArgs 1
+    app_global_put
+    intc_0 // 1
+    return
+
+main_store_route@6:
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    txna ApplicationArgs 1
+    btoi
+    txnas Accounts
+    txna ApplicationArgs 2
+    btoi
+    txnas Applications
+    txna ApplicationArgs 3
+    btoi
+    txnas Assets
+    pushbytes "acc"
+    uncover 3
+    app_global_put
+    pushbytes "asset"
+    swap
+    app_global_put
+    pushbytes "app"
+    swap
+    app_global_put
+    intc_0 // 1
+    return
+
+main_app_ret_route@5:
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    bytec 4 // 0x151f7c7500000000000004d2
+    log
+    intc_0 // 1
+    return
+
+main_asset_ret_route@4:
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    bytec 4 // 0x151f7c7500000000000004d2
+    log
+    intc_0 // 1
+    return
+
+main_acc_ret_route@3:
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    bytec_0 // 0x151f7c75
+    txn Sender
+    concat
+    log
+    intc_0 // 1
+    return
+
+main_bare_routing@15:
+    txn OnCompletion
+    bnz main_after_if_else@19
+    txn ApplicationID
+    !
+    assert // can only call when creating
+    intc_0 // 1
+    return

--- a/test_cases/arc4_conversions/out_O2/ReferenceReturn.clear.puya.map
+++ b/test_cases/arc4_conversions/out_O2/ReferenceReturn.clear.puya.map
@@ -1,0 +1,25 @@
+{
+  "version": 3,
+  "sources": [],
+  "mappings": ";;;",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "algopy.arc4.ARC4Contract.clear_state_program",
+      "params": {},
+      "block": "main",
+      "stack_in": [],
+      "op": "pushint 1 // 1",
+      "defined_out": [
+        "1"
+      ],
+      "stack_out": [
+        "1"
+      ]
+    },
+    "3": {
+      "op": "return",
+      "stack_out": []
+    }
+  }
+}

--- a/test_cases/arc4_conversions/out_O2/ReferenceReturn.clear.teal
+++ b/test_cases/arc4_conversions/out_O2/ReferenceReturn.clear.teal
@@ -1,0 +1,7 @@
+#pragma version 10
+#pragma typetrack false
+
+// algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+main:
+    pushint 1 // 1
+    return

--- a/test_cases/arc4_conversions/out_O2/ReferenceReturn.ir/ReferenceReturn.approval.0.destructured.ir
+++ b/test_cases/arc4_conversions/out_O2/ReferenceReturn.ir/ReferenceReturn.approval.0.destructured.ir
@@ -1,0 +1,148 @@
+main algopy.arc4.ARC4Contract.approval_program:
+    block@0: // L1
+        let tmp%0#1: uint64 = (txn NumAppArgs)
+        goto tmp%0#1 ? block@2 : block@15
+    block@2: // abi_routing_L4
+        let tmp%2#0: bytes = (txna ApplicationArgs 0)
+        switch tmp%2#0 {method "acc_ret()address" => block@3, method "asset_ret()uint64" => block@4, method "app_ret()uint64" => block@5, method "store(account,application,asset)void" => block@6, method "store_apps(uint64[])void" => block@7, method "store_assets(uint64[])void" => block@8, method "store_accounts(address[])void" => block@9, method "return_apps()uint64[]" => block@10, method "return_assets()uint64[]" => block@11, method "return_accounts()address[]" => block@12, * => block@19}
+    block@3: // acc_ret_route_L5
+        let tmp%3#0: uint64 = (txn OnCompletion)
+        let tmp%4#0: bool = (! tmp%3#0)
+        (assert tmp%4#0) // OnCompletion is not NoOp
+        let tmp%5#0: uint64 = (txn ApplicationID)
+        (assert tmp%5#0) // can only call when not creating
+        let tmp%0#2: bytes[32] = (txn Sender)
+        let tmp%8#0: bytes = (concat 0x151f7c75 tmp%0#2)
+        (log tmp%8#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@4: // asset_ret_route_L9
+        let tmp%9#0: uint64 = (txn OnCompletion)
+        let tmp%10#0: bool = (! tmp%9#0)
+        (assert tmp%10#0) // OnCompletion is not NoOp
+        let tmp%11#0: uint64 = (txn ApplicationID)
+        (assert tmp%11#0) // can only call when not creating
+        (log 0x151f7c7500000000000004d2)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@5: // app_ret_route_L13
+        let tmp%14#0: uint64 = (txn OnCompletion)
+        let tmp%15#0: bool = (! tmp%14#0)
+        (assert tmp%15#0) // OnCompletion is not NoOp
+        let tmp%16#0: uint64 = (txn ApplicationID)
+        (assert tmp%16#0) // can only call when not creating
+        (log 0x151f7c7500000000000004d2)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@6: // store_route_L17
+        let tmp%19#0: uint64 = (txn OnCompletion)
+        let tmp%20#0: bool = (! tmp%19#0)
+        (assert tmp%20#0) // OnCompletion is not NoOp
+        let tmp%21#0: uint64 = (txn ApplicationID)
+        (assert tmp%21#0) // can only call when not creating
+        let reinterpret_bytes[1]%0#0: bytes[1] = (txna ApplicationArgs 1)
+        let tmp%23#0: uint64 = (btoi reinterpret_bytes[1]%0#0)
+        let acc#0: bytes[32] = ((txnas Accounts) tmp%23#0)
+        let reinterpret_bytes[1]%1#0: bytes[1] = (txna ApplicationArgs 2)
+        let tmp%25#0: uint64 = (btoi reinterpret_bytes[1]%1#0)
+        let app#0: uint64 = ((txnas Applications) tmp%25#0)
+        let reinterpret_bytes[1]%2#0: bytes[1] = (txna ApplicationArgs 3)
+        let tmp%27#0: uint64 = (btoi reinterpret_bytes[1]%2#0)
+        let asset#0: uint64 = ((txnas Assets) tmp%27#0)
+        (app_global_put "acc" acc#0)
+        (app_global_put "asset" asset#0)
+        (app_global_put "app" app#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@7: // store_apps_route_L23
+        let tmp%29#0: uint64 = (txn OnCompletion)
+        let tmp%30#0: bool = (! tmp%29#0)
+        (assert tmp%30#0) // OnCompletion is not NoOp
+        let tmp%31#0: uint64 = (txn ApplicationID)
+        (assert tmp%31#0) // can only call when not creating
+        let apps#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        (app_global_put "apps" apps#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@8: // store_assets_route_L27
+        let tmp%33#0: uint64 = (txn OnCompletion)
+        let tmp%34#0: bool = (! tmp%33#0)
+        (assert tmp%34#0) // OnCompletion is not NoOp
+        let tmp%35#0: uint64 = (txn ApplicationID)
+        (assert tmp%35#0) // can only call when not creating
+        let assets#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        (app_global_put "assets" assets#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@9: // store_accounts_route_L31
+        let tmp%37#0: uint64 = (txn OnCompletion)
+        let tmp%38#0: bool = (! tmp%37#0)
+        (assert tmp%38#0) // OnCompletion is not NoOp
+        let tmp%39#0: uint64 = (txn ApplicationID)
+        (assert tmp%39#0) // can only call when not creating
+        let accounts#0: bytes[32][] = (txna ApplicationArgs 1)
+        (app_global_put "accounts" accounts#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@10: // return_apps_route_L35
+        let tmp%41#0: uint64 = (txn OnCompletion)
+        let tmp%42#0: bool = (! tmp%41#0)
+        (assert tmp%42#0) // OnCompletion is not NoOp
+        let tmp%43#0: uint64 = (txn ApplicationID)
+        (assert tmp%43#0) // can only call when not creating
+        let (maybe_value%0#1: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "apps")
+        (assert maybe_exists%0#0) // check self.apps exists
+        let tmp%46#0: bytes = (concat 0x151f7c75 maybe_value%0#1)
+        (log tmp%46#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@11: // return_assets_route_L39
+        let tmp%47#0: uint64 = (txn OnCompletion)
+        let tmp%48#0: bool = (! tmp%47#0)
+        (assert tmp%48#0) // OnCompletion is not NoOp
+        let tmp%49#0: uint64 = (txn ApplicationID)
+        (assert tmp%49#0) // can only call when not creating
+        let (maybe_value%0#1: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "assets")
+        (assert maybe_exists%0#0) // check self.assets exists
+        let tmp%52#0: bytes = (concat 0x151f7c75 maybe_value%0#1)
+        (log tmp%52#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@12: // return_accounts_route_L43
+        let tmp%53#0: uint64 = (txn OnCompletion)
+        let tmp%54#0: bool = (! tmp%53#0)
+        (assert tmp%54#0) // OnCompletion is not NoOp
+        let tmp%55#0: uint64 = (txn ApplicationID)
+        (assert tmp%55#0) // can only call when not creating
+        let (maybe_value%0#0: bytes[32][], maybe_exists%0#0: bool) = (app_global_get_ex 0u "accounts")
+        (assert maybe_exists%0#0) // check self.accounts exists
+        let tmp%58#0: bytes = (concat 0x151f7c75 maybe_value%0#0)
+        (log tmp%58#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@15: // bare_routing_L4
+        let tmp%59#0: uint64 = (txn OnCompletion)
+        goto tmp%59#0 ? block@19 : block@16
+    block@16: // __algopy_default_create_L1
+        let tmp%60#0: uint64 = (txn ApplicationID)
+        let tmp%61#0: bool = (! tmp%60#0)
+        (assert tmp%61#0) // can only call when creating
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@19: // after_if_else_L4
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 0u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@20: // after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router___L1
+        return tmp%0#0

--- a/test_cases/arc4_conversions/out_O2/ReferenceReturn.ir/ReferenceReturn.clear.0.destructured.ir
+++ b/test_cases/arc4_conversions/out_O2/ReferenceReturn.ir/ReferenceReturn.clear.0.destructured.ir
@@ -1,0 +1,3 @@
+main algopy.arc4.ARC4Contract.clear_state_program:
+    block@0: // L1
+        return 1u

--- a/test_cases/arc4_conversions/out_unoptimized/ReferenceReturn.approval.puya.map
+++ b/test_cases/arc4_conversions/out_unoptimized/ReferenceReturn.approval.puya.map
@@ -1,0 +1,2043 @@
+{
+  "version": 3,
+  "sources": [
+    "../reference.py"
+  ],
+  "mappings": ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAGA;;AAAA;AAAA;AAAA;;;AAAA;;;AAAA;;;;;;AAAA;;;;;;AAAA;;;;;;AAAA;;;;;;AAAA;;;;;;AAAA;;;;;;AAAA;;;;;;AAAA;;;;;;AAAA;;;;;;AAAA;;;;;;AAAA;;AAAA;;;;;;;;;;;;;;;;;;;;;;AAAA;;AAuCK;;AAAA;AAAA;AAAA;AAAA;;AAAA;AAAA;AAAA;AAAA;;;AAAA;AAAA;AAAA;AAAA;AAAA;;;;AAJA;;AAAA;AAAA;AAAA;AAAA;;AAAA;AAAA;AAAA;AAAA;;;AAAA;AAAA;AAAA;AAAA;AAAA;;;;AAJA;;AAAA;AAAA;AAAA;AAAA;;AAAA;AAAA;AAAA;AAAA;;;AAAA;AAAA;AAAA;AAAA;AAAA;;;;AAJA;;AAAA;AAAA;AAAA;AAAA;;AAAA;AAAA;AAAA;AA3BL;;;AA2BK;;;AAAA;;;;AAJA;;AAAA;AAAA;AAAA;AAAA;;AAAA;AAAA;AAAA;AAvBL;;;AAuBK;;;AAAA;;;;AAJA;;AAAA;AAAA;AAAA;AAAA;;AAAA;AAAA;AAAA;AAnBL;;;AAmBK;;;AAAA;;;;AANA;;AAAA;AAAA;AAAA;AAAA;;AAAA;AAAA;AAAA;AAbL;;;AAAA;AAAA;;AAAA;;;AAAA;AAAA;;AAAA;;;AAAA;AAAA;;AAaK;;AAAA;;AAAA;;AAAA;;;AAAA;;;;AAJA;;AAAA;AAAA;AAAA;AAAA;;AAAA;AAAA;AAAA;AAAA;;;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;;;;AAJA;;AAAA;AAAA;AAAA;AAAA;;AAAA;AAAA;AAAA;AAAA;;;AAAA;AAAA;AAAA;AAAA;AAAA;AAAA;;;;AAJA;;AAAA;AAAA;AAAA;AAAA;;AAAA;AAAA;AAAA;AAAA;;;AAAA;AAAA;AAAA;AAAA;AAAA;;;;AADL;;AAAA;AAAA;AAAA;;;;;;;;;;;;;;;;AAGe;;AAAP;AAIO;AAAP;AAIO;AAAP;AAER;;;AAEQ;;;;;AAAA;;AAAA;AACA;;;;;;;AAAA;;AAAA;AACA;;;;;AAAA;;AAAA;;AAER;;;AAEQ;AAAA;;AAAA;;AAER;;;AAEQ;AAAA;;AAAA;;AAER;;;AAEQ;AAAA;;AAAA;;AAIO;AAAA;AAAA;AAAA;AAAP;AAIO;AAAA;AAAA;AAAA;AAAP;AAIO;AAAA;AAAA;AAAA;AAAP",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "algopy.arc4.ARC4Contract.approval_program",
+      "params": {},
+      "block": "main",
+      "stack_in": [],
+      "op": "intcblock 0 1 1234"
+    },
+    "7": {
+      "op": "bytecblock 0x151f7c75 \"apps\" \"assets\" \"accounts\""
+    },
+    "35": {
+      "block": "main_block@1",
+      "stack_in": [],
+      "op": "txn NumAppArgs",
+      "defined_out": [
+        "tmp%0#1"
+      ],
+      "stack_out": [
+        "tmp%0#1"
+      ]
+    },
+    "37": {
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0",
+        "tmp%0#1"
+      ],
+      "stack_out": [
+        "tmp%0#1",
+        "0"
+      ]
+    },
+    "38": {
+      "op": "!=",
+      "defined_out": [
+        "tmp%1#0"
+      ],
+      "stack_out": [
+        "tmp%1#0"
+      ]
+    },
+    "39": {
+      "op": "bz main_bare_routing@15",
+      "stack_out": []
+    },
+    "42": {
+      "block": "main_abi_routing@2",
+      "stack_in": [],
+      "op": "txna ApplicationArgs 0",
+      "defined_out": [
+        "tmp%2#0"
+      ],
+      "stack_out": [
+        "tmp%2#0"
+      ]
+    },
+    "45": {
+      "op": "pushbytes 0x6c7a1cb5 // method \"acc_ret()address\"",
+      "defined_out": [
+        "Method(acc_ret()address)",
+        "tmp%2#0"
+      ],
+      "stack_out": [
+        "tmp%2#0",
+        "Method(acc_ret()address)"
+      ]
+    },
+    "51": {
+      "op": "pushbytes 0xc8480f0c // method \"asset_ret()uint64\"",
+      "defined_out": [
+        "Method(acc_ret()address)",
+        "Method(asset_ret()uint64)",
+        "tmp%2#0"
+      ],
+      "stack_out": [
+        "tmp%2#0",
+        "Method(acc_ret()address)",
+        "Method(asset_ret()uint64)"
+      ]
+    },
+    "57": {
+      "op": "pushbytes 0x37c0cbf2 // method \"app_ret()uint64\"",
+      "defined_out": [
+        "Method(acc_ret()address)",
+        "Method(app_ret()uint64)",
+        "Method(asset_ret()uint64)",
+        "tmp%2#0"
+      ],
+      "stack_out": [
+        "tmp%2#0",
+        "Method(acc_ret()address)",
+        "Method(asset_ret()uint64)",
+        "Method(app_ret()uint64)"
+      ]
+    },
+    "63": {
+      "op": "pushbytes 0x864086a7 // method \"store(account,application,asset)void\"",
+      "defined_out": [
+        "Method(acc_ret()address)",
+        "Method(app_ret()uint64)",
+        "Method(asset_ret()uint64)",
+        "Method(store(account,application,asset)void)",
+        "tmp%2#0"
+      ],
+      "stack_out": [
+        "tmp%2#0",
+        "Method(acc_ret()address)",
+        "Method(asset_ret()uint64)",
+        "Method(app_ret()uint64)",
+        "Method(store(account,application,asset)void)"
+      ]
+    },
+    "69": {
+      "op": "pushbytes 0x6728b1a1 // method \"store_apps(uint64[])void\"",
+      "defined_out": [
+        "Method(acc_ret()address)",
+        "Method(app_ret()uint64)",
+        "Method(asset_ret()uint64)",
+        "Method(store(account,application,asset)void)",
+        "Method(store_apps(uint64[])void)",
+        "tmp%2#0"
+      ],
+      "stack_out": [
+        "tmp%2#0",
+        "Method(acc_ret()address)",
+        "Method(asset_ret()uint64)",
+        "Method(app_ret()uint64)",
+        "Method(store(account,application,asset)void)",
+        "Method(store_apps(uint64[])void)"
+      ]
+    },
+    "75": {
+      "op": "pushbytes 0xce7e6cd3 // method \"store_assets(uint64[])void\"",
+      "defined_out": [
+        "Method(acc_ret()address)",
+        "Method(app_ret()uint64)",
+        "Method(asset_ret()uint64)",
+        "Method(store(account,application,asset)void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "tmp%2#0"
+      ],
+      "stack_out": [
+        "tmp%2#0",
+        "Method(acc_ret()address)",
+        "Method(asset_ret()uint64)",
+        "Method(app_ret()uint64)",
+        "Method(store(account,application,asset)void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)"
+      ]
+    },
+    "81": {
+      "op": "pushbytes 0x0a37f6e1 // method \"store_accounts(address[])void\"",
+      "defined_out": [
+        "Method(acc_ret()address)",
+        "Method(app_ret()uint64)",
+        "Method(asset_ret()uint64)",
+        "Method(store(account,application,asset)void)",
+        "Method(store_accounts(address[])void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "tmp%2#0"
+      ],
+      "stack_out": [
+        "tmp%2#0",
+        "Method(acc_ret()address)",
+        "Method(asset_ret()uint64)",
+        "Method(app_ret()uint64)",
+        "Method(store(account,application,asset)void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "Method(store_accounts(address[])void)"
+      ]
+    },
+    "87": {
+      "op": "pushbytes 0x4c894d7e // method \"return_apps()uint64[]\"",
+      "defined_out": [
+        "Method(acc_ret()address)",
+        "Method(app_ret()uint64)",
+        "Method(asset_ret()uint64)",
+        "Method(return_apps()uint64[])",
+        "Method(store(account,application,asset)void)",
+        "Method(store_accounts(address[])void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "tmp%2#0"
+      ],
+      "stack_out": [
+        "tmp%2#0",
+        "Method(acc_ret()address)",
+        "Method(asset_ret()uint64)",
+        "Method(app_ret()uint64)",
+        "Method(store(account,application,asset)void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "Method(store_accounts(address[])void)",
+        "Method(return_apps()uint64[])"
+      ]
+    },
+    "93": {
+      "op": "pushbytes 0x62ebcf89 // method \"return_assets()uint64[]\"",
+      "defined_out": [
+        "Method(acc_ret()address)",
+        "Method(app_ret()uint64)",
+        "Method(asset_ret()uint64)",
+        "Method(return_apps()uint64[])",
+        "Method(return_assets()uint64[])",
+        "Method(store(account,application,asset)void)",
+        "Method(store_accounts(address[])void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "tmp%2#0"
+      ],
+      "stack_out": [
+        "tmp%2#0",
+        "Method(acc_ret()address)",
+        "Method(asset_ret()uint64)",
+        "Method(app_ret()uint64)",
+        "Method(store(account,application,asset)void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "Method(store_accounts(address[])void)",
+        "Method(return_apps()uint64[])",
+        "Method(return_assets()uint64[])"
+      ]
+    },
+    "99": {
+      "op": "pushbytes 0x924e778c // method \"return_accounts()address[]\"",
+      "defined_out": [
+        "Method(acc_ret()address)",
+        "Method(app_ret()uint64)",
+        "Method(asset_ret()uint64)",
+        "Method(return_accounts()address[])",
+        "Method(return_apps()uint64[])",
+        "Method(return_assets()uint64[])",
+        "Method(store(account,application,asset)void)",
+        "Method(store_accounts(address[])void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "tmp%2#0"
+      ],
+      "stack_out": [
+        "tmp%2#0",
+        "Method(acc_ret()address)",
+        "Method(asset_ret()uint64)",
+        "Method(app_ret()uint64)",
+        "Method(store(account,application,asset)void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "Method(store_accounts(address[])void)",
+        "Method(return_apps()uint64[])",
+        "Method(return_assets()uint64[])",
+        "Method(return_accounts()address[])"
+      ]
+    },
+    "105": {
+      "op": "uncover 10",
+      "stack_out": [
+        "Method(acc_ret()address)",
+        "Method(asset_ret()uint64)",
+        "Method(app_ret()uint64)",
+        "Method(store(account,application,asset)void)",
+        "Method(store_apps(uint64[])void)",
+        "Method(store_assets(uint64[])void)",
+        "Method(store_accounts(address[])void)",
+        "Method(return_apps()uint64[])",
+        "Method(return_assets()uint64[])",
+        "Method(return_accounts()address[])",
+        "tmp%2#0"
+      ]
+    },
+    "107": {
+      "op": "match main_acc_ret_route@3 main_asset_ret_route@4 main_app_ret_route@5 main_store_route@6 main_store_apps_route@7 main_store_assets_route@8 main_store_accounts_route@9 main_return_apps_route@10 main_return_assets_route@11 main_return_accounts_route@12",
+      "stack_out": []
+    },
+    "129": {
+      "block": "main_after_if_else@19",
+      "stack_in": [],
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "130": {
+      "block": "main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20",
+      "stack_in": [
+        "tmp%0#0"
+      ],
+      "op": "return",
+      "defined_out": [],
+      "stack_out": []
+    },
+    "131": {
+      "block": "main_return_accounts_route@12",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%53#0"
+      ],
+      "stack_out": [
+        "tmp%53#0"
+      ]
+    },
+    "133": {
+      "op": "intc_0 // NoOp",
+      "defined_out": [
+        "NoOp",
+        "tmp%53#0"
+      ],
+      "stack_out": [
+        "tmp%53#0",
+        "NoOp"
+      ]
+    },
+    "134": {
+      "op": "==",
+      "defined_out": [
+        "tmp%54#0"
+      ],
+      "stack_out": [
+        "tmp%54#0"
+      ]
+    },
+    "135": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "136": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%55#0"
+      ],
+      "stack_out": [
+        "tmp%55#0"
+      ]
+    },
+    "138": {
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0",
+        "tmp%55#0"
+      ],
+      "stack_out": [
+        "tmp%55#0",
+        "0"
+      ]
+    },
+    "139": {
+      "op": "!=",
+      "defined_out": [
+        "tmp%56#0"
+      ],
+      "stack_out": [
+        "tmp%56#0"
+      ]
+    },
+    "140": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "141": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts",
+      "op": "callsub return_accounts",
+      "defined_out": [
+        "tmp%57#0"
+      ],
+      "stack_out": [
+        "tmp%57#0"
+      ]
+    },
+    "144": {
+      "op": "bytec_0 // 0x151f7c75",
+      "defined_out": [
+        "0x151f7c75",
+        "tmp%57#0"
+      ],
+      "stack_out": [
+        "tmp%57#0",
+        "0x151f7c75"
+      ]
+    },
+    "145": {
+      "op": "swap",
+      "stack_out": [
+        "0x151f7c75",
+        "tmp%57#0"
+      ]
+    },
+    "146": {
+      "op": "concat",
+      "defined_out": [
+        "tmp%58#0"
+      ],
+      "stack_out": [
+        "tmp%58#0"
+      ]
+    },
+    "147": {
+      "op": "log",
+      "stack_out": []
+    },
+    "148": {
+      "op": "intc_1 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "149": {
+      "op": "b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20"
+    },
+    "152": {
+      "block": "main_return_assets_route@11",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%47#0"
+      ],
+      "stack_out": [
+        "tmp%47#0"
+      ]
+    },
+    "154": {
+      "op": "intc_0 // NoOp",
+      "defined_out": [
+        "NoOp",
+        "tmp%47#0"
+      ],
+      "stack_out": [
+        "tmp%47#0",
+        "NoOp"
+      ]
+    },
+    "155": {
+      "op": "==",
+      "defined_out": [
+        "tmp%48#0"
+      ],
+      "stack_out": [
+        "tmp%48#0"
+      ]
+    },
+    "156": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "157": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%49#0"
+      ],
+      "stack_out": [
+        "tmp%49#0"
+      ]
+    },
+    "159": {
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0",
+        "tmp%49#0"
+      ],
+      "stack_out": [
+        "tmp%49#0",
+        "0"
+      ]
+    },
+    "160": {
+      "op": "!=",
+      "defined_out": [
+        "tmp%50#0"
+      ],
+      "stack_out": [
+        "tmp%50#0"
+      ]
+    },
+    "161": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "162": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.return_assets",
+      "op": "callsub return_assets",
+      "defined_out": [
+        "tmp%51#0"
+      ],
+      "stack_out": [
+        "tmp%51#0"
+      ]
+    },
+    "165": {
+      "op": "bytec_0 // 0x151f7c75",
+      "defined_out": [
+        "0x151f7c75",
+        "tmp%51#0"
+      ],
+      "stack_out": [
+        "tmp%51#0",
+        "0x151f7c75"
+      ]
+    },
+    "166": {
+      "op": "swap",
+      "stack_out": [
+        "0x151f7c75",
+        "tmp%51#0"
+      ]
+    },
+    "167": {
+      "op": "concat",
+      "defined_out": [
+        "tmp%52#0"
+      ],
+      "stack_out": [
+        "tmp%52#0"
+      ]
+    },
+    "168": {
+      "op": "log",
+      "stack_out": []
+    },
+    "169": {
+      "op": "intc_1 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "170": {
+      "op": "b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20"
+    },
+    "173": {
+      "block": "main_return_apps_route@10",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%41#0"
+      ],
+      "stack_out": [
+        "tmp%41#0"
+      ]
+    },
+    "175": {
+      "op": "intc_0 // NoOp",
+      "defined_out": [
+        "NoOp",
+        "tmp%41#0"
+      ],
+      "stack_out": [
+        "tmp%41#0",
+        "NoOp"
+      ]
+    },
+    "176": {
+      "op": "==",
+      "defined_out": [
+        "tmp%42#0"
+      ],
+      "stack_out": [
+        "tmp%42#0"
+      ]
+    },
+    "177": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "178": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%43#0"
+      ],
+      "stack_out": [
+        "tmp%43#0"
+      ]
+    },
+    "180": {
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0",
+        "tmp%43#0"
+      ],
+      "stack_out": [
+        "tmp%43#0",
+        "0"
+      ]
+    },
+    "181": {
+      "op": "!=",
+      "defined_out": [
+        "tmp%44#0"
+      ],
+      "stack_out": [
+        "tmp%44#0"
+      ]
+    },
+    "182": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "183": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.return_apps",
+      "op": "callsub return_apps",
+      "defined_out": [
+        "tmp%45#0"
+      ],
+      "stack_out": [
+        "tmp%45#0"
+      ]
+    },
+    "186": {
+      "op": "bytec_0 // 0x151f7c75",
+      "defined_out": [
+        "0x151f7c75",
+        "tmp%45#0"
+      ],
+      "stack_out": [
+        "tmp%45#0",
+        "0x151f7c75"
+      ]
+    },
+    "187": {
+      "op": "swap",
+      "stack_out": [
+        "0x151f7c75",
+        "tmp%45#0"
+      ]
+    },
+    "188": {
+      "op": "concat",
+      "defined_out": [
+        "tmp%46#0"
+      ],
+      "stack_out": [
+        "tmp%46#0"
+      ]
+    },
+    "189": {
+      "op": "log",
+      "stack_out": []
+    },
+    "190": {
+      "op": "intc_1 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "191": {
+      "op": "b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20"
+    },
+    "194": {
+      "block": "main_store_accounts_route@9",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%37#0"
+      ],
+      "stack_out": [
+        "tmp%37#0"
+      ]
+    },
+    "196": {
+      "op": "intc_0 // NoOp",
+      "defined_out": [
+        "NoOp",
+        "tmp%37#0"
+      ],
+      "stack_out": [
+        "tmp%37#0",
+        "NoOp"
+      ]
+    },
+    "197": {
+      "op": "==",
+      "defined_out": [
+        "tmp%38#0"
+      ],
+      "stack_out": [
+        "tmp%38#0"
+      ]
+    },
+    "198": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "199": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%39#0"
+      ],
+      "stack_out": [
+        "tmp%39#0"
+      ]
+    },
+    "201": {
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0",
+        "tmp%39#0"
+      ],
+      "stack_out": [
+        "tmp%39#0",
+        "0"
+      ]
+    },
+    "202": {
+      "op": "!=",
+      "defined_out": [
+        "tmp%40#0"
+      ],
+      "stack_out": [
+        "tmp%40#0"
+      ]
+    },
+    "203": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "204": {
+      "op": "txna ApplicationArgs 1",
+      "defined_out": [
+        "reinterpret_bytes[32][]%0#0"
+      ],
+      "stack_out": [
+        "reinterpret_bytes[32][]%0#0"
+      ]
+    },
+    "207": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts",
+      "op": "callsub store_accounts",
+      "stack_out": []
+    },
+    "210": {
+      "op": "intc_1 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "211": {
+      "op": "b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20"
+    },
+    "214": {
+      "block": "main_store_assets_route@8",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%33#0"
+      ],
+      "stack_out": [
+        "tmp%33#0"
+      ]
+    },
+    "216": {
+      "op": "intc_0 // NoOp",
+      "defined_out": [
+        "NoOp",
+        "tmp%33#0"
+      ],
+      "stack_out": [
+        "tmp%33#0",
+        "NoOp"
+      ]
+    },
+    "217": {
+      "op": "==",
+      "defined_out": [
+        "tmp%34#0"
+      ],
+      "stack_out": [
+        "tmp%34#0"
+      ]
+    },
+    "218": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "219": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%35#0"
+      ],
+      "stack_out": [
+        "tmp%35#0"
+      ]
+    },
+    "221": {
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0",
+        "tmp%35#0"
+      ],
+      "stack_out": [
+        "tmp%35#0",
+        "0"
+      ]
+    },
+    "222": {
+      "op": "!=",
+      "defined_out": [
+        "tmp%36#0"
+      ],
+      "stack_out": [
+        "tmp%36#0"
+      ]
+    },
+    "223": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "224": {
+      "op": "txna ApplicationArgs 1",
+      "defined_out": [
+        "reinterpret_encoded_uint64[]%1#0"
+      ],
+      "stack_out": [
+        "reinterpret_encoded_uint64[]%1#0"
+      ]
+    },
+    "227": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.store_assets",
+      "op": "callsub store_assets",
+      "stack_out": []
+    },
+    "230": {
+      "op": "intc_1 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "231": {
+      "op": "b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20"
+    },
+    "234": {
+      "block": "main_store_apps_route@7",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%29#0"
+      ],
+      "stack_out": [
+        "tmp%29#0"
+      ]
+    },
+    "236": {
+      "op": "intc_0 // NoOp",
+      "defined_out": [
+        "NoOp",
+        "tmp%29#0"
+      ],
+      "stack_out": [
+        "tmp%29#0",
+        "NoOp"
+      ]
+    },
+    "237": {
+      "op": "==",
+      "defined_out": [
+        "tmp%30#0"
+      ],
+      "stack_out": [
+        "tmp%30#0"
+      ]
+    },
+    "238": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "239": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%31#0"
+      ],
+      "stack_out": [
+        "tmp%31#0"
+      ]
+    },
+    "241": {
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0",
+        "tmp%31#0"
+      ],
+      "stack_out": [
+        "tmp%31#0",
+        "0"
+      ]
+    },
+    "242": {
+      "op": "!=",
+      "defined_out": [
+        "tmp%32#0"
+      ],
+      "stack_out": [
+        "tmp%32#0"
+      ]
+    },
+    "243": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "244": {
+      "op": "txna ApplicationArgs 1",
+      "defined_out": [
+        "reinterpret_encoded_uint64[]%0#0"
+      ],
+      "stack_out": [
+        "reinterpret_encoded_uint64[]%0#0"
+      ]
+    },
+    "247": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.store_apps",
+      "op": "callsub store_apps",
+      "stack_out": []
+    },
+    "250": {
+      "op": "intc_1 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "251": {
+      "op": "b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20"
+    },
+    "254": {
+      "block": "main_store_route@6",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%19#0"
+      ],
+      "stack_out": [
+        "tmp%19#0"
+      ]
+    },
+    "256": {
+      "op": "intc_0 // NoOp",
+      "defined_out": [
+        "NoOp",
+        "tmp%19#0"
+      ],
+      "stack_out": [
+        "tmp%19#0",
+        "NoOp"
+      ]
+    },
+    "257": {
+      "op": "==",
+      "defined_out": [
+        "tmp%20#0"
+      ],
+      "stack_out": [
+        "tmp%20#0"
+      ]
+    },
+    "258": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "259": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%21#0"
+      ],
+      "stack_out": [
+        "tmp%21#0"
+      ]
+    },
+    "261": {
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0",
+        "tmp%21#0"
+      ],
+      "stack_out": [
+        "tmp%21#0",
+        "0"
+      ]
+    },
+    "262": {
+      "op": "!=",
+      "defined_out": [
+        "tmp%22#0"
+      ],
+      "stack_out": [
+        "tmp%22#0"
+      ]
+    },
+    "263": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "264": {
+      "op": "txna ApplicationArgs 1",
+      "defined_out": [
+        "reinterpret_bytes[1]%0#0"
+      ],
+      "stack_out": [
+        "reinterpret_bytes[1]%0#0"
+      ]
+    },
+    "267": {
+      "op": "btoi",
+      "defined_out": [
+        "tmp%23#0"
+      ],
+      "stack_out": [
+        "tmp%23#0"
+      ]
+    },
+    "268": {
+      "op": "txnas Accounts",
+      "defined_out": [
+        "tmp%24#0"
+      ],
+      "stack_out": [
+        "tmp%24#0"
+      ]
+    },
+    "270": {
+      "op": "txna ApplicationArgs 2",
+      "defined_out": [
+        "reinterpret_bytes[1]%1#0",
+        "tmp%24#0"
+      ],
+      "stack_out": [
+        "tmp%24#0",
+        "reinterpret_bytes[1]%1#0"
+      ]
+    },
+    "273": {
+      "op": "btoi",
+      "defined_out": [
+        "tmp%24#0",
+        "tmp%25#0"
+      ],
+      "stack_out": [
+        "tmp%24#0",
+        "tmp%25#0"
+      ]
+    },
+    "274": {
+      "op": "txnas Applications",
+      "defined_out": [
+        "tmp%24#0",
+        "tmp%26#0"
+      ],
+      "stack_out": [
+        "tmp%24#0",
+        "tmp%26#0"
+      ]
+    },
+    "276": {
+      "op": "txna ApplicationArgs 3",
+      "defined_out": [
+        "reinterpret_bytes[1]%2#0",
+        "tmp%24#0",
+        "tmp%26#0"
+      ],
+      "stack_out": [
+        "tmp%24#0",
+        "tmp%26#0",
+        "reinterpret_bytes[1]%2#0"
+      ]
+    },
+    "279": {
+      "op": "btoi",
+      "defined_out": [
+        "tmp%24#0",
+        "tmp%26#0",
+        "tmp%27#0"
+      ],
+      "stack_out": [
+        "tmp%24#0",
+        "tmp%26#0",
+        "tmp%27#0"
+      ]
+    },
+    "280": {
+      "op": "txnas Assets",
+      "defined_out": [
+        "tmp%24#0",
+        "tmp%26#0",
+        "tmp%28#0"
+      ],
+      "stack_out": [
+        "tmp%24#0",
+        "tmp%26#0",
+        "tmp%28#0"
+      ]
+    },
+    "282": {
+      "op": "uncover 2",
+      "stack_out": [
+        "tmp%26#0",
+        "tmp%28#0",
+        "tmp%24#0"
+      ]
+    },
+    "284": {
+      "op": "uncover 2",
+      "stack_out": [
+        "tmp%28#0",
+        "tmp%24#0",
+        "tmp%26#0"
+      ]
+    },
+    "286": {
+      "op": "uncover 2",
+      "stack_out": [
+        "tmp%24#0",
+        "tmp%26#0",
+        "tmp%28#0"
+      ]
+    },
+    "288": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.store",
+      "op": "callsub store",
+      "stack_out": []
+    },
+    "291": {
+      "op": "intc_1 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "292": {
+      "op": "b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20"
+    },
+    "295": {
+      "block": "main_app_ret_route@5",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%14#0"
+      ],
+      "stack_out": [
+        "tmp%14#0"
+      ]
+    },
+    "297": {
+      "op": "intc_0 // NoOp",
+      "defined_out": [
+        "NoOp",
+        "tmp%14#0"
+      ],
+      "stack_out": [
+        "tmp%14#0",
+        "NoOp"
+      ]
+    },
+    "298": {
+      "op": "==",
+      "defined_out": [
+        "tmp%15#0"
+      ],
+      "stack_out": [
+        "tmp%15#0"
+      ]
+    },
+    "299": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "300": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%16#0"
+      ],
+      "stack_out": [
+        "tmp%16#0"
+      ]
+    },
+    "302": {
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0",
+        "tmp%16#0"
+      ],
+      "stack_out": [
+        "tmp%16#0",
+        "0"
+      ]
+    },
+    "303": {
+      "op": "!=",
+      "defined_out": [
+        "tmp%17#0"
+      ],
+      "stack_out": [
+        "tmp%17#0"
+      ]
+    },
+    "304": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "305": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.app_ret",
+      "op": "callsub app_ret",
+      "defined_out": [
+        "to_encode%1#0"
+      ],
+      "stack_out": [
+        "to_encode%1#0"
+      ]
+    },
+    "308": {
+      "op": "itob",
+      "defined_out": [
+        "val_as_bytes%1#0"
+      ],
+      "stack_out": [
+        "val_as_bytes%1#0"
+      ]
+    },
+    "309": {
+      "op": "bytec_0 // 0x151f7c75",
+      "defined_out": [
+        "0x151f7c75",
+        "val_as_bytes%1#0"
+      ],
+      "stack_out": [
+        "val_as_bytes%1#0",
+        "0x151f7c75"
+      ]
+    },
+    "310": {
+      "op": "swap",
+      "stack_out": [
+        "0x151f7c75",
+        "val_as_bytes%1#0"
+      ]
+    },
+    "311": {
+      "op": "concat",
+      "defined_out": [
+        "tmp%18#0"
+      ],
+      "stack_out": [
+        "tmp%18#0"
+      ]
+    },
+    "312": {
+      "op": "log",
+      "stack_out": []
+    },
+    "313": {
+      "op": "intc_1 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "314": {
+      "op": "b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20"
+    },
+    "317": {
+      "block": "main_asset_ret_route@4",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%9#0"
+      ],
+      "stack_out": [
+        "tmp%9#0"
+      ]
+    },
+    "319": {
+      "op": "intc_0 // NoOp",
+      "defined_out": [
+        "NoOp",
+        "tmp%9#0"
+      ],
+      "stack_out": [
+        "tmp%9#0",
+        "NoOp"
+      ]
+    },
+    "320": {
+      "op": "==",
+      "defined_out": [
+        "tmp%10#0"
+      ],
+      "stack_out": [
+        "tmp%10#0"
+      ]
+    },
+    "321": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "322": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%11#0"
+      ],
+      "stack_out": [
+        "tmp%11#0"
+      ]
+    },
+    "324": {
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0",
+        "tmp%11#0"
+      ],
+      "stack_out": [
+        "tmp%11#0",
+        "0"
+      ]
+    },
+    "325": {
+      "op": "!=",
+      "defined_out": [
+        "tmp%12#0"
+      ],
+      "stack_out": [
+        "tmp%12#0"
+      ]
+    },
+    "326": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "327": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret",
+      "op": "callsub asset_ret",
+      "defined_out": [
+        "to_encode%0#0"
+      ],
+      "stack_out": [
+        "to_encode%0#0"
+      ]
+    },
+    "330": {
+      "op": "itob",
+      "defined_out": [
+        "val_as_bytes%0#0"
+      ],
+      "stack_out": [
+        "val_as_bytes%0#0"
+      ]
+    },
+    "331": {
+      "op": "bytec_0 // 0x151f7c75",
+      "defined_out": [
+        "0x151f7c75",
+        "val_as_bytes%0#0"
+      ],
+      "stack_out": [
+        "val_as_bytes%0#0",
+        "0x151f7c75"
+      ]
+    },
+    "332": {
+      "op": "swap",
+      "stack_out": [
+        "0x151f7c75",
+        "val_as_bytes%0#0"
+      ]
+    },
+    "333": {
+      "op": "concat",
+      "defined_out": [
+        "tmp%13#0"
+      ],
+      "stack_out": [
+        "tmp%13#0"
+      ]
+    },
+    "334": {
+      "op": "log",
+      "stack_out": []
+    },
+    "335": {
+      "op": "intc_1 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "336": {
+      "op": "b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20"
+    },
+    "339": {
+      "block": "main_acc_ret_route@3",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%3#0"
+      ],
+      "stack_out": [
+        "tmp%3#0"
+      ]
+    },
+    "341": {
+      "op": "intc_0 // NoOp",
+      "defined_out": [
+        "NoOp",
+        "tmp%3#0"
+      ],
+      "stack_out": [
+        "tmp%3#0",
+        "NoOp"
+      ]
+    },
+    "342": {
+      "op": "==",
+      "defined_out": [
+        "tmp%4#0"
+      ],
+      "stack_out": [
+        "tmp%4#0"
+      ]
+    },
+    "343": {
+      "error": "OnCompletion is not NoOp",
+      "op": "assert // OnCompletion is not NoOp",
+      "stack_out": []
+    },
+    "344": {
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%5#0"
+      ],
+      "stack_out": [
+        "tmp%5#0"
+      ]
+    },
+    "346": {
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0",
+        "tmp%5#0"
+      ],
+      "stack_out": [
+        "tmp%5#0",
+        "0"
+      ]
+    },
+    "347": {
+      "op": "!=",
+      "defined_out": [
+        "tmp%6#0"
+      ],
+      "stack_out": [
+        "tmp%6#0"
+      ]
+    },
+    "348": {
+      "error": "can only call when not creating",
+      "op": "assert // can only call when not creating",
+      "stack_out": []
+    },
+    "349": {
+      "callsub": "test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret",
+      "op": "callsub acc_ret",
+      "defined_out": [
+        "tmp%7#0"
+      ],
+      "stack_out": [
+        "tmp%7#0"
+      ]
+    },
+    "352": {
+      "op": "bytec_0 // 0x151f7c75",
+      "defined_out": [
+        "0x151f7c75",
+        "tmp%7#0"
+      ],
+      "stack_out": [
+        "tmp%7#0",
+        "0x151f7c75"
+      ]
+    },
+    "353": {
+      "op": "swap",
+      "stack_out": [
+        "0x151f7c75",
+        "tmp%7#0"
+      ]
+    },
+    "354": {
+      "op": "concat",
+      "defined_out": [
+        "tmp%8#0"
+      ],
+      "stack_out": [
+        "tmp%8#0"
+      ]
+    },
+    "355": {
+      "op": "log",
+      "stack_out": []
+    },
+    "356": {
+      "op": "intc_1 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "357": {
+      "op": "b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20"
+    },
+    "360": {
+      "block": "main_bare_routing@15",
+      "stack_in": [],
+      "op": "txn OnCompletion",
+      "defined_out": [
+        "tmp%59#0"
+      ],
+      "stack_out": [
+        "tmp%59#0"
+      ]
+    },
+    "362": {
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0",
+        "tmp%59#0"
+      ],
+      "stack_out": [
+        "tmp%59#0",
+        "0"
+      ]
+    },
+    "363": {
+      "op": "swap",
+      "stack_out": [
+        "0",
+        "tmp%59#0"
+      ]
+    },
+    "364": {
+      "op": "match main___algopy_default_create@16",
+      "stack_out": []
+    },
+    "368": {
+      "block": "main_switch_case_next@18",
+      "stack_in": [],
+      "op": "b main_after_if_else@19"
+    },
+    "371": {
+      "block": "main___algopy_default_create@16",
+      "stack_in": [],
+      "op": "txn ApplicationID",
+      "defined_out": [
+        "tmp%60#0"
+      ],
+      "stack_out": [
+        "tmp%60#0"
+      ]
+    },
+    "373": {
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0",
+        "tmp%60#0"
+      ],
+      "stack_out": [
+        "tmp%60#0",
+        "0"
+      ]
+    },
+    "374": {
+      "op": "==",
+      "defined_out": [
+        "tmp%61#0"
+      ],
+      "stack_out": [
+        "tmp%61#0"
+      ]
+    },
+    "375": {
+      "error": "can only call when creating",
+      "op": "assert // can only call when creating",
+      "stack_out": []
+    },
+    "376": {
+      "block": "main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create@22",
+      "stack_in": [],
+      "op": "intc_1 // 1",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "377": {
+      "op": "b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20"
+    },
+    "380": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret",
+      "params": {},
+      "block": "acc_ret_block@0",
+      "stack_in": [],
+      "op": "txn Sender",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "382": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "383": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret",
+      "params": {},
+      "block": "asset_ret_block@0",
+      "stack_in": [],
+      "op": "intc_2 // 1234",
+      "defined_out": [
+        "1234"
+      ],
+      "stack_out": [
+        "1234"
+      ]
+    },
+    "384": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "385": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.app_ret",
+      "params": {},
+      "block": "app_ret_block@0",
+      "stack_in": [],
+      "op": "intc_2 // 1234",
+      "defined_out": [
+        "1234"
+      ],
+      "stack_out": [
+        "1234"
+      ]
+    },
+    "386": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "387": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.store",
+      "params": {
+        "acc#0": "bytes",
+        "app#0": "uint64",
+        "asset#0": "uint64"
+      },
+      "block": "store",
+      "stack_in": [],
+      "op": "proto 3 0"
+    },
+    "390": {
+      "block": "store_block@0",
+      "stack_in": [],
+      "op": "pushbytes \"acc\"",
+      "defined_out": [
+        "\"acc\""
+      ],
+      "stack_out": [
+        "\"acc\""
+      ]
+    },
+    "395": {
+      "op": "frame_dig -3",
+      "defined_out": [
+        "\"acc\"",
+        "acc#0 (copy)"
+      ],
+      "stack_out": [
+        "\"acc\"",
+        "acc#0 (copy)"
+      ]
+    },
+    "397": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "398": {
+      "op": "pushbytes \"asset\"",
+      "defined_out": [
+        "\"asset\""
+      ],
+      "stack_out": [
+        "\"asset\""
+      ]
+    },
+    "405": {
+      "op": "frame_dig -1",
+      "defined_out": [
+        "\"asset\"",
+        "asset#0 (copy)"
+      ],
+      "stack_out": [
+        "\"asset\"",
+        "asset#0 (copy)"
+      ]
+    },
+    "407": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "408": {
+      "op": "pushbytes \"app\"",
+      "defined_out": [
+        "\"app\""
+      ],
+      "stack_out": [
+        "\"app\""
+      ]
+    },
+    "413": {
+      "op": "frame_dig -2",
+      "defined_out": [
+        "\"app\"",
+        "app#0 (copy)"
+      ],
+      "stack_out": [
+        "\"app\"",
+        "app#0 (copy)"
+      ]
+    },
+    "415": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "416": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "417": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.store_apps",
+      "params": {
+        "apps#0": "bytes"
+      },
+      "block": "store_apps",
+      "stack_in": [],
+      "op": "proto 1 0"
+    },
+    "420": {
+      "block": "store_apps_block@0",
+      "stack_in": [],
+      "op": "bytec_1 // \"apps\"",
+      "defined_out": [
+        "\"apps\""
+      ],
+      "stack_out": [
+        "\"apps\""
+      ]
+    },
+    "421": {
+      "op": "frame_dig -1",
+      "defined_out": [
+        "\"apps\"",
+        "apps#0 (copy)"
+      ],
+      "stack_out": [
+        "\"apps\"",
+        "apps#0 (copy)"
+      ]
+    },
+    "423": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "424": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "425": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.store_assets",
+      "params": {
+        "assets#0": "bytes"
+      },
+      "block": "store_assets",
+      "stack_in": [],
+      "op": "proto 1 0"
+    },
+    "428": {
+      "block": "store_assets_block@0",
+      "stack_in": [],
+      "op": "bytec_2 // \"assets\"",
+      "defined_out": [
+        "\"assets\""
+      ],
+      "stack_out": [
+        "\"assets\""
+      ]
+    },
+    "429": {
+      "op": "frame_dig -1",
+      "defined_out": [
+        "\"assets\"",
+        "assets#0 (copy)"
+      ],
+      "stack_out": [
+        "\"assets\"",
+        "assets#0 (copy)"
+      ]
+    },
+    "431": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "432": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "433": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts",
+      "params": {
+        "accounts#0": "bytes"
+      },
+      "block": "store_accounts",
+      "stack_in": [],
+      "op": "proto 1 0"
+    },
+    "436": {
+      "block": "store_accounts_block@0",
+      "stack_in": [],
+      "op": "bytec_3 // \"accounts\"",
+      "defined_out": [
+        "\"accounts\""
+      ],
+      "stack_out": [
+        "\"accounts\""
+      ]
+    },
+    "437": {
+      "op": "frame_dig -1",
+      "defined_out": [
+        "\"accounts\"",
+        "accounts#0 (copy)"
+      ],
+      "stack_out": [
+        "\"accounts\"",
+        "accounts#0 (copy)"
+      ]
+    },
+    "439": {
+      "op": "app_global_put",
+      "stack_out": []
+    },
+    "440": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "441": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.return_apps",
+      "params": {},
+      "block": "return_apps_block@0",
+      "stack_in": [],
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0"
+      ],
+      "stack_out": [
+        "0"
+      ]
+    },
+    "442": {
+      "op": "bytec_1 // \"apps\"",
+      "defined_out": [
+        "\"apps\"",
+        "0"
+      ],
+      "stack_out": [
+        "0",
+        "\"apps\""
+      ]
+    },
+    "443": {
+      "op": "app_global_get_ex",
+      "defined_out": [
+        "maybe_exists%0#0",
+        "maybe_value%0#0"
+      ],
+      "stack_out": [
+        "maybe_value%0#0",
+        "maybe_exists%0#0"
+      ]
+    },
+    "444": {
+      "error": "check self.apps exists",
+      "op": "assert // check self.apps exists",
+      "stack_out": [
+        "maybe_value%0#0"
+      ]
+    },
+    "445": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "446": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.return_assets",
+      "params": {},
+      "block": "return_assets_block@0",
+      "stack_in": [],
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0"
+      ],
+      "stack_out": [
+        "0"
+      ]
+    },
+    "447": {
+      "op": "bytec_2 // \"assets\"",
+      "defined_out": [
+        "\"assets\"",
+        "0"
+      ],
+      "stack_out": [
+        "0",
+        "\"assets\""
+      ]
+    },
+    "448": {
+      "op": "app_global_get_ex",
+      "defined_out": [
+        "maybe_exists%0#0",
+        "maybe_value%0#0"
+      ],
+      "stack_out": [
+        "maybe_value%0#0",
+        "maybe_exists%0#0"
+      ]
+    },
+    "449": {
+      "error": "check self.assets exists",
+      "op": "assert // check self.assets exists",
+      "stack_out": [
+        "maybe_value%0#0"
+      ]
+    },
+    "450": {
+      "retsub": true,
+      "op": "retsub"
+    },
+    "451": {
+      "subroutine": "test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts",
+      "params": {},
+      "block": "return_accounts_block@0",
+      "stack_in": [],
+      "op": "intc_0 // 0",
+      "defined_out": [
+        "0"
+      ],
+      "stack_out": [
+        "0"
+      ]
+    },
+    "452": {
+      "op": "bytec_3 // \"accounts\"",
+      "defined_out": [
+        "\"accounts\"",
+        "0"
+      ],
+      "stack_out": [
+        "0",
+        "\"accounts\""
+      ]
+    },
+    "453": {
+      "op": "app_global_get_ex",
+      "defined_out": [
+        "maybe_exists%0#0",
+        "maybe_value%0#0"
+      ],
+      "stack_out": [
+        "maybe_value%0#0",
+        "maybe_exists%0#0"
+      ]
+    },
+    "454": {
+      "error": "check self.accounts exists",
+      "op": "assert // check self.accounts exists",
+      "stack_out": [
+        "maybe_value%0#0"
+      ]
+    },
+    "455": {
+      "retsub": true,
+      "op": "retsub"
+    }
+  }
+}

--- a/test_cases/arc4_conversions/out_unoptimized/ReferenceReturn.approval.teal
+++ b/test_cases/arc4_conversions/out_unoptimized/ReferenceReturn.approval.teal
@@ -1,0 +1,421 @@
+#pragma version 10
+#pragma typetrack false
+
+// algopy.arc4.ARC4Contract.approval_program() -> uint64:
+main:
+    intcblock 0 1 1234
+    bytecblock 0x151f7c75 "apps" "assets" "accounts"
+
+main_block@0:
+
+main_block@1:
+    // arc4_conversions/reference.py:4
+    // class ReferenceReturn(arc4.ARC4Contract):
+    txn NumAppArgs
+    intc_0 // 0
+    !=
+    bz main_bare_routing@15
+
+main_abi_routing@2:
+    // arc4_conversions/reference.py:4
+    // class ReferenceReturn(arc4.ARC4Contract):
+    txna ApplicationArgs 0
+    pushbytes 0x6c7a1cb5 // method "acc_ret()address"
+    pushbytes 0xc8480f0c // method "asset_ret()uint64"
+    pushbytes 0x37c0cbf2 // method "app_ret()uint64"
+    pushbytes 0x864086a7 // method "store(account,application,asset)void"
+    pushbytes 0x6728b1a1 // method "store_apps(uint64[])void"
+    pushbytes 0xce7e6cd3 // method "store_assets(uint64[])void"
+    pushbytes 0x0a37f6e1 // method "store_accounts(address[])void"
+    pushbytes 0x4c894d7e // method "return_apps()uint64[]"
+    pushbytes 0x62ebcf89 // method "return_assets()uint64[]"
+    pushbytes 0x924e778c // method "return_accounts()address[]"
+    uncover 10
+    match main_acc_ret_route@3 main_asset_ret_route@4 main_app_ret_route@5 main_store_route@6 main_store_apps_route@7 main_store_assets_route@8 main_store_accounts_route@9 main_return_apps_route@10 main_return_assets_route@11 main_return_accounts_route@12
+
+main_switch_case_default@13:
+
+main_switch_case_next@14:
+
+main_after_if_else@19:
+    // arc4_conversions/reference.py:4
+    // class ReferenceReturn(arc4.ARC4Contract):
+    intc_0 // 0
+
+main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20:
+    return
+
+main_return_accounts_route@12:
+    // arc4_conversions/reference.py:43
+    // @arc4.abimethod
+    txn OnCompletion
+    intc_0 // NoOp
+    ==
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    intc_0 // 0
+    !=
+    assert // can only call when not creating
+    callsub return_accounts
+    bytec_0 // 0x151f7c75
+    swap
+    concat
+    log
+    intc_1 // 1
+    b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20
+
+main_return_assets_route@11:
+    // arc4_conversions/reference.py:39
+    // @arc4.abimethod
+    txn OnCompletion
+    intc_0 // NoOp
+    ==
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    intc_0 // 0
+    !=
+    assert // can only call when not creating
+    callsub return_assets
+    bytec_0 // 0x151f7c75
+    swap
+    concat
+    log
+    intc_1 // 1
+    b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20
+
+main_return_apps_route@10:
+    // arc4_conversions/reference.py:35
+    // @arc4.abimethod
+    txn OnCompletion
+    intc_0 // NoOp
+    ==
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    intc_0 // 0
+    !=
+    assert // can only call when not creating
+    callsub return_apps
+    bytec_0 // 0x151f7c75
+    swap
+    concat
+    log
+    intc_1 // 1
+    b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20
+
+main_store_accounts_route@9:
+    // arc4_conversions/reference.py:31
+    // @arc4.abimethod
+    txn OnCompletion
+    intc_0 // NoOp
+    ==
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    intc_0 // 0
+    !=
+    assert // can only call when not creating
+    // arc4_conversions/reference.py:4
+    // class ReferenceReturn(arc4.ARC4Contract):
+    txna ApplicationArgs 1
+    // arc4_conversions/reference.py:31
+    // @arc4.abimethod
+    callsub store_accounts
+    intc_1 // 1
+    b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20
+
+main_store_assets_route@8:
+    // arc4_conversions/reference.py:27
+    // @arc4.abimethod
+    txn OnCompletion
+    intc_0 // NoOp
+    ==
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    intc_0 // 0
+    !=
+    assert // can only call when not creating
+    // arc4_conversions/reference.py:4
+    // class ReferenceReturn(arc4.ARC4Contract):
+    txna ApplicationArgs 1
+    // arc4_conversions/reference.py:27
+    // @arc4.abimethod
+    callsub store_assets
+    intc_1 // 1
+    b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20
+
+main_store_apps_route@7:
+    // arc4_conversions/reference.py:23
+    // @arc4.abimethod
+    txn OnCompletion
+    intc_0 // NoOp
+    ==
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    intc_0 // 0
+    !=
+    assert // can only call when not creating
+    // arc4_conversions/reference.py:4
+    // class ReferenceReturn(arc4.ARC4Contract):
+    txna ApplicationArgs 1
+    // arc4_conversions/reference.py:23
+    // @arc4.abimethod
+    callsub store_apps
+    intc_1 // 1
+    b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20
+
+main_store_route@6:
+    // arc4_conversions/reference.py:17
+    // @arc4.abimethod
+    txn OnCompletion
+    intc_0 // NoOp
+    ==
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    intc_0 // 0
+    !=
+    assert // can only call when not creating
+    // arc4_conversions/reference.py:4
+    // class ReferenceReturn(arc4.ARC4Contract):
+    txna ApplicationArgs 1
+    btoi
+    txnas Accounts
+    txna ApplicationArgs 2
+    btoi
+    txnas Applications
+    txna ApplicationArgs 3
+    btoi
+    txnas Assets
+    // arc4_conversions/reference.py:17
+    // @arc4.abimethod
+    uncover 2
+    uncover 2
+    uncover 2
+    callsub store
+    intc_1 // 1
+    b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20
+
+main_app_ret_route@5:
+    // arc4_conversions/reference.py:13
+    // @arc4.abimethod
+    txn OnCompletion
+    intc_0 // NoOp
+    ==
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    intc_0 // 0
+    !=
+    assert // can only call when not creating
+    callsub app_ret
+    itob
+    bytec_0 // 0x151f7c75
+    swap
+    concat
+    log
+    intc_1 // 1
+    b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20
+
+main_asset_ret_route@4:
+    // arc4_conversions/reference.py:9
+    // @arc4.abimethod
+    txn OnCompletion
+    intc_0 // NoOp
+    ==
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    intc_0 // 0
+    !=
+    assert // can only call when not creating
+    callsub asset_ret
+    itob
+    bytec_0 // 0x151f7c75
+    swap
+    concat
+    log
+    intc_1 // 1
+    b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20
+
+main_acc_ret_route@3:
+    // arc4_conversions/reference.py:5
+    // @arc4.abimethod
+    txn OnCompletion
+    intc_0 // NoOp
+    ==
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    intc_0 // 0
+    !=
+    assert // can only call when not creating
+    callsub acc_ret
+    bytec_0 // 0x151f7c75
+    swap
+    concat
+    log
+    intc_1 // 1
+    b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20
+
+main_bare_routing@15:
+    // arc4_conversions/reference.py:4
+    // class ReferenceReturn(arc4.ARC4Contract):
+    txn OnCompletion
+    intc_0 // 0
+    swap
+    match main___algopy_default_create@16
+
+main_switch_case_default@17:
+
+main_switch_case_next@18:
+    b main_after_if_else@19
+
+main___algopy_default_create@16:
+    txn ApplicationID
+    intc_0 // 0
+    ==
+    assert // can only call when creating
+
+main_block@21:
+
+main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create@22:
+    intc_1 // 1
+    b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes:
+acc_ret:
+
+acc_ret_block@0:
+    // arc4_conversions/reference.py:7
+    // return Txn.sender
+    txn Sender
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret() -> uint64:
+asset_ret:
+
+asset_ret_block@0:
+    // arc4_conversions/reference.py:11
+    // return Asset(1234)
+    intc_2 // 1234
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.app_ret() -> uint64:
+app_ret:
+
+app_ret_block@0:
+    // arc4_conversions/reference.py:15
+    // return Application(1234)
+    intc_2 // 1234
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes, app: uint64, asset: uint64) -> void:
+store:
+    // arc4_conversions/reference.py:17-18
+    // @arc4.abimethod
+    // def store(self, acc: Account, app: Application, asset: Asset) -> None:
+    proto 3 0
+
+store_block@0:
+    // arc4_conversions/reference.py:19
+    // self.acc = acc
+    pushbytes "acc"
+    frame_dig -3
+    app_global_put
+    // arc4_conversions/reference.py:20
+    // self.asset = asset
+    pushbytes "asset"
+    frame_dig -1
+    app_global_put
+    // arc4_conversions/reference.py:21
+    // self.app = app
+    pushbytes "app"
+    frame_dig -2
+    app_global_put
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: bytes) -> void:
+store_apps:
+    // arc4_conversions/reference.py:23-24
+    // @arc4.abimethod
+    // def store_apps(self, apps: ImmutableArray[Application]) -> None:
+    proto 1 0
+
+store_apps_block@0:
+    // arc4_conversions/reference.py:25
+    // self.apps = apps
+    bytec_1 // "apps"
+    frame_dig -1
+    app_global_put
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: bytes) -> void:
+store_assets:
+    // arc4_conversions/reference.py:27-28
+    // @arc4.abimethod
+    // def store_assets(self, assets: ImmutableArray[Asset]) -> None:
+    proto 1 0
+
+store_assets_block@0:
+    // arc4_conversions/reference.py:29
+    // self.assets = assets
+    bytec_2 // "assets"
+    frame_dig -1
+    app_global_put
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes) -> void:
+store_accounts:
+    // arc4_conversions/reference.py:31-32
+    // @arc4.abimethod
+    // def store_accounts(self, accounts: ImmutableArray[Account]) -> None:
+    proto 1 0
+
+store_accounts_block@0:
+    // arc4_conversions/reference.py:33
+    // self.accounts = accounts
+    bytec_3 // "accounts"
+    frame_dig -1
+    app_global_put
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> bytes:
+return_apps:
+
+return_apps_block@0:
+    // arc4_conversions/reference.py:37
+    // return self.apps
+    intc_0 // 0
+    bytec_1 // "apps"
+    app_global_get_ex
+    assert // check self.apps exists
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> bytes:
+return_assets:
+
+return_assets_block@0:
+    // arc4_conversions/reference.py:41
+    // return self.assets
+    intc_0 // 0
+    bytec_2 // "assets"
+    app_global_get_ex
+    assert // check self.assets exists
+    retsub
+
+
+// test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes:
+return_accounts:
+
+return_accounts_block@0:
+    // arc4_conversions/reference.py:45
+    // return self.accounts
+    intc_0 // 0
+    bytec_3 // "accounts"
+    app_global_get_ex
+    assert // check self.accounts exists
+    retsub

--- a/test_cases/arc4_conversions/out_unoptimized/ReferenceReturn.clear.puya.map
+++ b/test_cases/arc4_conversions/out_unoptimized/ReferenceReturn.clear.puya.map
@@ -1,0 +1,25 @@
+{
+  "version": 3,
+  "sources": [],
+  "mappings": ";;;",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "algopy.arc4.ARC4Contract.clear_state_program",
+      "params": {},
+      "block": "main_block@0",
+      "stack_in": [],
+      "op": "pushint 1 // 1",
+      "defined_out": [
+        "1"
+      ],
+      "stack_out": [
+        "1"
+      ]
+    },
+    "3": {
+      "op": "return",
+      "stack_out": []
+    }
+  }
+}

--- a/test_cases/arc4_conversions/out_unoptimized/ReferenceReturn.clear.teal
+++ b/test_cases/arc4_conversions/out_unoptimized/ReferenceReturn.clear.teal
@@ -1,0 +1,9 @@
+#pragma version 10
+#pragma typetrack false
+
+// algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+main:
+
+main_block@0:
+    pushint 1 // 1
+    return

--- a/test_cases/arc4_conversions/out_unoptimized/ReferenceReturn.ir/ReferenceReturn.approval.0.destructured.ir
+++ b/test_cases/arc4_conversions/out_unoptimized/ReferenceReturn.ir/ReferenceReturn.approval.0.destructured.ir
@@ -1,0 +1,227 @@
+main algopy.arc4.ARC4Contract.approval_program:
+    block@0: // L1
+        goto block@1
+    block@1: // L4
+        let tmp%0#1: uint64 = (txn NumAppArgs)
+        let tmp%1#0: bool = (!= tmp%0#1 0u)
+        goto tmp%1#0 ? block@2 : block@15
+    block@2: // abi_routing_L4
+        let tmp%2#0: bytes = (txna ApplicationArgs 0)
+        switch tmp%2#0 {method "acc_ret()address" => block@3, method "asset_ret()uint64" => block@4, method "app_ret()uint64" => block@5, method "store(account,application,asset)void" => block@6, method "store_apps(uint64[])void" => block@7, method "store_assets(uint64[])void" => block@8, method "store_accounts(address[])void" => block@9, method "return_apps()uint64[]" => block@10, method "return_assets()uint64[]" => block@11, method "return_accounts()address[]" => block@12, * => block@13}
+    block@3: // acc_ret_route_L5
+        let tmp%3#0: uint64 = (txn OnCompletion)
+        let tmp%4#0: bool = (== tmp%3#0 NoOp)
+        (assert tmp%4#0) // OnCompletion is not NoOp
+        let tmp%5#0: uint64 = (txn ApplicationID)
+        let tmp%6#0: bool = (!= tmp%5#0 0u)
+        (assert tmp%6#0) // can only call when not creating
+        let tmp%7#0: bytes[32] = test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret()
+        let tmp%8#0: bytes = (concat 0x151f7c75 tmp%7#0)
+        (log tmp%8#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@4: // asset_ret_route_L9
+        let tmp%9#0: uint64 = (txn OnCompletion)
+        let tmp%10#0: bool = (== tmp%9#0 NoOp)
+        (assert tmp%10#0) // OnCompletion is not NoOp
+        let tmp%11#0: uint64 = (txn ApplicationID)
+        let tmp%12#0: bool = (!= tmp%11#0 0u)
+        (assert tmp%12#0) // can only call when not creating
+        let to_encode%0#0: uint64 = test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret()
+        let val_as_bytes%0#0: bytes[8] = (itob to_encode%0#0)
+        let tmp%13#0: bytes = (concat 0x151f7c75 val_as_bytes%0#0)
+        (log tmp%13#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@5: // app_ret_route_L13
+        let tmp%14#0: uint64 = (txn OnCompletion)
+        let tmp%15#0: bool = (== tmp%14#0 NoOp)
+        (assert tmp%15#0) // OnCompletion is not NoOp
+        let tmp%16#0: uint64 = (txn ApplicationID)
+        let tmp%17#0: bool = (!= tmp%16#0 0u)
+        (assert tmp%17#0) // can only call when not creating
+        let to_encode%1#0: uint64 = test_cases.arc4_conversions.reference.ReferenceReturn.app_ret()
+        let val_as_bytes%1#0: bytes[8] = (itob to_encode%1#0)
+        let tmp%18#0: bytes = (concat 0x151f7c75 val_as_bytes%1#0)
+        (log tmp%18#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@6: // store_route_L17
+        let tmp%19#0: uint64 = (txn OnCompletion)
+        let tmp%20#0: bool = (== tmp%19#0 NoOp)
+        (assert tmp%20#0) // OnCompletion is not NoOp
+        let tmp%21#0: uint64 = (txn ApplicationID)
+        let tmp%22#0: bool = (!= tmp%21#0 0u)
+        (assert tmp%22#0) // can only call when not creating
+        let reinterpret_bytes[1]%0#0: bytes[1] = (txna ApplicationArgs 1)
+        let tmp%23#0: uint64 = (btoi reinterpret_bytes[1]%0#0)
+        let tmp%24#0: bytes[32] = ((txnas Accounts) tmp%23#0)
+        let reinterpret_bytes[1]%1#0: bytes[1] = (txna ApplicationArgs 2)
+        let tmp%25#0: uint64 = (btoi reinterpret_bytes[1]%1#0)
+        let tmp%26#0: uint64 = ((txnas Applications) tmp%25#0)
+        let reinterpret_bytes[1]%2#0: bytes[1] = (txna ApplicationArgs 3)
+        let tmp%27#0: uint64 = (btoi reinterpret_bytes[1]%2#0)
+        let tmp%28#0: uint64 = ((txnas Assets) tmp%27#0)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store(tmp%24#0, tmp%26#0, tmp%28#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@7: // store_apps_route_L23
+        let tmp%29#0: uint64 = (txn OnCompletion)
+        let tmp%30#0: bool = (== tmp%29#0 NoOp)
+        (assert tmp%30#0) // OnCompletion is not NoOp
+        let tmp%31#0: uint64 = (txn ApplicationID)
+        let tmp%32#0: bool = (!= tmp%31#0 0u)
+        (assert tmp%32#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%0#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(reinterpret_encoded_uint64[]%0#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@8: // store_assets_route_L27
+        let tmp%33#0: uint64 = (txn OnCompletion)
+        let tmp%34#0: bool = (== tmp%33#0 NoOp)
+        (assert tmp%34#0) // OnCompletion is not NoOp
+        let tmp%35#0: uint64 = (txn ApplicationID)
+        let tmp%36#0: bool = (!= tmp%35#0 0u)
+        (assert tmp%36#0) // can only call when not creating
+        let reinterpret_encoded_uint64[]%1#0: encoded_uint64[] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(reinterpret_encoded_uint64[]%1#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@9: // store_accounts_route_L31
+        let tmp%37#0: uint64 = (txn OnCompletion)
+        let tmp%38#0: bool = (== tmp%37#0 NoOp)
+        (assert tmp%38#0) // OnCompletion is not NoOp
+        let tmp%39#0: uint64 = (txn ApplicationID)
+        let tmp%40#0: bool = (!= tmp%39#0 0u)
+        (assert tmp%40#0) // can only call when not creating
+        let reinterpret_bytes[32][]%0#0: bytes[32][] = (txna ApplicationArgs 1)
+        test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(reinterpret_bytes[32][]%0#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@10: // return_apps_route_L35
+        let tmp%41#0: uint64 = (txn OnCompletion)
+        let tmp%42#0: bool = (== tmp%41#0 NoOp)
+        (assert tmp%42#0) // OnCompletion is not NoOp
+        let tmp%43#0: uint64 = (txn ApplicationID)
+        let tmp%44#0: bool = (!= tmp%43#0 0u)
+        (assert tmp%44#0) // can only call when not creating
+        let tmp%45#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_apps()
+        let tmp%46#0: bytes = (concat 0x151f7c75 tmp%45#0)
+        (log tmp%46#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@11: // return_assets_route_L39
+        let tmp%47#0: uint64 = (txn OnCompletion)
+        let tmp%48#0: bool = (== tmp%47#0 NoOp)
+        (assert tmp%48#0) // OnCompletion is not NoOp
+        let tmp%49#0: uint64 = (txn ApplicationID)
+        let tmp%50#0: bool = (!= tmp%49#0 0u)
+        (assert tmp%50#0) // can only call when not creating
+        let tmp%51#0: encoded_uint64[] = test_cases.arc4_conversions.reference.ReferenceReturn.return_assets()
+        let tmp%52#0: bytes = (concat 0x151f7c75 tmp%51#0)
+        (log tmp%52#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@12: // return_accounts_route_L43
+        let tmp%53#0: uint64 = (txn OnCompletion)
+        let tmp%54#0: bool = (== tmp%53#0 NoOp)
+        (assert tmp%54#0) // OnCompletion is not NoOp
+        let tmp%55#0: uint64 = (txn ApplicationID)
+        let tmp%56#0: bool = (!= tmp%55#0 0u)
+        (assert tmp%56#0) // can only call when not creating
+        let tmp%57#0: bytes[32][] = test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts()
+        let tmp%58#0: bytes = (concat 0x151f7c75 tmp%57#0)
+        (log tmp%58#0)
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@13: // switch_case_default_L4
+        goto block@14
+    block@14: // switch_case_next_L4
+        goto block@19
+    block@15: // bare_routing_L4
+        let tmp%59#0: uint64 = (txn OnCompletion)
+        switch tmp%59#0 {0u => block@16, * => block@17}
+    block@16: // __algopy_default_create_L1
+        let tmp%60#0: uint64 = (txn ApplicationID)
+        let tmp%61#0: bool = (== tmp%60#0 0u)
+        (assert tmp%61#0) // can only call when creating
+        goto block@21
+    block@21: // L1
+        goto block@22
+    block@22: // after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create_L1
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@17: // switch_case_default_L4
+        goto block@18
+    block@18: // switch_case_next_L4
+        goto block@19
+    block@19: // after_if_else_L4
+        let test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0: bool = 0u
+        let tmp%0#0: bool = test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0
+        goto block@20
+    block@20: // after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router___L1
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes[32]:
+    block@0: // L5
+        let tmp%0#0: bytes[32] = (txn Sender)
+        return tmp%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret() -> uint64:
+    block@0: // L9
+        return 1234u
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret() -> uint64:
+    block@0: // L13
+        return 1234u
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes[32], app: uint64, asset: uint64) -> void:
+    block@0: // L17
+        (app_global_put "acc" acc#0)
+        (app_global_put "asset" asset#0)
+        (app_global_put "app" app#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: encoded_uint64[]) -> void:
+    block@0: // L23
+        (app_global_put "apps" apps#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: encoded_uint64[]) -> void:
+    block@0: // L27
+        (app_global_put "assets" assets#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes[32][]) -> void:
+    block@0: // L31
+        (app_global_put "accounts" accounts#0)
+        return 
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> encoded_uint64[]:
+    block@0: // L35
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "apps")
+        (assert maybe_exists%0#0) // check self.apps exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> encoded_uint64[]:
+    block@0: // L39
+        let (maybe_value%0#0: encoded_uint64[], maybe_exists%0#0: bool) = (app_global_get_ex 0u "assets")
+        (assert maybe_exists%0#0) // check self.assets exists
+        return maybe_value%0#0
+
+subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes[32][]:
+    block@0: // L43
+        let (maybe_value%0#0: bytes[32][], maybe_exists%0#0: bool) = (app_global_get_ex 0u "accounts")
+        (assert maybe_exists%0#0) // check self.accounts exists
+        return maybe_value%0#0

--- a/test_cases/arc4_conversions/out_unoptimized/ReferenceReturn.ir/ReferenceReturn.clear.0.destructured.ir
+++ b/test_cases/arc4_conversions/out_unoptimized/ReferenceReturn.ir/ReferenceReturn.clear.0.destructured.ir
@@ -1,0 +1,3 @@
+main algopy.arc4.ARC4Contract.clear_state_program:
+    block@0: // L1
+        return 1u

--- a/test_cases/arc4_conversions/puya.log
+++ b/test_cases/arc4_conversions/puya.log
@@ -385,6 +385,140 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_conversions.contract.my_dyn_struct_arc4
 debug: Sealing block@0
 debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Sealing block@1
+debug: Terminated block@1
+debug: Sealing block@2
+debug: Terminated block@2
+debug: Sealing block@3
+debug: Terminated block@3
+debug: Sealing block@4
+debug: Terminated block@4
+debug: Sealing block@5
+debug: Terminated block@5
+debug: Sealing block@6
+debug: Terminated block@6
+debug: Sealing block@7
+debug: Terminated block@7
+debug: Sealing block@8
+debug: Terminated block@8
+debug: Sealing block@9
+debug: Terminated block@9
+debug: Sealing block@10
+debug: Terminated block@10
+debug: Sealing block@11
+debug: Terminated block@11
+debug: Sealing block@12
+debug: Terminated block@12
+debug: Sealing block@13
+debug: Terminated block@13
+debug: Sealing block@14
+debug: Terminated block@14
+debug: Sealing block@15
+debug: Terminated block@15
+debug: Sealing block@16
+debug: Terminated block@16
+debug: Sealing block@17
+debug: Terminated block@17
+debug: Sealing block@18
+debug: Terminated block@18
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function algopy.arc4.ARC4Contract.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function algopy.arc4.ARC4Contract.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function algopy.arc4.ARC4Contract.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_struct
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_dyn_struct
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_dyn_struct_arc4
+debug: removing unused subroutine algopy.arc4.ARC4Contract.approval_program
+debug: removing unused subroutine algopy.arc4.ARC4Contract.clear_state_program
+debug: Building IR for function algopy.arc4.ARC4Contract.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_struct
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_dyn_struct
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_dyn_struct_arc4
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create
+debug: removing unused subroutine algopy.arc4.ARC4Contract.approval_program
+debug: removing unused subroutine algopy.arc4.ARC4Contract.clear_state_program
 debug: Building IR for function test_cases.arc4_conversions.contract.TestContract.__puya_arc4_router__
 debug: Sealing block@0
 debug: Terminated block@0
@@ -736,6 +870,1297 @@ debug: removing unused subroutine test_cases.arc4_conversions.contract.CheckApp.
 debug: removing unused subroutine test_cases.arc4_conversions.contract.CheckApp.__algopy_default_create
 debug: removing unused subroutine algopy.arc4.ARC4Contract.approval_program
 debug: removing unused subroutine algopy.arc4.ARC4Contract.clear_state_program
+debug: Output IR to arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.0.ssa.ir
+debug: Output IR to arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.0.ssa.ir
+debug: optimizing approval program of test_cases.arc4_conversions.reference.ReferenceReturn at level 1
+debug: Begin optimization pass 1/100
+debug: marking trivial method test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret as inlineable
+debug: marking trivial method test_cases.arc4_conversions.reference.ReferenceReturn.app_ret as inlineable
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__ in algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Simplified (== tmp%3#0 NoOp) to (! tmp%3#0)
+debug: Simplified (== tmp%9#0 NoOp) to (! tmp%9#0)
+debug: Simplified (== tmp%14#0 NoOp) to (! tmp%14#0)
+debug: Simplified (== tmp%19#0 NoOp) to (! tmp%19#0)
+debug: Simplified (== tmp%29#0 NoOp) to (! tmp%29#0)
+debug: Simplified (== tmp%33#0 NoOp) to (! tmp%33#0)
+debug: Simplified (== tmp%37#0 NoOp) to (! tmp%37#0)
+debug: Simplified (== tmp%41#0 NoOp) to (! tmp%41#0)
+debug: Simplified (== tmp%47#0 NoOp) to (! tmp%47#0)
+debug: Simplified (== tmp%53#0 NoOp) to (! tmp%53#0)
+debug: Simplified (== tmp%60#0 0u) to (! tmp%60#0)
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: simplifying a switch with constants into goto nth
+debug: simplified terminator of block@15 from switch tmp%59#0 {0u => block@16, * => block@17} to goto_nth [block@16][tmp%59#0] else goto block@17
+debug: simplifying a goto nth with two targets into a conditional branch
+debug: simplified terminator of block@15 from goto_nth [block@16][tmp%59#0] else goto block@17 to goto tmp%59#0 ? block@17 : block@16
+debug: Optimizer: Remove Linear Jump
+debug: Replaced predecessor block@1 with block@0 in block@15
+debug: Replaced predecessor block@1 with block@0 in block@2
+debug: Merged linear block@1 into block@0
+debug: Replaced predecessor block@14 with block@13 in block@19
+debug: Merged linear block@14 into block@13
+debug: Replaced predecessor block@18 with block@17 in block@19
+debug: Merged linear block@18 into block@17
+debug: Optimizer: Remove Empty Blocks
+debug: Removed empty block: block@13
+debug: Removed empty block: block@17
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+debug: Optimizer: Perform Subroutine Inlining
+debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create in test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+arc4_conversions/reference.py:13:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.app_ret in test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+arc4_conversions/reference.py:9:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret in test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Removing unused variable to_encode%0#0
+debug: Removing unused variable to_encode%1#0
+debug: Optimizer: Intrinsic Simplifier
+debug: Simplified (== tmp%3#0 NoOp) to (! tmp%3#0)
+debug: Simplified (== tmp%9#0 NoOp) to (! tmp%9#0)
+debug: Simplified (concat 0x151f7c75 val_as_bytes%0#0) to 0x151f7c7500000000000004d2
+debug: Simplified (== tmp%14#0 NoOp) to (! tmp%14#0)
+debug: Simplified (concat 0x151f7c75 val_as_bytes%1#0) to 0x151f7c7500000000000004d2
+debug: Simplified (== tmp%19#0 NoOp) to (! tmp%19#0)
+debug: Simplified (== tmp%29#0 NoOp) to (! tmp%29#0)
+debug: Simplified (== tmp%33#0 NoOp) to (! tmp%33#0)
+debug: Simplified (== tmp%37#0 NoOp) to (! tmp%37#0)
+debug: Simplified (== tmp%41#0 NoOp) to (! tmp%41#0)
+debug: Simplified (== tmp%47#0 NoOp) to (! tmp%47#0)
+debug: Simplified (== tmp%53#0 NoOp) to (! tmp%53#0)
+debug: Simplified (== tmp%60#0 0u) to (! tmp%60#0)
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: simplifying a switch with constants into goto nth
+debug: simplified terminator of block@14 from switch tmp%59#0 {0u => block@15, * => block@16} to goto_nth [block@15][tmp%59#0] else goto block@16
+debug: simplifying a goto nth with two targets into a conditional branch
+debug: simplified terminator of block@14 from goto_nth [block@15][tmp%59#0] else goto block@16 to goto tmp%59#0 ? block@16 : block@15
+debug: Optimizer: Remove Linear Jump
+debug: Replaced predecessor block@23 with block@3 in block@24
+debug: Merged linear block@23 into block@3
+debug: Merged linear block@24 into block@3
+debug: Replaced predecessor block@21 with block@4 in block@22
+debug: Merged linear block@21 into block@4
+debug: Merged linear block@22 into block@4
+debug: Replaced predecessor block@13 with block@12 in block@18
+debug: Merged linear block@13 into block@12
+debug: Replaced predecessor block@19 with block@15 in block@20
+debug: Merged linear block@19 into block@15
+debug: Merged linear block@20 into block@15
+debug: Replaced predecessor block@17 with block@16 in block@18
+debug: Merged linear block@17 into block@16
+debug: Optimizer: Remove Empty Blocks
+debug: Removed empty block: block@12
+debug: Removed empty block: block@16
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+debug: Unused subroutines removed
+debug: Output IR to arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.1.ssa.opt.ir
+debug: Begin optimization pass 2/100
+debug: marking trivial method test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret as inlineable
+debug: marking trivial method test_cases.arc4_conversions.reference.ReferenceReturn.app_ret as inlineable
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create in algopy.arc4.ARC4Contract.approval_program
+arc4_conversions/reference.py:13:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.app_ret in algopy.arc4.ARC4Contract.approval_program
+arc4_conversions/reference.py:9:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret in algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Removing unused variable tmp%1#0
+debug: Removing unused variable tmp%6#0
+debug: Removing unused variable tmp%12#0
+debug: Removing unused variable to_encode%0#0
+debug: Removing unused variable tmp%17#0
+debug: Removing unused variable to_encode%1#0
+debug: Removing unused variable tmp%22#0
+debug: Removing unused variable tmp%32#0
+debug: Removing unused variable tmp%36#0
+debug: Removing unused variable tmp%40#0
+debug: Removing unused variable tmp%44#0
+debug: Removing unused variable tmp%50#0
+debug: Removing unused variable tmp%56#0
+debug: Optimizer: Intrinsic Simplifier
+debug: Simplified (concat 0x151f7c75 val_as_bytes%0#0) to 0x151f7c7500000000000004d2
+debug: Simplified (concat 0x151f7c75 val_as_bytes%1#0) to 0x151f7c7500000000000004d2
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Replaced predecessor block@25 with block@4 in block@26
+debug: Merged linear block@25 into block@4
+debug: Replaced predecessor block@26 with block@4 in block@20
+debug: Merged linear block@26 into block@4
+debug: Replaced predecessor block@23 with block@5 in block@24
+debug: Merged linear block@23 into block@5
+debug: Replaced predecessor block@24 with block@5 in block@20
+debug: Merged linear block@24 into block@5
+debug: Replaced predecessor block@21 with block@16 in block@22
+debug: Merged linear block@21 into block@16
+debug: Replaced predecessor block@22 with block@16 in block@20
+debug: Merged linear block@22 into block@16
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create
+debug: Unused subroutines removed
+debug: Output IR to arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.2.ssa.opt.ir
+debug: Begin optimization pass 3/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Removing unused variable val_as_bytes%0#0
+debug: Removing unused variable tmp%13#0
+debug: Removing unused variable val_as_bytes%1#0
+debug: Removing unused variable tmp%18#0
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Output IR to arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.3.ssa.opt.ir
+debug: Begin optimization pass 4/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: No optimizations performed in pass 4, ending loop
+debug: optimizing clear program of test_cases.arc4_conversions.reference.ReferenceReturn at level 1
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: lowering array IR nodes in approval program of test_cases.arc4_conversions.reference.ReferenceReturn
+debug: Output IR to arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.4.ssa.array.ir
+debug: lowering array IR nodes in clear program of test_cases.arc4_conversions.reference.ReferenceReturn
+debug: Output IR to arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.1.ssa.array.ir
+debug: optimizing approval program of test_cases.arc4_conversions.reference.ReferenceReturn at level 1
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: optimizing clear program of test_cases.arc4_conversions.reference.ReferenceReturn at level 1
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: removing local static slots in approval program of test_cases.arc4_conversions.reference.ReferenceReturn
+debug: auto reserving slots in algopy.arc4.ARC4Contract.approval_program, []
+arc4_conversions/reference.py:5 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret, []
+arc4_conversions/reference.py:17 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.store, []
+arc4_conversions/reference.py:23 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.store_apps, []
+arc4_conversions/reference.py:27 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.store_assets, []
+arc4_conversions/reference.py:31 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts, []
+arc4_conversions/reference.py:35 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.return_apps, []
+arc4_conversions/reference.py:39 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.return_assets, []
+arc4_conversions/reference.py:43 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts, []
+debug: Slot allocation not required
+debug: Output IR to arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.5.ssa.slot.ir
+debug: removing local static slots in clear program of test_cases.arc4_conversions.reference.ReferenceReturn
+debug: auto reserving slots in algopy.arc4.ARC4Contract.clear_state_program, []
+debug: Slot allocation not required
+debug: Output IR to arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.2.ssa.slot.ir
+debug: Performing SSA IR destructuring for algopy.arc4.ARC4Contract.approval_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in algopy.arc4.ARC4Contract.approval_program using strategy RootOperandGrouping
+debug: Coalescing test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 with [test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#1, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#2, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#3, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#4, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#5, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#6, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#7, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#8, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#9, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#10, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#11]
+debug: Coalescing tmp%0#0 with [tmp%0#2]
+debug: Coalescing resulted in 35 replacement/s
+debug: Sequentializing parallel copies in algopy.arc4.ARC4Contract.approval_program
+debug: Performing post-SSA optimizations at level 1
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Performing post-SSA optimizations at level 1
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.store using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Performing post-SSA optimizations at level 1
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.store_apps using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Performing post-SSA optimizations at level 1
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.store_assets using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Performing post-SSA optimizations at level 1
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Performing post-SSA optimizations at level 1
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.return_apps using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Performing post-SSA optimizations at level 1
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.return_assets using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Performing post-SSA optimizations at level 1
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Performing post-SSA optimizations at level 1
+debug: Output IR to arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.approval.6.destructured.ir
+debug: Performing SSA IR destructuring for algopy.arc4.ARC4Contract.clear_state_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in algopy.arc4.ARC4Contract.clear_state_program using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in algopy.arc4.ARC4Contract.clear_state_program
+debug: Performing post-SSA optimizations at level 1
+debug: Output IR to arc4_conversions/out/ReferenceReturn.ir/ReferenceReturn.clear.3.destructured.ir
+debug: Inserted main_block@0.ops[1]: 'l-store-copy tmp%0#1 0'
+debug: Replaced main_block@0.ops[3]: 'v-load tmp%0#1' with 'l-load tmp%0#1'
+debug: Inserted main_abi_routing@2.ops[1]: 'l-store-copy tmp%2#0 0'
+debug: Replaced main_abi_routing@2.ops[13]: 'v-load tmp%2#0' with 'l-load tmp%2#0'
+debug: Inserted main_acc_ret_route@3.ops[1]: 'l-store-copy tmp%3#0 0'
+debug: Replaced main_acc_ret_route@3.ops[3]: 'v-load tmp%3#0' with 'l-load tmp%3#0'
+debug: Inserted main_acc_ret_route@3.ops[5]: 'l-store-copy tmp%4#0 0'
+debug: Replaced main_acc_ret_route@3.ops[7]: 'v-load tmp%4#0' with 'l-load tmp%4#0'
+debug: Inserted main_acc_ret_route@3.ops[10]: 'l-store-copy tmp%5#0 0'
+debug: Replaced main_acc_ret_route@3.ops[12]: 'v-load tmp%5#0' with 'l-load tmp%5#0'
+debug: Inserted main_acc_ret_route@3.ops[19]: 'l-store-copy tmp%8#0 0'
+debug: Replaced main_acc_ret_route@3.ops[21]: 'v-load tmp%8#0' with 'l-load tmp%8#0'
+debug: Inserted main_acc_ret_route@3.ops[24]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_acc_ret_route@3.ops[26]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_acc_ret_route@3.ops[15]: 'l-store-copy tmp%7#0 0'
+debug: Replaced main_acc_ret_route@3.ops[18]: 'v-load tmp%7#0' with 'l-load tmp%7#0'
+debug: Inserted main_asset_ret_route@4.ops[1]: 'l-store-copy tmp%9#0 0'
+debug: Replaced main_asset_ret_route@4.ops[3]: 'v-load tmp%9#0' with 'l-load tmp%9#0'
+debug: Inserted main_asset_ret_route@4.ops[5]: 'l-store-copy tmp%10#0 0'
+debug: Replaced main_asset_ret_route@4.ops[7]: 'v-load tmp%10#0' with 'l-load tmp%10#0'
+debug: Inserted main_asset_ret_route@4.ops[10]: 'l-store-copy tmp%11#0 0'
+debug: Replaced main_asset_ret_route@4.ops[12]: 'v-load tmp%11#0' with 'l-load tmp%11#0'
+debug: Inserted main_asset_ret_route@4.ops[17]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_asset_ret_route@4.ops[19]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_app_ret_route@5.ops[1]: 'l-store-copy tmp%14#0 0'
+debug: Replaced main_app_ret_route@5.ops[3]: 'v-load tmp%14#0' with 'l-load tmp%14#0'
+debug: Inserted main_app_ret_route@5.ops[5]: 'l-store-copy tmp%15#0 0'
+debug: Replaced main_app_ret_route@5.ops[7]: 'v-load tmp%15#0' with 'l-load tmp%15#0'
+debug: Inserted main_app_ret_route@5.ops[10]: 'l-store-copy tmp%16#0 0'
+debug: Replaced main_app_ret_route@5.ops[12]: 'v-load tmp%16#0' with 'l-load tmp%16#0'
+debug: Inserted main_app_ret_route@5.ops[17]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_app_ret_route@5.ops[19]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_store_route@6.ops[1]: 'l-store-copy tmp%19#0 0'
+debug: Replaced main_store_route@6.ops[3]: 'v-load tmp%19#0' with 'l-load tmp%19#0'
+debug: Inserted main_store_route@6.ops[5]: 'l-store-copy tmp%20#0 0'
+debug: Replaced main_store_route@6.ops[7]: 'v-load tmp%20#0' with 'l-load tmp%20#0'
+debug: Inserted main_store_route@6.ops[10]: 'l-store-copy tmp%21#0 0'
+debug: Replaced main_store_route@6.ops[12]: 'v-load tmp%21#0' with 'l-load tmp%21#0'
+debug: Inserted main_store_route@6.ops[15]: 'l-store-copy reinterpret_bytes[1]%0#0 0'
+debug: Replaced main_store_route@6.ops[17]: 'v-load reinterpret_bytes[1]%0#0' with 'l-load reinterpret_bytes[1]%0#0'
+debug: Inserted main_store_route@6.ops[19]: 'l-store-copy tmp%23#0 0'
+debug: Replaced main_store_route@6.ops[21]: 'v-load tmp%23#0' with 'l-load tmp%23#0'
+debug: Inserted main_store_route@6.ops[25]: 'l-store-copy reinterpret_bytes[1]%1#0 0'
+debug: Replaced main_store_route@6.ops[27]: 'v-load reinterpret_bytes[1]%1#0' with 'l-load reinterpret_bytes[1]%1#0'
+debug: Inserted main_store_route@6.ops[29]: 'l-store-copy tmp%25#0 0'
+debug: Replaced main_store_route@6.ops[31]: 'v-load tmp%25#0' with 'l-load tmp%25#0'
+debug: Inserted main_store_route@6.ops[35]: 'l-store-copy reinterpret_bytes[1]%2#0 0'
+debug: Replaced main_store_route@6.ops[37]: 'v-load reinterpret_bytes[1]%2#0' with 'l-load reinterpret_bytes[1]%2#0'
+debug: Inserted main_store_route@6.ops[39]: 'l-store-copy tmp%27#0 0'
+debug: Replaced main_store_route@6.ops[41]: 'v-load tmp%27#0' with 'l-load tmp%27#0'
+debug: Inserted main_store_route@6.ops[49]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_store_route@6.ops[51]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_store_route@6.ops[43]: 'l-store-copy tmp%28#0 0'
+debug: Replaced main_store_route@6.ops[47]: 'v-load tmp%28#0' with 'l-load tmp%28#0'
+debug: Inserted main_store_route@6.ops[33]: 'l-store-copy tmp%26#0 0'
+debug: Replaced main_store_route@6.ops[47]: 'v-load tmp%26#0' with 'l-load tmp%26#0'
+debug: Inserted main_store_route@6.ops[23]: 'l-store-copy tmp%24#0 0'
+debug: Replaced main_store_route@6.ops[47]: 'v-load tmp%24#0' with 'l-load tmp%24#0'
+debug: Inserted main_store_apps_route@7.ops[1]: 'l-store-copy tmp%29#0 0'
+debug: Replaced main_store_apps_route@7.ops[3]: 'v-load tmp%29#0' with 'l-load tmp%29#0'
+debug: Inserted main_store_apps_route@7.ops[5]: 'l-store-copy tmp%30#0 0'
+debug: Replaced main_store_apps_route@7.ops[7]: 'v-load tmp%30#0' with 'l-load tmp%30#0'
+debug: Inserted main_store_apps_route@7.ops[10]: 'l-store-copy tmp%31#0 0'
+debug: Replaced main_store_apps_route@7.ops[12]: 'v-load tmp%31#0' with 'l-load tmp%31#0'
+debug: Inserted main_store_apps_route@7.ops[15]: 'l-store-copy reinterpret_encoded_uint64[]%0#0 0'
+debug: Replaced main_store_apps_route@7.ops[17]: 'v-load reinterpret_encoded_uint64[]%0#0' with 'l-load reinterpret_encoded_uint64[]%0#0'
+debug: Inserted main_store_apps_route@7.ops[20]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_store_apps_route@7.ops[22]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_store_assets_route@8.ops[1]: 'l-store-copy tmp%33#0 0'
+debug: Replaced main_store_assets_route@8.ops[3]: 'v-load tmp%33#0' with 'l-load tmp%33#0'
+debug: Inserted main_store_assets_route@8.ops[5]: 'l-store-copy tmp%34#0 0'
+debug: Replaced main_store_assets_route@8.ops[7]: 'v-load tmp%34#0' with 'l-load tmp%34#0'
+debug: Inserted main_store_assets_route@8.ops[10]: 'l-store-copy tmp%35#0 0'
+debug: Replaced main_store_assets_route@8.ops[12]: 'v-load tmp%35#0' with 'l-load tmp%35#0'
+debug: Inserted main_store_assets_route@8.ops[15]: 'l-store-copy reinterpret_encoded_uint64[]%1#0 0'
+debug: Replaced main_store_assets_route@8.ops[17]: 'v-load reinterpret_encoded_uint64[]%1#0' with 'l-load reinterpret_encoded_uint64[]%1#0'
+debug: Inserted main_store_assets_route@8.ops[20]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_store_assets_route@8.ops[22]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_store_accounts_route@9.ops[1]: 'l-store-copy tmp%37#0 0'
+debug: Replaced main_store_accounts_route@9.ops[3]: 'v-load tmp%37#0' with 'l-load tmp%37#0'
+debug: Inserted main_store_accounts_route@9.ops[5]: 'l-store-copy tmp%38#0 0'
+debug: Replaced main_store_accounts_route@9.ops[7]: 'v-load tmp%38#0' with 'l-load tmp%38#0'
+debug: Inserted main_store_accounts_route@9.ops[10]: 'l-store-copy tmp%39#0 0'
+debug: Replaced main_store_accounts_route@9.ops[12]: 'v-load tmp%39#0' with 'l-load tmp%39#0'
+debug: Inserted main_store_accounts_route@9.ops[15]: 'l-store-copy reinterpret_bytes[32][]%0#0 0'
+debug: Replaced main_store_accounts_route@9.ops[17]: 'v-load reinterpret_bytes[32][]%0#0' with 'l-load reinterpret_bytes[32][]%0#0'
+debug: Inserted main_store_accounts_route@9.ops[20]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_store_accounts_route@9.ops[22]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_return_apps_route@10.ops[1]: 'l-store-copy tmp%41#0 0'
+debug: Replaced main_return_apps_route@10.ops[3]: 'v-load tmp%41#0' with 'l-load tmp%41#0'
+debug: Inserted main_return_apps_route@10.ops[5]: 'l-store-copy tmp%42#0 0'
+debug: Replaced main_return_apps_route@10.ops[7]: 'v-load tmp%42#0' with 'l-load tmp%42#0'
+debug: Inserted main_return_apps_route@10.ops[10]: 'l-store-copy tmp%43#0 0'
+debug: Replaced main_return_apps_route@10.ops[12]: 'v-load tmp%43#0' with 'l-load tmp%43#0'
+debug: Inserted main_return_apps_route@10.ops[19]: 'l-store-copy tmp%46#0 0'
+debug: Replaced main_return_apps_route@10.ops[21]: 'v-load tmp%46#0' with 'l-load tmp%46#0'
+debug: Inserted main_return_apps_route@10.ops[24]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_return_apps_route@10.ops[26]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_return_apps_route@10.ops[15]: 'l-store-copy tmp%45#0 0'
+debug: Replaced main_return_apps_route@10.ops[18]: 'v-load tmp%45#0' with 'l-load tmp%45#0'
+debug: Inserted main_return_assets_route@11.ops[1]: 'l-store-copy tmp%47#0 0'
+debug: Replaced main_return_assets_route@11.ops[3]: 'v-load tmp%47#0' with 'l-load tmp%47#0'
+debug: Inserted main_return_assets_route@11.ops[5]: 'l-store-copy tmp%48#0 0'
+debug: Replaced main_return_assets_route@11.ops[7]: 'v-load tmp%48#0' with 'l-load tmp%48#0'
+debug: Inserted main_return_assets_route@11.ops[10]: 'l-store-copy tmp%49#0 0'
+debug: Replaced main_return_assets_route@11.ops[12]: 'v-load tmp%49#0' with 'l-load tmp%49#0'
+debug: Inserted main_return_assets_route@11.ops[19]: 'l-store-copy tmp%52#0 0'
+debug: Replaced main_return_assets_route@11.ops[21]: 'v-load tmp%52#0' with 'l-load tmp%52#0'
+debug: Inserted main_return_assets_route@11.ops[24]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_return_assets_route@11.ops[26]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_return_assets_route@11.ops[15]: 'l-store-copy tmp%51#0 0'
+debug: Replaced main_return_assets_route@11.ops[18]: 'v-load tmp%51#0' with 'l-load tmp%51#0'
+debug: Inserted main_return_accounts_route@12.ops[1]: 'l-store-copy tmp%53#0 0'
+debug: Replaced main_return_accounts_route@12.ops[3]: 'v-load tmp%53#0' with 'l-load tmp%53#0'
+debug: Inserted main_return_accounts_route@12.ops[5]: 'l-store-copy tmp%54#0 0'
+debug: Replaced main_return_accounts_route@12.ops[7]: 'v-load tmp%54#0' with 'l-load tmp%54#0'
+debug: Inserted main_return_accounts_route@12.ops[10]: 'l-store-copy tmp%55#0 0'
+debug: Replaced main_return_accounts_route@12.ops[12]: 'v-load tmp%55#0' with 'l-load tmp%55#0'
+debug: Inserted main_return_accounts_route@12.ops[19]: 'l-store-copy tmp%58#0 0'
+debug: Replaced main_return_accounts_route@12.ops[21]: 'v-load tmp%58#0' with 'l-load tmp%58#0'
+debug: Inserted main_return_accounts_route@12.ops[24]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_return_accounts_route@12.ops[26]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_return_accounts_route@12.ops[15]: 'l-store-copy tmp%57#0 0'
+debug: Replaced main_return_accounts_route@12.ops[18]: 'v-load tmp%57#0' with 'l-load tmp%57#0'
+debug: Inserted main_bare_routing@15.ops[1]: 'l-store-copy tmp%59#0 0'
+debug: Replaced main_bare_routing@15.ops[3]: 'v-load tmp%59#0' with 'l-load tmp%59#0'
+debug: Inserted main___algopy_default_create@16.ops[1]: 'l-store-copy tmp%60#0 0'
+debug: Replaced main___algopy_default_create@16.ops[3]: 'v-load tmp%60#0' with 'l-load tmp%60#0'
+debug: Inserted main___algopy_default_create@16.ops[5]: 'l-store-copy tmp%61#0 0'
+debug: Replaced main___algopy_default_create@16.ops[7]: 'v-load tmp%61#0' with 'l-load tmp%61#0'
+debug: Inserted main___algopy_default_create@16.ops[10]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main___algopy_default_create@16.ops[12]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_after_if_else@19.ops[1]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_after_if_else@19.ops[3]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted acc_ret_block@0.ops[1]: 'l-store-copy tmp%0#0 0'
+debug: Replaced acc_ret_block@0.ops[3]: 'v-load tmp%0#0' with 'l-load tmp%0#0'
+debug: Inserted return_apps_block@0.ops[3]: 'l-store-copy maybe_exists%0#0 1'
+debug: Replaced return_apps_block@0.ops[6]: 'v-load maybe_exists%0#0' with 'l-load maybe_exists%0#0'
+debug: Inserted return_apps_block@0.ops[5]: 'l-store-copy maybe_value%0#0 1'
+debug: Replaced return_apps_block@0.ops[9]: 'v-load maybe_value%0#0' with 'l-load maybe_value%0#0'
+debug: Inserted return_assets_block@0.ops[3]: 'l-store-copy maybe_exists%0#0 1'
+debug: Replaced return_assets_block@0.ops[6]: 'v-load maybe_exists%0#0' with 'l-load maybe_exists%0#0'
+debug: Inserted return_assets_block@0.ops[5]: 'l-store-copy maybe_value%0#0 1'
+debug: Replaced return_assets_block@0.ops[9]: 'v-load maybe_value%0#0' with 'l-load maybe_value%0#0'
+debug: Inserted return_accounts_block@0.ops[3]: 'l-store-copy maybe_exists%0#0 1'
+debug: Replaced return_accounts_block@0.ops[6]: 'v-load maybe_exists%0#0' with 'l-load maybe_exists%0#0'
+debug: Inserted return_accounts_block@0.ops[5]: 'l-store-copy maybe_value%0#0 1'
+debug: Replaced return_accounts_block@0.ops[9]: 'v-load maybe_value%0#0' with 'l-load maybe_value%0#0'
+debug: Found 3 edge set/s for algopy.arc4.ARC4Contract.approval_program
+debug: Allocated 1 variable/s to x-stack: tmp%0#0
+debug: shared x-stack for main_acc_ret_route@3 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_asset_ret_route@4 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_app_ret_route@5 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_store_route@6 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_store_apps_route@7 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_store_assets_route@8 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_store_accounts_route@9 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_return_apps_route@10 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_return_assets_route@11 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_return_accounts_route@12 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main___algopy_default_create@16 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_after_if_else@19 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: optimizing TEAL subroutine ops algopy.arc4.ARC4Contract.approval_program() -> uint64:
+arc4_conversions/reference.py:5 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes:
+arc4_conversions/reference.py:17 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes, app: uint64, asset: uint64) -> void:
+arc4_conversions/reference.py:23 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: bytes) -> void:
+arc4_conversions/reference.py:27 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: bytes) -> void:
+arc4_conversions/reference.py:31 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes) -> void:
+arc4_conversions/reference.py:35 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> bytes:
+arc4_conversions/reference.py:39 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> bytes:
+arc4_conversions/reference.py:43 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes:
+debug: optimizing TEAL subroutine blocks algopy.arc4.ARC4Contract.approval_program() -> uint64:
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: inlining single reference block main_block@0 into main
+debug: inlining single reference block main_abi_routing@2 into main
+debug: inlining single reference block main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 into main_after_if_else@19
+debug: inlining single reference block main___algopy_default_create@16 into main_bare_routing@15
+debug: removing explicit jump to fall-through block main_after_if_else@19
+arc4_conversions/reference.py:5 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes:
+debug: inlining single reference block acc_ret_block@0 into acc_ret
+arc4_conversions/reference.py:17 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes, app: uint64, asset: uint64) -> void:
+debug: inlining single reference block store_block@0 into store
+arc4_conversions/reference.py:23 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: bytes) -> void:
+debug: inlining single reference block store_apps_block@0 into store_apps
+arc4_conversions/reference.py:27 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: bytes) -> void:
+debug: inlining single reference block store_assets_block@0 into store_assets
+arc4_conversions/reference.py:31 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes) -> void:
+debug: inlining single reference block store_accounts_block@0 into store_accounts
+arc4_conversions/reference.py:35 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> bytes:
+debug: inlining single reference block return_apps_block@0 into return_apps
+arc4_conversions/reference.py:39 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> bytes:
+debug: inlining single reference block return_assets_block@0 into return_assets
+arc4_conversions/reference.py:43 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes:
+debug: inlining single reference block return_accounts_block@0 into return_accounts
+debug: optimizing TEAL subroutine ops algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+debug: optimizing TEAL subroutine blocks algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+debug: inlining single reference block main_block@0 into main
 debug: Output IR to arc4_conversions/out/CheckApp.ir/CheckApp.approval.0.ssa.ir
 debug: Output IR to arc4_conversions/out/CheckApp.ir/CheckApp.clear.0.ssa.ir
 debug: optimizing approval program of test_cases.arc4_conversions.contract.CheckApp at level 1
@@ -7410,6 +8835,14 @@ debug: removing explicit jump to fall-through block test_bytes_to_fixed_after_if
 debug: optimizing TEAL subroutine ops algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
 debug: optimizing TEAL subroutine blocks algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
 debug: inlining single reference block main_block@0 into main
+info: Writing arc4_conversions/out/ReferenceReturn.arc32.json
+info: Writing arc4_conversions/out/ReferenceReturn.arc56.json
+info: Writing arc4_conversions/out/ReferenceReturn.approval.teal
+info: Writing arc4_conversions/out/ReferenceReturn.clear.teal
+info: Writing arc4_conversions/out/ReferenceReturn.approval.bin
+info: Writing arc4_conversions/out/ReferenceReturn.clear.bin
+info: Writing arc4_conversions/out/ReferenceReturn.approval.puya.map
+info: Writing arc4_conversions/out/ReferenceReturn.clear.puya.map
 info: Writing arc4_conversions/out/CheckApp.arc32.json
 info: Writing arc4_conversions/out/CheckApp.arc56.json
 info: Writing arc4_conversions/out/CheckApp.approval.teal
@@ -7426,5 +8859,6 @@ info: Writing arc4_conversions/out/TestContract.approval.bin
 info: Writing arc4_conversions/out/TestContract.clear.bin
 info: Writing arc4_conversions/out/TestContract.approval.puya.map
 info: Writing arc4_conversions/out/TestContract.clear.puya.map
+info: writing arc4_conversions/out/client_ReferenceReturn.py
 info: writing arc4_conversions/out/client_CheckApp.py
 info: writing arc4_conversions/out/client_TestContract.py

--- a/test_cases/arc4_conversions/puya_O2.log
+++ b/test_cases/arc4_conversions/puya_O2.log
@@ -384,6 +384,140 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_conversions.contract.my_dyn_struct_arc4
 debug: Sealing block@0
 debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Sealing block@1
+debug: Terminated block@1
+debug: Sealing block@2
+debug: Terminated block@2
+debug: Sealing block@3
+debug: Terminated block@3
+debug: Sealing block@4
+debug: Terminated block@4
+debug: Sealing block@5
+debug: Terminated block@5
+debug: Sealing block@6
+debug: Terminated block@6
+debug: Sealing block@7
+debug: Terminated block@7
+debug: Sealing block@8
+debug: Terminated block@8
+debug: Sealing block@9
+debug: Terminated block@9
+debug: Sealing block@10
+debug: Terminated block@10
+debug: Sealing block@11
+debug: Terminated block@11
+debug: Sealing block@12
+debug: Terminated block@12
+debug: Sealing block@13
+debug: Terminated block@13
+debug: Sealing block@14
+debug: Terminated block@14
+debug: Sealing block@15
+debug: Terminated block@15
+debug: Sealing block@16
+debug: Terminated block@16
+debug: Sealing block@17
+debug: Terminated block@17
+debug: Sealing block@18
+debug: Terminated block@18
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function algopy.arc4.ARC4Contract.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function algopy.arc4.ARC4Contract.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function algopy.arc4.ARC4Contract.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_struct
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_dyn_struct
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_dyn_struct_arc4
+debug: removing unused subroutine algopy.arc4.ARC4Contract.approval_program
+debug: removing unused subroutine algopy.arc4.ARC4Contract.clear_state_program
+debug: Building IR for function algopy.arc4.ARC4Contract.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_struct
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_dyn_struct
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_dyn_struct_arc4
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create
+debug: removing unused subroutine algopy.arc4.ARC4Contract.approval_program
+debug: removing unused subroutine algopy.arc4.ARC4Contract.clear_state_program
 debug: Building IR for function test_cases.arc4_conversions.contract.TestContract.__puya_arc4_router__
 debug: Sealing block@0
 debug: Terminated block@0
@@ -735,6 +869,948 @@ debug: removing unused subroutine test_cases.arc4_conversions.contract.CheckApp.
 debug: removing unused subroutine test_cases.arc4_conversions.contract.CheckApp.__algopy_default_create
 debug: removing unused subroutine algopy.arc4.ARC4Contract.approval_program
 debug: removing unused subroutine algopy.arc4.ARC4Contract.clear_state_program
+debug: optimizing approval program of test_cases.arc4_conversions.reference.ReferenceReturn at level 2
+debug: Begin optimization pass 1/100
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret for inlining
+debug: marking trivial method test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret as inlineable
+debug: marking trivial method test_cases.arc4_conversions.reference.ReferenceReturn.app_ret as inlineable
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.store for inlining
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.store_apps for inlining
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.store_assets for inlining
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts for inlining
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.return_apps for inlining
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.return_assets for inlining
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts for inlining
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__ in algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Simplified (== tmp%3#0 NoOp) to (! tmp%3#0)
+debug: Simplified (== tmp%9#0 NoOp) to (! tmp%9#0)
+debug: Simplified (== tmp%14#0 NoOp) to (! tmp%14#0)
+debug: Simplified (== tmp%19#0 NoOp) to (! tmp%19#0)
+debug: Simplified (== tmp%29#0 NoOp) to (! tmp%29#0)
+debug: Simplified (== tmp%33#0 NoOp) to (! tmp%33#0)
+debug: Simplified (== tmp%37#0 NoOp) to (! tmp%37#0)
+debug: Simplified (== tmp%41#0 NoOp) to (! tmp%41#0)
+debug: Simplified (== tmp%47#0 NoOp) to (! tmp%47#0)
+debug: Simplified (== tmp%53#0 NoOp) to (! tmp%53#0)
+debug: Simplified (== tmp%60#0 0u) to (! tmp%60#0)
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: simplifying a switch with constants into goto nth
+debug: simplified terminator of block@15 from switch tmp%59#0 {0u => block@16, * => block@17} to goto_nth [block@16][tmp%59#0] else goto block@17
+debug: simplifying a goto nth with two targets into a conditional branch
+debug: simplified terminator of block@15 from goto_nth [block@16][tmp%59#0] else goto block@17 to goto tmp%59#0 ? block@17 : block@16
+debug: Optimizer: Remove Linear Jump
+debug: Replaced predecessor block@1 with block@0 in block@15
+debug: Replaced predecessor block@1 with block@0 in block@2
+debug: Merged linear block@1 into block@0
+debug: Replaced predecessor block@14 with block@13 in block@19
+debug: Merged linear block@14 into block@13
+debug: Replaced predecessor block@18 with block@17 in block@19
+debug: Merged linear block@18 into block@17
+debug: Optimizer: Remove Empty Blocks
+debug: Removed empty block: block@13
+debug: Removed empty block: block@17
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+debug: Optimizer: Perform Subroutine Inlining
+debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create in test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+arc4_conversions/reference.py:43:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts in test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+arc4_conversions/reference.py:39:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.return_assets in test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+arc4_conversions/reference.py:35:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.return_apps in test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+arc4_conversions/reference.py:31:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts in test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+arc4_conversions/reference.py:27:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.store_assets in test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+arc4_conversions/reference.py:23:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.store_apps in test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+arc4_conversions/reference.py:17:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.store in test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+arc4_conversions/reference.py:13:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.app_ret in test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+arc4_conversions/reference.py:9:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret in test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+arc4_conversions/reference.py:5:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret in test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Found equivalence set: tmp%0#1, tmp%7#0
+debug: selected tmp%0#1 from equivalence set
+debug: Found equivalence set: tmp%24#0, acc#0
+debug: selected acc#0 from equivalence set
+debug: Found equivalence set: tmp%26#0, app#0
+debug: selected app#0 from equivalence set
+debug: Found equivalence set: tmp%28#0, asset#0
+debug: selected asset#0 from equivalence set
+debug: Found equivalence set: reinterpret_encoded_uint64[]%0#0, apps#0
+debug: selected apps#0 from equivalence set
+debug: Found equivalence set: reinterpret_encoded_uint64[]%1#0, assets#0
+debug: selected assets#0 from equivalence set
+debug: Found equivalence set: reinterpret_bytes[32][]%0#0, accounts#0
+debug: selected accounts#0 from equivalence set
+debug: Found equivalence set: maybe_value%0#2, tmp%45#0
+debug: selected maybe_value%0#2 from equivalence set
+debug: Found equivalence set: maybe_value%0#1, tmp%51#0
+debug: selected maybe_value%0#1 from equivalence set
+debug: Found equivalence set: maybe_value%0#0, tmp%57#0
+debug: selected maybe_value%0#0 from equivalence set
+debug: Copy propagation made 10 modifications
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Removing unused variable to_encode%0#0
+debug: Removing unused variable to_encode%1#0
+debug: Optimizer: Intrinsic Simplifier
+debug: Simplified (== tmp%3#0 NoOp) to (! tmp%3#0)
+debug: Simplified (== tmp%9#0 NoOp) to (! tmp%9#0)
+debug: Simplified (concat 0x151f7c75 val_as_bytes%0#0) to 0x151f7c7500000000000004d2
+debug: Simplified (== tmp%14#0 NoOp) to (! tmp%14#0)
+debug: Simplified (concat 0x151f7c75 val_as_bytes%1#0) to 0x151f7c7500000000000004d2
+debug: Simplified (== tmp%19#0 NoOp) to (! tmp%19#0)
+debug: Simplified (== tmp%29#0 NoOp) to (! tmp%29#0)
+debug: Simplified (== tmp%33#0 NoOp) to (! tmp%33#0)
+debug: Simplified (== tmp%37#0 NoOp) to (! tmp%37#0)
+debug: Simplified (== tmp%41#0 NoOp) to (! tmp%41#0)
+debug: Simplified (== tmp%47#0 NoOp) to (! tmp%47#0)
+debug: Simplified (== tmp%53#0 NoOp) to (! tmp%53#0)
+debug: Simplified (== tmp%60#0 0u) to (! tmp%60#0)
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: simplifying a switch with constants into goto nth
+debug: simplified terminator of block@14 from switch tmp%59#0 {0u => block@15, * => block@16} to goto_nth [block@15][tmp%59#0] else goto block@16
+debug: simplifying a goto nth with two targets into a conditional branch
+debug: simplified terminator of block@14 from goto_nth [block@15][tmp%59#0] else goto block@16 to goto tmp%59#0 ? block@16 : block@15
+debug: Optimizer: Remove Linear Jump
+debug: Replaced predecessor block@39 with block@2 in block@40
+debug: Merged linear block@39 into block@2
+debug: Merged linear block@40 into block@2
+debug: Replaced predecessor block@37 with block@3 in block@38
+debug: Merged linear block@37 into block@3
+debug: Merged linear block@38 into block@3
+debug: Replaced predecessor block@35 with block@4 in block@36
+debug: Merged linear block@35 into block@4
+debug: Merged linear block@36 into block@4
+debug: Replaced predecessor block@33 with block@5 in block@34
+debug: Merged linear block@33 into block@5
+debug: Merged linear block@34 into block@5
+debug: Replaced predecessor block@31 with block@6 in block@32
+debug: Merged linear block@31 into block@6
+debug: Merged linear block@32 into block@6
+debug: Replaced predecessor block@29 with block@7 in block@30
+debug: Merged linear block@29 into block@7
+debug: Merged linear block@30 into block@7
+debug: Replaced predecessor block@27 with block@8 in block@28
+debug: Merged linear block@27 into block@8
+debug: Merged linear block@28 into block@8
+debug: Replaced predecessor block@25 with block@9 in block@26
+debug: Merged linear block@25 into block@9
+debug: Merged linear block@26 into block@9
+debug: Replaced predecessor block@23 with block@10 in block@24
+debug: Merged linear block@23 into block@10
+debug: Merged linear block@24 into block@10
+debug: Replaced predecessor block@21 with block@11 in block@22
+debug: Merged linear block@21 into block@11
+debug: Merged linear block@22 into block@11
+debug: Replaced predecessor block@13 with block@12 in block@18
+debug: Merged linear block@13 into block@12
+debug: Replaced predecessor block@19 with block@15 in block@20
+debug: Merged linear block@19 into block@15
+debug: Merged linear block@20 into block@15
+debug: Replaced predecessor block@17 with block@16 in block@18
+debug: Merged linear block@17 into block@16
+debug: Optimizer: Remove Empty Blocks
+debug: Removed empty block: block@12
+debug: Removed empty block: block@16
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+debug: Unused subroutines removed
+debug: Begin optimization pass 2/100
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret for inlining
+debug: marking trivial method test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret as inlineable
+debug: marking trivial method test_cases.arc4_conversions.reference.ReferenceReturn.app_ret as inlineable
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.store for inlining
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.store_apps for inlining
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.store_assets for inlining
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts for inlining
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.return_apps for inlining
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.return_assets for inlining
+debug: marking single-use function test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts for inlining
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create in algopy.arc4.ARC4Contract.approval_program
+arc4_conversions/reference.py:43:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts in algopy.arc4.ARC4Contract.approval_program
+arc4_conversions/reference.py:39:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.return_assets in algopy.arc4.ARC4Contract.approval_program
+arc4_conversions/reference.py:35:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.return_apps in algopy.arc4.ARC4Contract.approval_program
+arc4_conversions/reference.py:31:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts in algopy.arc4.ARC4Contract.approval_program
+arc4_conversions/reference.py:27:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.store_assets in algopy.arc4.ARC4Contract.approval_program
+arc4_conversions/reference.py:23:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.store_apps in algopy.arc4.ARC4Contract.approval_program
+arc4_conversions/reference.py:17:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.store in algopy.arc4.ARC4Contract.approval_program
+arc4_conversions/reference.py:13:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.app_ret in algopy.arc4.ARC4Contract.approval_program
+arc4_conversions/reference.py:9:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret in algopy.arc4.ARC4Contract.approval_program
+arc4_conversions/reference.py:5:6 debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret in algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Found equivalence set: tmp%0#2, tmp%7#0
+debug: selected tmp%0#2 from equivalence set
+debug: Found equivalence set: tmp%24#0, acc#0
+debug: selected acc#0 from equivalence set
+debug: Found equivalence set: tmp%26#0, app#0
+debug: selected app#0 from equivalence set
+debug: Found equivalence set: tmp%28#0, asset#0
+debug: selected asset#0 from equivalence set
+debug: Found equivalence set: reinterpret_encoded_uint64[]%0#0, apps#0
+debug: selected apps#0 from equivalence set
+debug: Found equivalence set: reinterpret_encoded_uint64[]%1#0, assets#0
+debug: selected assets#0 from equivalence set
+debug: Found equivalence set: reinterpret_bytes[32][]%0#0, accounts#0
+debug: selected accounts#0 from equivalence set
+debug: Found equivalence set: maybe_value%0#2, tmp%45#0
+debug: selected maybe_value%0#2 from equivalence set
+debug: Found equivalence set: maybe_value%0#1, tmp%51#0
+debug: selected maybe_value%0#1 from equivalence set
+debug: Found equivalence set: maybe_value%0#0, tmp%57#0
+debug: selected maybe_value%0#0 from equivalence set
+debug: Copy propagation made 10 modifications
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Removing unused variable tmp%1#0
+debug: Removing unused variable tmp%6#0
+debug: Removing unused variable tmp%12#0
+debug: Removing unused variable to_encode%0#0
+debug: Removing unused variable tmp%17#0
+debug: Removing unused variable to_encode%1#0
+debug: Removing unused variable tmp%22#0
+debug: Removing unused variable tmp%32#0
+debug: Removing unused variable tmp%36#0
+debug: Removing unused variable tmp%40#0
+debug: Removing unused variable tmp%44#0
+debug: Removing unused variable tmp%50#0
+debug: Removing unused variable tmp%56#0
+debug: Optimizer: Intrinsic Simplifier
+debug: Simplified (concat 0x151f7c75 val_as_bytes%0#0) to 0x151f7c7500000000000004d2
+debug: Simplified (concat 0x151f7c75 val_as_bytes%1#0) to 0x151f7c7500000000000004d2
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Replaced predecessor block@41 with block@3 in block@42
+debug: Merged linear block@41 into block@3
+debug: Replaced predecessor block@42 with block@3 in block@20
+debug: Merged linear block@42 into block@3
+debug: Replaced predecessor block@39 with block@4 in block@40
+debug: Merged linear block@39 into block@4
+debug: Replaced predecessor block@40 with block@4 in block@20
+debug: Merged linear block@40 into block@4
+debug: Replaced predecessor block@37 with block@5 in block@38
+debug: Merged linear block@37 into block@5
+debug: Replaced predecessor block@38 with block@5 in block@20
+debug: Merged linear block@38 into block@5
+debug: Replaced predecessor block@35 with block@6 in block@36
+debug: Merged linear block@35 into block@6
+debug: Replaced predecessor block@36 with block@6 in block@20
+debug: Merged linear block@36 into block@6
+debug: Replaced predecessor block@33 with block@7 in block@34
+debug: Merged linear block@33 into block@7
+debug: Replaced predecessor block@34 with block@7 in block@20
+debug: Merged linear block@34 into block@7
+debug: Replaced predecessor block@31 with block@8 in block@32
+debug: Merged linear block@31 into block@8
+debug: Replaced predecessor block@32 with block@8 in block@20
+debug: Merged linear block@32 into block@8
+debug: Replaced predecessor block@29 with block@9 in block@30
+debug: Merged linear block@29 into block@9
+debug: Replaced predecessor block@30 with block@9 in block@20
+debug: Merged linear block@30 into block@9
+debug: Replaced predecessor block@27 with block@10 in block@28
+debug: Merged linear block@27 into block@10
+debug: Replaced predecessor block@28 with block@10 in block@20
+debug: Merged linear block@28 into block@10
+debug: Replaced predecessor block@25 with block@11 in block@26
+debug: Merged linear block@25 into block@11
+debug: Replaced predecessor block@26 with block@11 in block@20
+debug: Merged linear block@26 into block@11
+debug: Replaced predecessor block@23 with block@12 in block@24
+debug: Merged linear block@23 into block@12
+debug: Replaced predecessor block@24 with block@12 in block@20
+debug: Merged linear block@24 into block@12
+debug: Replaced predecessor block@21 with block@16 in block@22
+debug: Merged linear block@21 into block@16
+debug: Replaced predecessor block@22 with block@16 in block@20
+debug: Merged linear block@22 into block@16
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create
+debug: Unused subroutines removed
+debug: Begin optimization pass 3/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Removing unused variable val_as_bytes%0#0
+debug: Removing unused variable tmp%13#0
+debug: Removing unused variable val_as_bytes%1#0
+debug: Removing unused variable tmp%18#0
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: Begin optimization pass 4/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: No optimizations performed in pass 4, ending loop
+debug: optimizing clear program of test_cases.arc4_conversions.reference.ReferenceReturn at level 2
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: lowering array IR nodes in approval program of test_cases.arc4_conversions.reference.ReferenceReturn
+debug: lowering array IR nodes in clear program of test_cases.arc4_conversions.reference.ReferenceReturn
+debug: optimizing approval program of test_cases.arc4_conversions.reference.ReferenceReturn at level 2
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: optimizing clear program of test_cases.arc4_conversions.reference.ReferenceReturn at level 2
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Remove Linear Jump
+debug: Optimizer: Remove Empty Blocks
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Redundant Slot Op Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: removing local static slots in approval program of test_cases.arc4_conversions.reference.ReferenceReturn
+debug: auto reserving slots in algopy.arc4.ARC4Contract.approval_program, []
+debug: Slot allocation not required
+debug: removing local static slots in clear program of test_cases.arc4_conversions.reference.ReferenceReturn
+debug: auto reserving slots in algopy.arc4.ARC4Contract.clear_state_program, []
+debug: Slot allocation not required
+debug: Performing SSA IR destructuring for algopy.arc4.ARC4Contract.approval_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in algopy.arc4.ARC4Contract.approval_program using strategy RootOperandGrouping
+debug: Coalescing test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 with [test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#1, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#2, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#3, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#4, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#5, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#6, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#7, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#8, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#9, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#10, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#11]
+debug: Coalescing tmp%0#0 with [tmp%0#3]
+debug: Coalescing maybe_value%0#1 with [maybe_value%0#2]
+debug: Coalescing maybe_exists%0#0 with [maybe_exists%0#2, maybe_exists%0#1]
+debug: Coalescing resulted in 41 replacement/s
+debug: Sequentializing parallel copies in algopy.arc4.ARC4Contract.approval_program
+debug: Performing post-SSA optimizations at level 2
+debug: Output IR to arc4_conversions/out_O2/ReferenceReturn.ir/ReferenceReturn.approval.0.destructured.ir
+debug: Performing SSA IR destructuring for algopy.arc4.ARC4Contract.clear_state_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in algopy.arc4.ARC4Contract.clear_state_program using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in algopy.arc4.ARC4Contract.clear_state_program
+debug: Performing post-SSA optimizations at level 2
+debug: Output IR to arc4_conversions/out_O2/ReferenceReturn.ir/ReferenceReturn.clear.0.destructured.ir
+debug: Inserted main_block@0.ops[1]: 'l-store-copy tmp%0#1 0'
+debug: Replaced main_block@0.ops[3]: 'v-load tmp%0#1' with 'l-load tmp%0#1'
+debug: Inserted main_abi_routing@2.ops[1]: 'l-store-copy tmp%2#0 0'
+debug: Replaced main_abi_routing@2.ops[13]: 'v-load tmp%2#0' with 'l-load tmp%2#0'
+debug: Inserted main_acc_ret_route@3.ops[1]: 'l-store-copy tmp%3#0 0'
+debug: Replaced main_acc_ret_route@3.ops[3]: 'v-load tmp%3#0' with 'l-load tmp%3#0'
+debug: Inserted main_acc_ret_route@3.ops[5]: 'l-store-copy tmp%4#0 0'
+debug: Replaced main_acc_ret_route@3.ops[7]: 'v-load tmp%4#0' with 'l-load tmp%4#0'
+debug: Inserted main_acc_ret_route@3.ops[10]: 'l-store-copy tmp%5#0 0'
+debug: Replaced main_acc_ret_route@3.ops[12]: 'v-load tmp%5#0' with 'l-load tmp%5#0'
+debug: Inserted main_acc_ret_route@3.ops[19]: 'l-store-copy tmp%8#0 0'
+debug: Replaced main_acc_ret_route@3.ops[21]: 'v-load tmp%8#0' with 'l-load tmp%8#0'
+debug: Inserted main_acc_ret_route@3.ops[24]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_acc_ret_route@3.ops[26]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_acc_ret_route@3.ops[15]: 'l-store-copy tmp%0#2 0'
+debug: Replaced main_acc_ret_route@3.ops[18]: 'v-load tmp%0#2' with 'l-load tmp%0#2'
+debug: Inserted main_asset_ret_route@4.ops[1]: 'l-store-copy tmp%9#0 0'
+debug: Replaced main_asset_ret_route@4.ops[3]: 'v-load tmp%9#0' with 'l-load tmp%9#0'
+debug: Inserted main_asset_ret_route@4.ops[5]: 'l-store-copy tmp%10#0 0'
+debug: Replaced main_asset_ret_route@4.ops[7]: 'v-load tmp%10#0' with 'l-load tmp%10#0'
+debug: Inserted main_asset_ret_route@4.ops[10]: 'l-store-copy tmp%11#0 0'
+debug: Replaced main_asset_ret_route@4.ops[12]: 'v-load tmp%11#0' with 'l-load tmp%11#0'
+debug: Inserted main_asset_ret_route@4.ops[17]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_asset_ret_route@4.ops[19]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_app_ret_route@5.ops[1]: 'l-store-copy tmp%14#0 0'
+debug: Replaced main_app_ret_route@5.ops[3]: 'v-load tmp%14#0' with 'l-load tmp%14#0'
+debug: Inserted main_app_ret_route@5.ops[5]: 'l-store-copy tmp%15#0 0'
+debug: Replaced main_app_ret_route@5.ops[7]: 'v-load tmp%15#0' with 'l-load tmp%15#0'
+debug: Inserted main_app_ret_route@5.ops[10]: 'l-store-copy tmp%16#0 0'
+debug: Replaced main_app_ret_route@5.ops[12]: 'v-load tmp%16#0' with 'l-load tmp%16#0'
+debug: Inserted main_app_ret_route@5.ops[17]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_app_ret_route@5.ops[19]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_store_route@6.ops[1]: 'l-store-copy tmp%19#0 0'
+debug: Replaced main_store_route@6.ops[3]: 'v-load tmp%19#0' with 'l-load tmp%19#0'
+debug: Inserted main_store_route@6.ops[5]: 'l-store-copy tmp%20#0 0'
+debug: Replaced main_store_route@6.ops[7]: 'v-load tmp%20#0' with 'l-load tmp%20#0'
+debug: Inserted main_store_route@6.ops[10]: 'l-store-copy tmp%21#0 0'
+debug: Replaced main_store_route@6.ops[12]: 'v-load tmp%21#0' with 'l-load tmp%21#0'
+debug: Inserted main_store_route@6.ops[15]: 'l-store-copy reinterpret_bytes[1]%0#0 0'
+debug: Replaced main_store_route@6.ops[17]: 'v-load reinterpret_bytes[1]%0#0' with 'l-load reinterpret_bytes[1]%0#0'
+debug: Inserted main_store_route@6.ops[19]: 'l-store-copy tmp%23#0 0'
+debug: Replaced main_store_route@6.ops[21]: 'v-load tmp%23#0' with 'l-load tmp%23#0'
+debug: Inserted main_store_route@6.ops[25]: 'l-store-copy reinterpret_bytes[1]%1#0 0'
+debug: Replaced main_store_route@6.ops[27]: 'v-load reinterpret_bytes[1]%1#0' with 'l-load reinterpret_bytes[1]%1#0'
+debug: Inserted main_store_route@6.ops[29]: 'l-store-copy tmp%25#0 0'
+debug: Replaced main_store_route@6.ops[31]: 'v-load tmp%25#0' with 'l-load tmp%25#0'
+debug: Inserted main_store_route@6.ops[35]: 'l-store-copy reinterpret_bytes[1]%2#0 0'
+debug: Replaced main_store_route@6.ops[37]: 'v-load reinterpret_bytes[1]%2#0' with 'l-load reinterpret_bytes[1]%2#0'
+debug: Inserted main_store_route@6.ops[39]: 'l-store-copy tmp%27#0 0'
+debug: Replaced main_store_route@6.ops[41]: 'v-load tmp%27#0' with 'l-load tmp%27#0'
+debug: Inserted main_store_route@6.ops[54]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_store_route@6.ops[56]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_store_route@6.ops[43]: 'l-store-copy asset#0 0'
+debug: Replaced main_store_route@6.ops[49]: 'v-load asset#0' with 'l-load asset#0'
+debug: Inserted main_store_route@6.ops[33]: 'l-store-copy app#0 0'
+debug: Replaced main_store_route@6.ops[53]: 'v-load app#0' with 'l-load app#0'
+debug: Inserted main_store_route@6.ops[23]: 'l-store-copy acc#0 0'
+debug: Replaced main_store_route@6.ops[48]: 'v-load acc#0' with 'l-load acc#0'
+debug: Inserted main_store_apps_route@7.ops[1]: 'l-store-copy tmp%29#0 0'
+debug: Replaced main_store_apps_route@7.ops[3]: 'v-load tmp%29#0' with 'l-load tmp%29#0'
+debug: Inserted main_store_apps_route@7.ops[5]: 'l-store-copy tmp%30#0 0'
+debug: Replaced main_store_apps_route@7.ops[7]: 'v-load tmp%30#0' with 'l-load tmp%30#0'
+debug: Inserted main_store_apps_route@7.ops[10]: 'l-store-copy tmp%31#0 0'
+debug: Replaced main_store_apps_route@7.ops[12]: 'v-load tmp%31#0' with 'l-load tmp%31#0'
+debug: Inserted main_store_apps_route@7.ops[20]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_store_apps_route@7.ops[22]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_store_apps_route@7.ops[15]: 'l-store-copy apps#0 0'
+debug: Replaced main_store_apps_route@7.ops[18]: 'v-load apps#0' with 'l-load apps#0'
+debug: Inserted main_store_assets_route@8.ops[1]: 'l-store-copy tmp%33#0 0'
+debug: Replaced main_store_assets_route@8.ops[3]: 'v-load tmp%33#0' with 'l-load tmp%33#0'
+debug: Inserted main_store_assets_route@8.ops[5]: 'l-store-copy tmp%34#0 0'
+debug: Replaced main_store_assets_route@8.ops[7]: 'v-load tmp%34#0' with 'l-load tmp%34#0'
+debug: Inserted main_store_assets_route@8.ops[10]: 'l-store-copy tmp%35#0 0'
+debug: Replaced main_store_assets_route@8.ops[12]: 'v-load tmp%35#0' with 'l-load tmp%35#0'
+debug: Inserted main_store_assets_route@8.ops[20]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_store_assets_route@8.ops[22]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_store_assets_route@8.ops[15]: 'l-store-copy assets#0 0'
+debug: Replaced main_store_assets_route@8.ops[18]: 'v-load assets#0' with 'l-load assets#0'
+debug: Inserted main_store_accounts_route@9.ops[1]: 'l-store-copy tmp%37#0 0'
+debug: Replaced main_store_accounts_route@9.ops[3]: 'v-load tmp%37#0' with 'l-load tmp%37#0'
+debug: Inserted main_store_accounts_route@9.ops[5]: 'l-store-copy tmp%38#0 0'
+debug: Replaced main_store_accounts_route@9.ops[7]: 'v-load tmp%38#0' with 'l-load tmp%38#0'
+debug: Inserted main_store_accounts_route@9.ops[10]: 'l-store-copy tmp%39#0 0'
+debug: Replaced main_store_accounts_route@9.ops[12]: 'v-load tmp%39#0' with 'l-load tmp%39#0'
+debug: Inserted main_store_accounts_route@9.ops[20]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_store_accounts_route@9.ops[22]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_store_accounts_route@9.ops[15]: 'l-store-copy accounts#0 0'
+debug: Replaced main_store_accounts_route@9.ops[18]: 'v-load accounts#0' with 'l-load accounts#0'
+debug: Inserted main_return_apps_route@10.ops[1]: 'l-store-copy tmp%41#0 0'
+debug: Replaced main_return_apps_route@10.ops[3]: 'v-load tmp%41#0' with 'l-load tmp%41#0'
+debug: Inserted main_return_apps_route@10.ops[5]: 'l-store-copy tmp%42#0 0'
+debug: Replaced main_return_apps_route@10.ops[7]: 'v-load tmp%42#0' with 'l-load tmp%42#0'
+debug: Inserted main_return_apps_route@10.ops[10]: 'l-store-copy tmp%43#0 0'
+debug: Replaced main_return_apps_route@10.ops[12]: 'v-load tmp%43#0' with 'l-load tmp%43#0'
+debug: Inserted main_return_apps_route@10.ops[24]: 'l-store-copy tmp%46#0 0'
+debug: Replaced main_return_apps_route@10.ops[26]: 'v-load tmp%46#0' with 'l-load tmp%46#0'
+debug: Inserted main_return_apps_route@10.ops[29]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_return_apps_route@10.ops[31]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_return_apps_route@10.ops[17]: 'l-store-copy maybe_exists%0#0 1'
+debug: Replaced main_return_apps_route@10.ops[20]: 'v-load maybe_exists%0#0' with 'l-load maybe_exists%0#0'
+debug: Inserted main_return_apps_route@10.ops[19]: 'l-store-copy maybe_value%0#1 1'
+debug: Replaced main_return_apps_route@10.ops[24]: 'v-load maybe_value%0#1' with 'l-load maybe_value%0#1'
+debug: Inserted main_return_assets_route@11.ops[1]: 'l-store-copy tmp%47#0 0'
+debug: Replaced main_return_assets_route@11.ops[3]: 'v-load tmp%47#0' with 'l-load tmp%47#0'
+debug: Inserted main_return_assets_route@11.ops[5]: 'l-store-copy tmp%48#0 0'
+debug: Replaced main_return_assets_route@11.ops[7]: 'v-load tmp%48#0' with 'l-load tmp%48#0'
+debug: Inserted main_return_assets_route@11.ops[10]: 'l-store-copy tmp%49#0 0'
+debug: Replaced main_return_assets_route@11.ops[12]: 'v-load tmp%49#0' with 'l-load tmp%49#0'
+debug: Inserted main_return_assets_route@11.ops[24]: 'l-store-copy tmp%52#0 0'
+debug: Replaced main_return_assets_route@11.ops[26]: 'v-load tmp%52#0' with 'l-load tmp%52#0'
+debug: Inserted main_return_assets_route@11.ops[29]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_return_assets_route@11.ops[31]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_return_assets_route@11.ops[17]: 'l-store-copy maybe_exists%0#0 1'
+debug: Replaced main_return_assets_route@11.ops[20]: 'v-load maybe_exists%0#0' with 'l-load maybe_exists%0#0'
+debug: Inserted main_return_assets_route@11.ops[19]: 'l-store-copy maybe_value%0#1 1'
+debug: Replaced main_return_assets_route@11.ops[24]: 'v-load maybe_value%0#1' with 'l-load maybe_value%0#1'
+debug: Inserted main_return_accounts_route@12.ops[1]: 'l-store-copy tmp%53#0 0'
+debug: Replaced main_return_accounts_route@12.ops[3]: 'v-load tmp%53#0' with 'l-load tmp%53#0'
+debug: Inserted main_return_accounts_route@12.ops[5]: 'l-store-copy tmp%54#0 0'
+debug: Replaced main_return_accounts_route@12.ops[7]: 'v-load tmp%54#0' with 'l-load tmp%54#0'
+debug: Inserted main_return_accounts_route@12.ops[10]: 'l-store-copy tmp%55#0 0'
+debug: Replaced main_return_accounts_route@12.ops[12]: 'v-load tmp%55#0' with 'l-load tmp%55#0'
+debug: Inserted main_return_accounts_route@12.ops[24]: 'l-store-copy tmp%58#0 0'
+debug: Replaced main_return_accounts_route@12.ops[26]: 'v-load tmp%58#0' with 'l-load tmp%58#0'
+debug: Inserted main_return_accounts_route@12.ops[29]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_return_accounts_route@12.ops[31]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_return_accounts_route@12.ops[17]: 'l-store-copy maybe_exists%0#0 1'
+debug: Replaced main_return_accounts_route@12.ops[20]: 'v-load maybe_exists%0#0' with 'l-load maybe_exists%0#0'
+debug: Inserted main_return_accounts_route@12.ops[19]: 'l-store-copy maybe_value%0#0 1'
+debug: Replaced main_return_accounts_route@12.ops[24]: 'v-load maybe_value%0#0' with 'l-load maybe_value%0#0'
+debug: Inserted main_bare_routing@15.ops[1]: 'l-store-copy tmp%59#0 0'
+debug: Replaced main_bare_routing@15.ops[3]: 'v-load tmp%59#0' with 'l-load tmp%59#0'
+debug: Inserted main___algopy_default_create@16.ops[1]: 'l-store-copy tmp%60#0 0'
+debug: Replaced main___algopy_default_create@16.ops[3]: 'v-load tmp%60#0' with 'l-load tmp%60#0'
+debug: Inserted main___algopy_default_create@16.ops[5]: 'l-store-copy tmp%61#0 0'
+debug: Replaced main___algopy_default_create@16.ops[7]: 'v-load tmp%61#0' with 'l-load tmp%61#0'
+debug: Inserted main___algopy_default_create@16.ops[10]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main___algopy_default_create@16.ops[12]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_after_if_else@19.ops[1]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_after_if_else@19.ops[3]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Found 3 edge set/s for algopy.arc4.ARC4Contract.approval_program
+debug: Allocated 1 variable/s to x-stack: tmp%0#0
+debug: shared x-stack for main_acc_ret_route@3 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_asset_ret_route@4 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_app_ret_route@5 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_store_route@6 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_store_apps_route@7 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_store_assets_route@8 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_store_accounts_route@9 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_return_apps_route@10 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_return_assets_route@11 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_return_accounts_route@12 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main___algopy_default_create@16 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_after_if_else@19 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: optimizing TEAL subroutine ops algopy.arc4.ARC4Contract.approval_program() -> uint64:
+debug: optimizing TEAL subroutine blocks algopy.arc4.ARC4Contract.approval_program() -> uint64:
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: replacing `b main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20` with `return`
+debug: inlining single reference block main_block@0 into main
+debug: inlining single reference block main_abi_routing@2 into main
+debug: inlining single reference block main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20 into main_after_if_else@19
+debug: inlining single reference block main___algopy_default_create@16 into main_bare_routing@15
+debug: removing explicit jump to fall-through block main_after_if_else@19
+debug: optimizing TEAL subroutine ops algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+debug: optimizing TEAL subroutine blocks algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+debug: inlining single reference block main_block@0 into main
 debug: optimizing approval program of test_cases.arc4_conversions.contract.CheckApp at level 2
 debug: Begin optimization pass 1/100
 debug: marking trivial method test_cases.arc4_conversions.contract.CheckApp.delete_application as inlineable
@@ -9089,6 +10165,12 @@ debug: inlining single reference block my_dyn_struct_arc4_block@0 into my_dyn_st
 debug: optimizing TEAL subroutine ops algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
 debug: optimizing TEAL subroutine blocks algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
 debug: inlining single reference block main_block@0 into main
+info: Writing arc4_conversions/out_O2/ReferenceReturn.approval.teal
+info: Writing arc4_conversions/out_O2/ReferenceReturn.clear.teal
+info: Writing arc4_conversions/out_O2/ReferenceReturn.approval.bin
+info: Writing arc4_conversions/out_O2/ReferenceReturn.clear.bin
+info: Writing arc4_conversions/out_O2/ReferenceReturn.approval.puya.map
+info: Writing arc4_conversions/out_O2/ReferenceReturn.clear.puya.map
 info: Writing arc4_conversions/out_O2/CheckApp.approval.teal
 info: Writing arc4_conversions/out_O2/CheckApp.clear.teal
 info: Writing arc4_conversions/out_O2/CheckApp.approval.bin

--- a/test_cases/arc4_conversions/puya_unoptimized.log
+++ b/test_cases/arc4_conversions/puya_unoptimized.log
@@ -384,6 +384,140 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_conversions.contract.my_dyn_struct_arc4
 debug: Sealing block@0
 debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Sealing block@1
+debug: Terminated block@1
+debug: Sealing block@2
+debug: Terminated block@2
+debug: Sealing block@3
+debug: Terminated block@3
+debug: Sealing block@4
+debug: Terminated block@4
+debug: Sealing block@5
+debug: Terminated block@5
+debug: Sealing block@6
+debug: Terminated block@6
+debug: Sealing block@7
+debug: Terminated block@7
+debug: Sealing block@8
+debug: Terminated block@8
+debug: Sealing block@9
+debug: Terminated block@9
+debug: Sealing block@10
+debug: Terminated block@10
+debug: Sealing block@11
+debug: Terminated block@11
+debug: Sealing block@12
+debug: Terminated block@12
+debug: Sealing block@13
+debug: Terminated block@13
+debug: Sealing block@14
+debug: Terminated block@14
+debug: Sealing block@15
+debug: Terminated block@15
+debug: Sealing block@16
+debug: Terminated block@16
+debug: Sealing block@17
+debug: Terminated block@17
+debug: Sealing block@18
+debug: Terminated block@18
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function algopy.arc4.ARC4Contract.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function algopy.arc4.ARC4Contract.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function algopy.arc4.ARC4Contract.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_struct
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_dyn_struct
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_dyn_struct_arc4
+debug: removing unused subroutine algopy.arc4.ARC4Contract.approval_program
+debug: removing unused subroutine algopy.arc4.ARC4Contract.clear_state_program
+debug: Building IR for function algopy.arc4.ARC4Contract.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_struct
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_dyn_struct
+debug: removing unused subroutine test_cases.arc4_conversions.contract.my_dyn_struct_arc4
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create
+debug: removing unused subroutine algopy.arc4.ARC4Contract.approval_program
+debug: removing unused subroutine algopy.arc4.ARC4Contract.clear_state_program
 debug: Building IR for function test_cases.arc4_conversions.contract.TestContract.__puya_arc4_router__
 debug: Sealing block@0
 debug: Terminated block@0
@@ -735,6 +869,718 @@ debug: removing unused subroutine test_cases.arc4_conversions.contract.CheckApp.
 debug: removing unused subroutine test_cases.arc4_conversions.contract.CheckApp.__algopy_default_create
 debug: removing unused subroutine algopy.arc4.ARC4Contract.approval_program
 debug: removing unused subroutine algopy.arc4.ARC4Contract.clear_state_program
+debug: optimizing approval program of test_cases.arc4_conversions.reference.ReferenceReturn at level 0
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__ in algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+debug: Optimizer: Perform Subroutine Inlining
+debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create in test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__
+debug: Unused subroutines removed
+debug: Begin optimization pass 2/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: inlining call to test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create in algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: removing unused subroutine test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create
+debug: Unused subroutines removed
+debug: Begin optimization pass 3/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: No optimizations performed in pass 3, ending loop
+debug: optimizing clear program of test_cases.arc4_conversions.reference.ReferenceReturn at level 0
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: No optimizations performed in pass 1, ending loop
+debug: lowering array IR nodes in approval program of test_cases.arc4_conversions.reference.ReferenceReturn
+debug: lowering array IR nodes in clear program of test_cases.arc4_conversions.reference.ReferenceReturn
+debug: optimizing approval program of test_cases.arc4_conversions.reference.ReferenceReturn at level 0
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizing subroutine test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: No optimizations performed in pass 1, ending loop
+debug: optimizing clear program of test_cases.arc4_conversions.reference.ReferenceReturn at level 0
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine algopy.arc4.ARC4Contract.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: No optimizations performed in pass 1, ending loop
+debug: removing local static slots in approval program of test_cases.arc4_conversions.reference.ReferenceReturn
+debug: auto reserving slots in algopy.arc4.ARC4Contract.approval_program, []
+arc4_conversions/reference.py:5 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret, []
+arc4_conversions/reference.py:9 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret, []
+arc4_conversions/reference.py:13 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.app_ret, []
+arc4_conversions/reference.py:17 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.store, []
+arc4_conversions/reference.py:23 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.store_apps, []
+arc4_conversions/reference.py:27 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.store_assets, []
+arc4_conversions/reference.py:31 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts, []
+arc4_conversions/reference.py:35 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.return_apps, []
+arc4_conversions/reference.py:39 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.return_assets, []
+arc4_conversions/reference.py:43 debug: auto reserving slots in test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts, []
+debug: Slot allocation not required
+debug: removing local static slots in clear program of test_cases.arc4_conversions.reference.ReferenceReturn
+debug: auto reserving slots in algopy.arc4.ARC4Contract.clear_state_program, []
+debug: Slot allocation not required
+debug: Performing SSA IR destructuring for algopy.arc4.ARC4Contract.approval_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in algopy.arc4.ARC4Contract.approval_program using strategy RootOperandGrouping
+debug: Coalescing test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 with [test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#1, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#2, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#3, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#4, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#5, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#6, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#7, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#8, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#9, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#10, test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#11]
+debug: Coalescing tmp%0#0 with [tmp%0#2]
+debug: Coalescing resulted in 35 replacement/s
+debug: Sequentializing parallel copies in algopy.arc4.ARC4Contract.approval_program
+debug: Performing post-SSA optimizations at level 0
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret
+debug: Performing post-SSA optimizations at level 0
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret
+debug: Performing post-SSA optimizations at level 0
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.app_ret using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.app_ret
+debug: Performing post-SSA optimizations at level 0
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.store using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.store
+debug: Performing post-SSA optimizations at level 0
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.store_apps using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.store_apps
+debug: Performing post-SSA optimizations at level 0
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.store_assets using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.store_assets
+debug: Performing post-SSA optimizations at level 0
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts
+debug: Performing post-SSA optimizations at level 0
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.return_apps using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.return_apps
+debug: Performing post-SSA optimizations at level 0
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.return_assets using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.return_assets
+debug: Performing post-SSA optimizations at level 0
+debug: Performing SSA IR destructuring for test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts
+debug: Performing post-SSA optimizations at level 0
+debug: Output IR to arc4_conversions/out_unoptimized/ReferenceReturn.ir/ReferenceReturn.approval.0.destructured.ir
+debug: Performing SSA IR destructuring for algopy.arc4.ARC4Contract.clear_state_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in algopy.arc4.ARC4Contract.clear_state_program using strategy RootOperandGrouping
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in algopy.arc4.ARC4Contract.clear_state_program
+debug: Performing post-SSA optimizations at level 0
+debug: Output IR to arc4_conversions/out_unoptimized/ReferenceReturn.ir/ReferenceReturn.clear.0.destructured.ir
+debug: Inserted main_block@1.ops[1]: 'l-store-copy tmp%0#1 0'
+debug: Replaced main_block@1.ops[3]: 'v-load tmp%0#1' with 'l-load tmp%0#1'
+debug: Inserted main_block@1.ops[6]: 'l-store-copy tmp%1#0 0'
+debug: Replaced main_block@1.ops[8]: 'v-load tmp%1#0' with 'l-load tmp%1#0'
+debug: Inserted main_abi_routing@2.ops[1]: 'l-store-copy tmp%2#0 0'
+debug: Replaced main_abi_routing@2.ops[13]: 'v-load tmp%2#0' with 'l-load tmp%2#0'
+debug: Inserted main_acc_ret_route@3.ops[1]: 'l-store-copy tmp%3#0 0'
+debug: Replaced main_acc_ret_route@3.ops[3]: 'v-load tmp%3#0' with 'l-load tmp%3#0'
+debug: Inserted main_acc_ret_route@3.ops[6]: 'l-store-copy tmp%4#0 0'
+debug: Replaced main_acc_ret_route@3.ops[8]: 'v-load tmp%4#0' with 'l-load tmp%4#0'
+debug: Inserted main_acc_ret_route@3.ops[11]: 'l-store-copy tmp%5#0 0'
+debug: Replaced main_acc_ret_route@3.ops[13]: 'v-load tmp%5#0' with 'l-load tmp%5#0'
+debug: Inserted main_acc_ret_route@3.ops[16]: 'l-store-copy tmp%6#0 0'
+debug: Replaced main_acc_ret_route@3.ops[18]: 'v-load tmp%6#0' with 'l-load tmp%6#0'
+debug: Inserted main_acc_ret_route@3.ops[25]: 'l-store-copy tmp%8#0 0'
+debug: Replaced main_acc_ret_route@3.ops[27]: 'v-load tmp%8#0' with 'l-load tmp%8#0'
+debug: Inserted main_acc_ret_route@3.ops[30]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_acc_ret_route@3.ops[32]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_acc_ret_route@3.ops[21]: 'l-store-copy tmp%7#0 0'
+debug: Replaced main_acc_ret_route@3.ops[24]: 'v-load tmp%7#0' with 'l-load tmp%7#0'
+debug: Inserted main_asset_ret_route@4.ops[1]: 'l-store-copy tmp%9#0 0'
+debug: Replaced main_asset_ret_route@4.ops[3]: 'v-load tmp%9#0' with 'l-load tmp%9#0'
+debug: Inserted main_asset_ret_route@4.ops[6]: 'l-store-copy tmp%10#0 0'
+debug: Replaced main_asset_ret_route@4.ops[8]: 'v-load tmp%10#0' with 'l-load tmp%10#0'
+debug: Inserted main_asset_ret_route@4.ops[11]: 'l-store-copy tmp%11#0 0'
+debug: Replaced main_asset_ret_route@4.ops[13]: 'v-load tmp%11#0' with 'l-load tmp%11#0'
+debug: Inserted main_asset_ret_route@4.ops[16]: 'l-store-copy tmp%12#0 0'
+debug: Replaced main_asset_ret_route@4.ops[18]: 'v-load tmp%12#0' with 'l-load tmp%12#0'
+debug: Inserted main_asset_ret_route@4.ops[21]: 'l-store-copy to_encode%0#0 0'
+debug: Replaced main_asset_ret_route@4.ops[23]: 'v-load to_encode%0#0' with 'l-load to_encode%0#0'
+debug: Inserted main_asset_ret_route@4.ops[29]: 'l-store-copy tmp%13#0 0'
+debug: Replaced main_asset_ret_route@4.ops[31]: 'v-load tmp%13#0' with 'l-load tmp%13#0'
+debug: Inserted main_asset_ret_route@4.ops[34]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_asset_ret_route@4.ops[36]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_asset_ret_route@4.ops[25]: 'l-store-copy val_as_bytes%0#0 0'
+debug: Replaced main_asset_ret_route@4.ops[28]: 'v-load val_as_bytes%0#0' with 'l-load val_as_bytes%0#0'
+debug: Inserted main_app_ret_route@5.ops[1]: 'l-store-copy tmp%14#0 0'
+debug: Replaced main_app_ret_route@5.ops[3]: 'v-load tmp%14#0' with 'l-load tmp%14#0'
+debug: Inserted main_app_ret_route@5.ops[6]: 'l-store-copy tmp%15#0 0'
+debug: Replaced main_app_ret_route@5.ops[8]: 'v-load tmp%15#0' with 'l-load tmp%15#0'
+debug: Inserted main_app_ret_route@5.ops[11]: 'l-store-copy tmp%16#0 0'
+debug: Replaced main_app_ret_route@5.ops[13]: 'v-load tmp%16#0' with 'l-load tmp%16#0'
+debug: Inserted main_app_ret_route@5.ops[16]: 'l-store-copy tmp%17#0 0'
+debug: Replaced main_app_ret_route@5.ops[18]: 'v-load tmp%17#0' with 'l-load tmp%17#0'
+debug: Inserted main_app_ret_route@5.ops[21]: 'l-store-copy to_encode%1#0 0'
+debug: Replaced main_app_ret_route@5.ops[23]: 'v-load to_encode%1#0' with 'l-load to_encode%1#0'
+debug: Inserted main_app_ret_route@5.ops[29]: 'l-store-copy tmp%18#0 0'
+debug: Replaced main_app_ret_route@5.ops[31]: 'v-load tmp%18#0' with 'l-load tmp%18#0'
+debug: Inserted main_app_ret_route@5.ops[34]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_app_ret_route@5.ops[36]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_app_ret_route@5.ops[25]: 'l-store-copy val_as_bytes%1#0 0'
+debug: Replaced main_app_ret_route@5.ops[28]: 'v-load val_as_bytes%1#0' with 'l-load val_as_bytes%1#0'
+debug: Inserted main_store_route@6.ops[1]: 'l-store-copy tmp%19#0 0'
+debug: Replaced main_store_route@6.ops[3]: 'v-load tmp%19#0' with 'l-load tmp%19#0'
+debug: Inserted main_store_route@6.ops[6]: 'l-store-copy tmp%20#0 0'
+debug: Replaced main_store_route@6.ops[8]: 'v-load tmp%20#0' with 'l-load tmp%20#0'
+debug: Inserted main_store_route@6.ops[11]: 'l-store-copy tmp%21#0 0'
+debug: Replaced main_store_route@6.ops[13]: 'v-load tmp%21#0' with 'l-load tmp%21#0'
+debug: Inserted main_store_route@6.ops[16]: 'l-store-copy tmp%22#0 0'
+debug: Replaced main_store_route@6.ops[18]: 'v-load tmp%22#0' with 'l-load tmp%22#0'
+debug: Inserted main_store_route@6.ops[21]: 'l-store-copy reinterpret_bytes[1]%0#0 0'
+debug: Replaced main_store_route@6.ops[23]: 'v-load reinterpret_bytes[1]%0#0' with 'l-load reinterpret_bytes[1]%0#0'
+debug: Inserted main_store_route@6.ops[25]: 'l-store-copy tmp%23#0 0'
+debug: Replaced main_store_route@6.ops[27]: 'v-load tmp%23#0' with 'l-load tmp%23#0'
+debug: Inserted main_store_route@6.ops[31]: 'l-store-copy reinterpret_bytes[1]%1#0 0'
+debug: Replaced main_store_route@6.ops[33]: 'v-load reinterpret_bytes[1]%1#0' with 'l-load reinterpret_bytes[1]%1#0'
+debug: Inserted main_store_route@6.ops[35]: 'l-store-copy tmp%25#0 0'
+debug: Replaced main_store_route@6.ops[37]: 'v-load tmp%25#0' with 'l-load tmp%25#0'
+debug: Inserted main_store_route@6.ops[41]: 'l-store-copy reinterpret_bytes[1]%2#0 0'
+debug: Replaced main_store_route@6.ops[43]: 'v-load reinterpret_bytes[1]%2#0' with 'l-load reinterpret_bytes[1]%2#0'
+debug: Inserted main_store_route@6.ops[45]: 'l-store-copy tmp%27#0 0'
+debug: Replaced main_store_route@6.ops[47]: 'v-load tmp%27#0' with 'l-load tmp%27#0'
+debug: Inserted main_store_route@6.ops[55]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_store_route@6.ops[57]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_store_route@6.ops[49]: 'l-store-copy tmp%28#0 0'
+debug: Replaced main_store_route@6.ops[53]: 'v-load tmp%28#0' with 'l-load tmp%28#0'
+debug: Inserted main_store_route@6.ops[39]: 'l-store-copy tmp%26#0 0'
+debug: Replaced main_store_route@6.ops[53]: 'v-load tmp%26#0' with 'l-load tmp%26#0'
+debug: Inserted main_store_route@6.ops[29]: 'l-store-copy tmp%24#0 0'
+debug: Replaced main_store_route@6.ops[53]: 'v-load tmp%24#0' with 'l-load tmp%24#0'
+debug: Inserted main_store_apps_route@7.ops[1]: 'l-store-copy tmp%29#0 0'
+debug: Replaced main_store_apps_route@7.ops[3]: 'v-load tmp%29#0' with 'l-load tmp%29#0'
+debug: Inserted main_store_apps_route@7.ops[6]: 'l-store-copy tmp%30#0 0'
+debug: Replaced main_store_apps_route@7.ops[8]: 'v-load tmp%30#0' with 'l-load tmp%30#0'
+debug: Inserted main_store_apps_route@7.ops[11]: 'l-store-copy tmp%31#0 0'
+debug: Replaced main_store_apps_route@7.ops[13]: 'v-load tmp%31#0' with 'l-load tmp%31#0'
+debug: Inserted main_store_apps_route@7.ops[16]: 'l-store-copy tmp%32#0 0'
+debug: Replaced main_store_apps_route@7.ops[18]: 'v-load tmp%32#0' with 'l-load tmp%32#0'
+debug: Inserted main_store_apps_route@7.ops[21]: 'l-store-copy reinterpret_encoded_uint64[]%0#0 0'
+debug: Replaced main_store_apps_route@7.ops[23]: 'v-load reinterpret_encoded_uint64[]%0#0' with 'l-load reinterpret_encoded_uint64[]%0#0'
+debug: Inserted main_store_apps_route@7.ops[26]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_store_apps_route@7.ops[28]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_store_assets_route@8.ops[1]: 'l-store-copy tmp%33#0 0'
+debug: Replaced main_store_assets_route@8.ops[3]: 'v-load tmp%33#0' with 'l-load tmp%33#0'
+debug: Inserted main_store_assets_route@8.ops[6]: 'l-store-copy tmp%34#0 0'
+debug: Replaced main_store_assets_route@8.ops[8]: 'v-load tmp%34#0' with 'l-load tmp%34#0'
+debug: Inserted main_store_assets_route@8.ops[11]: 'l-store-copy tmp%35#0 0'
+debug: Replaced main_store_assets_route@8.ops[13]: 'v-load tmp%35#0' with 'l-load tmp%35#0'
+debug: Inserted main_store_assets_route@8.ops[16]: 'l-store-copy tmp%36#0 0'
+debug: Replaced main_store_assets_route@8.ops[18]: 'v-load tmp%36#0' with 'l-load tmp%36#0'
+debug: Inserted main_store_assets_route@8.ops[21]: 'l-store-copy reinterpret_encoded_uint64[]%1#0 0'
+debug: Replaced main_store_assets_route@8.ops[23]: 'v-load reinterpret_encoded_uint64[]%1#0' with 'l-load reinterpret_encoded_uint64[]%1#0'
+debug: Inserted main_store_assets_route@8.ops[26]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_store_assets_route@8.ops[28]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_store_accounts_route@9.ops[1]: 'l-store-copy tmp%37#0 0'
+debug: Replaced main_store_accounts_route@9.ops[3]: 'v-load tmp%37#0' with 'l-load tmp%37#0'
+debug: Inserted main_store_accounts_route@9.ops[6]: 'l-store-copy tmp%38#0 0'
+debug: Replaced main_store_accounts_route@9.ops[8]: 'v-load tmp%38#0' with 'l-load tmp%38#0'
+debug: Inserted main_store_accounts_route@9.ops[11]: 'l-store-copy tmp%39#0 0'
+debug: Replaced main_store_accounts_route@9.ops[13]: 'v-load tmp%39#0' with 'l-load tmp%39#0'
+debug: Inserted main_store_accounts_route@9.ops[16]: 'l-store-copy tmp%40#0 0'
+debug: Replaced main_store_accounts_route@9.ops[18]: 'v-load tmp%40#0' with 'l-load tmp%40#0'
+debug: Inserted main_store_accounts_route@9.ops[21]: 'l-store-copy reinterpret_bytes[32][]%0#0 0'
+debug: Replaced main_store_accounts_route@9.ops[23]: 'v-load reinterpret_bytes[32][]%0#0' with 'l-load reinterpret_bytes[32][]%0#0'
+debug: Inserted main_store_accounts_route@9.ops[26]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_store_accounts_route@9.ops[28]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_return_apps_route@10.ops[1]: 'l-store-copy tmp%41#0 0'
+debug: Replaced main_return_apps_route@10.ops[3]: 'v-load tmp%41#0' with 'l-load tmp%41#0'
+debug: Inserted main_return_apps_route@10.ops[6]: 'l-store-copy tmp%42#0 0'
+debug: Replaced main_return_apps_route@10.ops[8]: 'v-load tmp%42#0' with 'l-load tmp%42#0'
+debug: Inserted main_return_apps_route@10.ops[11]: 'l-store-copy tmp%43#0 0'
+debug: Replaced main_return_apps_route@10.ops[13]: 'v-load tmp%43#0' with 'l-load tmp%43#0'
+debug: Inserted main_return_apps_route@10.ops[16]: 'l-store-copy tmp%44#0 0'
+debug: Replaced main_return_apps_route@10.ops[18]: 'v-load tmp%44#0' with 'l-load tmp%44#0'
+debug: Inserted main_return_apps_route@10.ops[25]: 'l-store-copy tmp%46#0 0'
+debug: Replaced main_return_apps_route@10.ops[27]: 'v-load tmp%46#0' with 'l-load tmp%46#0'
+debug: Inserted main_return_apps_route@10.ops[30]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_return_apps_route@10.ops[32]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_return_apps_route@10.ops[21]: 'l-store-copy tmp%45#0 0'
+debug: Replaced main_return_apps_route@10.ops[24]: 'v-load tmp%45#0' with 'l-load tmp%45#0'
+debug: Inserted main_return_assets_route@11.ops[1]: 'l-store-copy tmp%47#0 0'
+debug: Replaced main_return_assets_route@11.ops[3]: 'v-load tmp%47#0' with 'l-load tmp%47#0'
+debug: Inserted main_return_assets_route@11.ops[6]: 'l-store-copy tmp%48#0 0'
+debug: Replaced main_return_assets_route@11.ops[8]: 'v-load tmp%48#0' with 'l-load tmp%48#0'
+debug: Inserted main_return_assets_route@11.ops[11]: 'l-store-copy tmp%49#0 0'
+debug: Replaced main_return_assets_route@11.ops[13]: 'v-load tmp%49#0' with 'l-load tmp%49#0'
+debug: Inserted main_return_assets_route@11.ops[16]: 'l-store-copy tmp%50#0 0'
+debug: Replaced main_return_assets_route@11.ops[18]: 'v-load tmp%50#0' with 'l-load tmp%50#0'
+debug: Inserted main_return_assets_route@11.ops[25]: 'l-store-copy tmp%52#0 0'
+debug: Replaced main_return_assets_route@11.ops[27]: 'v-load tmp%52#0' with 'l-load tmp%52#0'
+debug: Inserted main_return_assets_route@11.ops[30]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_return_assets_route@11.ops[32]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_return_assets_route@11.ops[21]: 'l-store-copy tmp%51#0 0'
+debug: Replaced main_return_assets_route@11.ops[24]: 'v-load tmp%51#0' with 'l-load tmp%51#0'
+debug: Inserted main_return_accounts_route@12.ops[1]: 'l-store-copy tmp%53#0 0'
+debug: Replaced main_return_accounts_route@12.ops[3]: 'v-load tmp%53#0' with 'l-load tmp%53#0'
+debug: Inserted main_return_accounts_route@12.ops[6]: 'l-store-copy tmp%54#0 0'
+debug: Replaced main_return_accounts_route@12.ops[8]: 'v-load tmp%54#0' with 'l-load tmp%54#0'
+debug: Inserted main_return_accounts_route@12.ops[11]: 'l-store-copy tmp%55#0 0'
+debug: Replaced main_return_accounts_route@12.ops[13]: 'v-load tmp%55#0' with 'l-load tmp%55#0'
+debug: Inserted main_return_accounts_route@12.ops[16]: 'l-store-copy tmp%56#0 0'
+debug: Replaced main_return_accounts_route@12.ops[18]: 'v-load tmp%56#0' with 'l-load tmp%56#0'
+debug: Inserted main_return_accounts_route@12.ops[25]: 'l-store-copy tmp%58#0 0'
+debug: Replaced main_return_accounts_route@12.ops[27]: 'v-load tmp%58#0' with 'l-load tmp%58#0'
+debug: Inserted main_return_accounts_route@12.ops[30]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_return_accounts_route@12.ops[32]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_return_accounts_route@12.ops[21]: 'l-store-copy tmp%57#0 0'
+debug: Replaced main_return_accounts_route@12.ops[24]: 'v-load tmp%57#0' with 'l-load tmp%57#0'
+debug: Inserted main_bare_routing@15.ops[1]: 'l-store-copy tmp%59#0 0'
+debug: Replaced main_bare_routing@15.ops[4]: 'v-load tmp%59#0' with 'l-load tmp%59#0'
+debug: Inserted main___algopy_default_create@16.ops[1]: 'l-store-copy tmp%60#0 0'
+debug: Replaced main___algopy_default_create@16.ops[3]: 'v-load tmp%60#0' with 'l-load tmp%60#0'
+debug: Inserted main___algopy_default_create@16.ops[6]: 'l-store-copy tmp%61#0 0'
+debug: Replaced main___algopy_default_create@16.ops[8]: 'v-load tmp%61#0' with 'l-load tmp%61#0'
+debug: Inserted main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create@22.ops[1]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create@22.ops[3]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted main_after_if_else@19.ops[1]: 'l-store-copy test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0 0'
+debug: Replaced main_after_if_else@19.ops[3]: 'v-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0' with 'l-load test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__%0#0'
+debug: Inserted acc_ret_block@0.ops[1]: 'l-store-copy tmp%0#0 0'
+debug: Replaced acc_ret_block@0.ops[3]: 'v-load tmp%0#0' with 'l-load tmp%0#0'
+debug: Inserted return_apps_block@0.ops[3]: 'l-store-copy maybe_exists%0#0 1'
+debug: Replaced return_apps_block@0.ops[6]: 'v-load maybe_exists%0#0' with 'l-load maybe_exists%0#0'
+debug: Inserted return_apps_block@0.ops[5]: 'l-store-copy maybe_value%0#0 1'
+debug: Replaced return_apps_block@0.ops[9]: 'v-load maybe_value%0#0' with 'l-load maybe_value%0#0'
+debug: Inserted return_assets_block@0.ops[3]: 'l-store-copy maybe_exists%0#0 1'
+debug: Replaced return_assets_block@0.ops[6]: 'v-load maybe_exists%0#0' with 'l-load maybe_exists%0#0'
+debug: Inserted return_assets_block@0.ops[5]: 'l-store-copy maybe_value%0#0 1'
+debug: Replaced return_assets_block@0.ops[9]: 'v-load maybe_value%0#0' with 'l-load maybe_value%0#0'
+debug: Inserted return_accounts_block@0.ops[3]: 'l-store-copy maybe_exists%0#0 1'
+debug: Replaced return_accounts_block@0.ops[6]: 'v-load maybe_exists%0#0' with 'l-load maybe_exists%0#0'
+debug: Inserted return_accounts_block@0.ops[5]: 'l-store-copy maybe_value%0#0 1'
+debug: Replaced return_accounts_block@0.ops[9]: 'v-load maybe_value%0#0' with 'l-load maybe_value%0#0'
+debug: Found 10 edge set/s for algopy.arc4.ARC4Contract.approval_program
+debug: Allocated 1 variable/s to x-stack: tmp%0#0
+debug: shared x-stack for main_acc_ret_route@3 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_asset_ret_route@4 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_app_ret_route@5 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_store_route@6 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_store_apps_route@7 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_store_assets_route@8 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_store_accounts_route@9 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_return_apps_route@10 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_return_assets_route@11 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_return_accounts_route@12 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_after_if_else@19 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: shared x-stack for main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create@22 -> main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20: tmp%0#0
+debug: optimizing TEAL subroutine ops algopy.arc4.ARC4Contract.approval_program() -> uint64:
+arc4_conversions/reference.py:5 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes:
+arc4_conversions/reference.py:9 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret() -> uint64:
+arc4_conversions/reference.py:13 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.app_ret() -> uint64:
+arc4_conversions/reference.py:17 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes, app: uint64, asset: uint64) -> void:
+arc4_conversions/reference.py:23 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: bytes) -> void:
+arc4_conversions/reference.py:27 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: bytes) -> void:
+arc4_conversions/reference.py:31 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes) -> void:
+arc4_conversions/reference.py:35 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> bytes:
+arc4_conversions/reference.py:39 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> bytes:
+arc4_conversions/reference.py:43 debug: optimizing TEAL subroutine ops test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes:
+debug: optimizing TEAL subroutine blocks algopy.arc4.ARC4Contract.approval_program() -> uint64:
+debug: removing explicit jump to fall-through block main_block@0
+debug: removing explicit jump to fall-through block main_block@1
+debug: removing explicit jump to fall-through block main_abi_routing@2
+debug: removing explicit jump to fall-through block main_switch_case_default@13
+debug: removing explicit jump to fall-through block main_switch_case_next@14
+debug: removing explicit jump to fall-through block main_after_if_else@19
+debug: removing explicit jump to fall-through block main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__puya_arc4_router__@20
+debug: removing explicit jump to fall-through block main_switch_case_default@17
+debug: removing explicit jump to fall-through block main_switch_case_next@18
+debug: removing explicit jump to fall-through block main_block@21
+debug: removing explicit jump to fall-through block main_after_inlined_test_cases.arc4_conversions.reference.ReferenceReturn.__algopy_default_create@22
+arc4_conversions/reference.py:5 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.acc_ret() -> bytes:
+debug: removing explicit jump to fall-through block acc_ret_block@0
+arc4_conversions/reference.py:9 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.asset_ret() -> uint64:
+debug: removing explicit jump to fall-through block asset_ret_block@0
+arc4_conversions/reference.py:13 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.app_ret() -> uint64:
+debug: removing explicit jump to fall-through block app_ret_block@0
+arc4_conversions/reference.py:17 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.store(acc: bytes, app: uint64, asset: uint64) -> void:
+debug: removing explicit jump to fall-through block store_block@0
+arc4_conversions/reference.py:23 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.store_apps(apps: bytes) -> void:
+debug: removing explicit jump to fall-through block store_apps_block@0
+arc4_conversions/reference.py:27 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.store_assets(assets: bytes) -> void:
+debug: removing explicit jump to fall-through block store_assets_block@0
+arc4_conversions/reference.py:31 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.store_accounts(accounts: bytes) -> void:
+debug: removing explicit jump to fall-through block store_accounts_block@0
+arc4_conversions/reference.py:35 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.return_apps() -> bytes:
+debug: removing explicit jump to fall-through block return_apps_block@0
+arc4_conversions/reference.py:39 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.return_assets() -> bytes:
+debug: removing explicit jump to fall-through block return_assets_block@0
+arc4_conversions/reference.py:43 debug: optimizing TEAL subroutine blocks test_cases.arc4_conversions.reference.ReferenceReturn.return_accounts() -> bytes:
+debug: removing explicit jump to fall-through block return_accounts_block@0
+debug: optimizing TEAL subroutine ops algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+debug: optimizing TEAL subroutine blocks algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+debug: removing explicit jump to fall-through block main_block@0
 debug: optimizing approval program of test_cases.arc4_conversions.contract.CheckApp at level 0
 debug: Begin optimization pass 1/100
 debug: Optimizing subroutine algopy.arc4.ARC4Contract.approval_program
@@ -5727,6 +6573,12 @@ debug: removing explicit jump to fall-through block test_bytes_to_fixed_next_txn
 debug: optimizing TEAL subroutine ops algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
 debug: optimizing TEAL subroutine blocks algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
 debug: removing explicit jump to fall-through block main_block@0
+info: Writing arc4_conversions/out_unoptimized/ReferenceReturn.approval.teal
+info: Writing arc4_conversions/out_unoptimized/ReferenceReturn.clear.teal
+info: Writing arc4_conversions/out_unoptimized/ReferenceReturn.approval.bin
+info: Writing arc4_conversions/out_unoptimized/ReferenceReturn.clear.bin
+info: Writing arc4_conversions/out_unoptimized/ReferenceReturn.approval.puya.map
+info: Writing arc4_conversions/out_unoptimized/ReferenceReturn.clear.puya.map
 info: Writing arc4_conversions/out_unoptimized/CheckApp.approval.teal
 info: Writing arc4_conversions/out_unoptimized/CheckApp.clear.teal
 info: Writing arc4_conversions/out_unoptimized/CheckApp.approval.bin

--- a/test_cases/arc4_conversions/reference.py
+++ b/test_cases/arc4_conversions/reference.py
@@ -1,0 +1,45 @@
+from algopy import Account, Application, Asset, ImmutableArray, Txn, arc4
+
+
+class ReferenceReturn(arc4.ARC4Contract):
+    @arc4.abimethod
+    def acc_ret(self) -> Account:
+        return Txn.sender
+
+    @arc4.abimethod
+    def asset_ret(self) -> Asset:
+        return Asset(1234)
+
+    @arc4.abimethod
+    def app_ret(self) -> Application:
+        return Application(1234)
+
+    @arc4.abimethod
+    def store(self, acc: Account, app: Application, asset: Asset) -> None:
+        self.acc = acc
+        self.asset = asset
+        self.app = app
+
+    @arc4.abimethod
+    def store_apps(self, apps: ImmutableArray[Application]) -> None:
+        self.apps = apps
+
+    @arc4.abimethod
+    def store_assets(self, assets: ImmutableArray[Asset]) -> None:
+        self.assets = assets
+
+    @arc4.abimethod
+    def store_accounts(self, accounts: ImmutableArray[Account]) -> None:
+        self.accounts = accounts
+
+    @arc4.abimethod
+    def return_apps(self) -> ImmutableArray[Application]:
+        return self.apps
+
+    @arc4.abimethod
+    def return_assets(self) -> ImmutableArray[Asset]:
+        return self.assets
+
+    @arc4.abimethod
+    def return_accounts(self) -> ImmutableArray[Account]:
+        return self.accounts

--- a/test_cases/arc_56/out/Contract.arc56.json
+++ b/test_cases/arc_56/out/Contract.arc56.json
@@ -399,7 +399,7 @@
                 },
                 "b_uint64": {
                     "keyType": "AVMBytes",
-                    "valueType": "AVMUint64",
+                    "valueType": "uint64",
                     "key": "YnU="
                 },
                 "b_address": {
@@ -429,7 +429,7 @@
                     "prefix": "Ym94X21hcF9zdHJ1Y3Q="
                 },
                 "box_map_uint64": {
-                    "keyType": "AVMUint64",
+                    "keyType": "uint64",
                     "valueType": "SharedStruct",
                     "prefix": "Ym11"
                 },

--- a/test_cases/compile/out/HelloOtherConstants.arc56.json
+++ b/test_cases/compile/out/HelloOtherConstants.arc56.json
@@ -86,7 +86,7 @@
                 },
                 "address": {
                     "keyType": "AVMString",
-                    "valueType": "AVMBytes",
+                    "valueType": "address",
                     "key": "YWRkcmVzcw=="
                 },
                 "method": {
@@ -196,7 +196,7 @@
             "value": "Qg=="
         },
         "TMPL_ACCOUNT": {
-            "type": "AVMBytes",
+            "type": "address",
             "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
         },
         "TMPL_METHOD": {

--- a/test_cases/everything/out/MyContract.arc56.json
+++ b/test_cases/everything/out/MyContract.arc56.json
@@ -118,7 +118,7 @@
             "global": {
                 "creator": {
                     "keyType": "AVMString",
-                    "valueType": "AVMBytes",
+                    "valueType": "address",
                     "key": "Y3JlYXRvcg=="
                 },
                 "counter": {

--- a/test_cases/state_mutations/out/Contract.arc56.json
+++ b/test_cases/state_mutations/out/Contract.arc56.json
@@ -95,7 +95,7 @@
             "local": {},
             "box": {
                 "map": {
-                    "keyType": "AVMBytes",
+                    "keyType": "address",
                     "valueType": "(uint64,string)[]",
                     "prefix": "bWFw"
                 }

--- a/tests/test_expected_output/arc4.test
+++ b/tests/test_expected_output/arc4.test
@@ -779,7 +779,7 @@ from algopy import *
 class ARC4Reference(arc4.ARC4Contract):
     @arc4.abimethod()
     def test(self,
-        arg: tuple[Account, Asset], ## E: ARC-4 tuples can only contain ARC-4 types but elements 0 and 1 are not ARC-4 types
+        arg: tuple[Account, Asset],
         arg2: tuple[Account, Application],
     ) -> None:
         pass
@@ -791,6 +791,14 @@ from algopy import *
 class ARC4Reference(arc4.ARC4Contract):
     @arc4.abimethod()
     def test(self,
-        arg: ImmutableArray[Asset], ## E: ARC-4 arrays can only contain ARC-4 elements
+        arg: ImmutableArray[Asset],
     ) -> None:
         pass
+
+## case: return_txn_type
+from algopy import *
+
+class ReferenceReturn(arc4.ARC4Contract):
+    @arc4.abimethod ## E: unsupported return type for an ARC-4 method
+    def txn(self) -> gtxn.Transaction:
+        return gtxn.Transaction(1)

--- a/tests/test_expected_output/arrays.test
+++ b/tests/test_expected_output/arrays.test
@@ -120,24 +120,6 @@ class MyContract(arc4.ARC4Contract):
         arr = ImmutableArray[gtxn.Transaction]() ## E: unsupported array element type
         arr = arr.append(txn)
 
-## case: test_asset_ref
-from algopy import *
-
-class MyContract(arc4.ARC4Contract):
-
-    @arc4.abimethod
-    def imm_asset_arg(self, arr: ImmutableArray[Asset]) -> None: ## E: ARC-4 arrays can only contain ARC-4 elements
-        pass
-
-## case: test_account_ref
-from algopy import *
-
-class MyContract(arc4.ARC4Contract):
-
-    @arc4.abimethod
-    def imm_account_arg(self, arr: ImmutableArray[Account]) -> None: ## E: ARC-4 arrays can only contain ARC-4 elements
-        pass
-
 ## case: test_imm_array_itxn
 from algopy import *
 


### PR DESCRIPTION
Currently the types `Account`, `Application` and `Asset` are only supported as ABI method arguments when used on their own, in these scenarios the values are represented by their ARC-4 aliases and are read from the foreign arrays by the ARC-4 router.

This PR allows their usage in ABI methods when part of native tuples, immutable arrays or on their own as a return type. In these scenarios the values are encoded as their equivalent ARC-4 types. `uint64` for `Asset` and `Application`, and `address` for `Account`