### PR TITLE
feat: generate arc56 app spec by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Algorand Python is compiled for execution on the AVM by PuyaPy, an optimising co
 
 The easiest way to use Algorand Python is to instantiate a template with AlgoKit via:
 
-```algokit init -t python```
+```
+algokit init -t python
+```
 
 This will give you a full development environment with intellisense, linting, automatic formatting, breakpoint debugging, deployment and CI/CD.
 
@@ -45,13 +47,13 @@ Alternatively, if you want to start from scratch you can do the following:
     algokit compile py contract.py
     ```
 2. You should now have `HelloWorldContract.approval.teal` and `HelloWorldContract.clear.teal` on the file system!
-3. We generally recommend using ARC-32 and [generated typed clients](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/features/generate.md#1-typed-clients) to have the most optimal deployment and consumption experience; to do this you need to ask PuyaPy to output an ARC-32 compatible app spec file:
+3. We generally recommend using ARC-56 and [generated typed clients](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/features/generate.md#1-typed-clients) to have the most optimal deployment and consumption experience; PuyaPy produces an ARC-56 compatible app spec file by default:
     ```shell
-    algokit compile py contract.py --output-arc32 --no-output-teal
+    algokit compile py contract.py --no-output-teal
     ```
-4. You should now have `HelloWorldContract.arc32.json`, which can be generated into a client e.g. using AlgoKit CLI:
+4. You should now have `HelloWorldContract.arc56.json`, which can be generated into a client e.g. using AlgoKit CLI:
     ```shell
-    algokit generate client HelloWorldContract.arc32.json --output client.py
+    algokit generate client HelloWorldContract.arc56.json --output client.py
     ```
 5. From here you can dive into the [examples](https://github.com/algorandfoundation/puya/tree/main/examples) or look at the [documentation](https://algorandfoundation.github.io/puya/).
 

--- a/changelog.d/20250422_104915_bobby.lat_default_arc56.md
+++ b/changelog.d/20250422_104915_bobby.lat_default_arc56.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+
+### Changed
+
+-   output ARC56 app spec, in addition to ARC32 app spec by default when compiling
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -2,7 +2,7 @@
 
 The PuyaPy compiler is a multi-stage, optimising compiler that takes Algorand Python and prepares it for execution on the AVM. PuyaPy ensures the resulting AVM bytecode execution semantics that match the given Python code. PuyaPy produces output that is directly compatible with [AlgoKit typed clients](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/features/generate.md#1-typed-clients) to make deployment and calling easy (among other formats).
 
-The PuyaPy compiler is based on the [Puya compiler architecture](https://github.com/algorandfoundation/puya/blob/main/ARCHITECTURE.md), 
+The PuyaPy compiler is based on the [Puya compiler architecture](https://github.com/algorandfoundation/puya/blob/main/ARCHITECTURE.md),
 which allows for multiple frontend languages to leverage the majority of the compiler logic so adding new frontend languages for execution on Algorand is relatively easy.
 
 ## Compiler installation
@@ -72,7 +72,7 @@ The options available for the compile can be seen by executing `puyapy -h` or `a
 
 ```
 puyapy [-h] [--version] [-O {0,1,2}]
-    [--output-teal | --no-output-teal] [--output-arc32 | --no-output-arc32]
+    [--output-teal | --no-output-teal] [--output-arc32 | --no-output-arc32] [--output-arc56 | --no-output-arc56]
     [--output-client | --no-output-client] [--out-dir OUT_DIR]
     [--log-level {notset,debug,info,warning,error,critical}] [-g {0,1,2}] [--output-awst | --no-output-awst]
     [--output-ssa-ir | --no-output-ssa-ir] [--output-optimization-ir | --no-output-optimization-ir]
@@ -85,20 +85,20 @@ puyapy [-h] [--version] [-O {0,1,2}]
 ### Options
 
 | Option                                                   | Description                                                                                                                                                           | Default                 |
-|----------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|
+| -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
 | `-h`, `--help`                                           | Show the help message and exit                                                                                                                                        | N/A                     |
 | `--version`                                              | Show program's version number and exit                                                                                                                                | N/A                     |
 | `-O {0,1,2}` <br />`--optimization-level {0,1,2}`        | Set optimization level of output TEAL / AVM bytecode                                                                                                                  | `1`                     |
 | `--output-teal`, `--no-output-teal`                      | Output TEAL                                                                                                                                                           | `True`                  |
 | `--output-arc32`, `--no-output-arc32`                    | Output {contract}.arc32.json ARC-32 app spec file if the contract is an ARC-4 contract                                                                                | `True`                  |
-| `--output-arc56`, `--no-output-arc56`                    | Output {contract}.arc56.json ARC-56 app spec file if the contract is an ARC-4 contract                                                                                | `False`                 |
-| `--output-client`, `--no-output-client`                  | Output Algorand Python contract client for typed ARC-4 ABI calls                                                                                                       | `False`                 |
+| `--output-arc56`, `--no-output-arc56`                    | Output {contract}.arc56.json ARC-56 app spec file if the contract is an ARC-4 contract                                                                                | `True`                  |
+| `--output-client`, `--no-output-client`                  | Output Algorand Python contract client for typed ARC-4 ABI calls                                                                                                      | `False`                 |
 | `--output-bytecode`, `--no-output-bytecode`              | Output AVM bytecode                                                                                                                                                   | `False`                 |
 | `--out-dir OUT_DIR`                                      | The path for outputting artefacts                                                                                                                                     | Same folder as contract |
 | `--log-level {notset,debug,info,warning,error,critical}` | Minimum level to log to console                                                                                                                                       | `info`                  |
 | `-g {0,1,2}`, `--debug-level {0,1,2}`                    | Output debug information level<br /> `0` = No debug annotations <br /> `1` = Output debug annotations <br /> `2` = Reserved for future use, currently the same as `1` | `1`                     |
 | `--template-var`                                         | Allows specifying template values. Can be used multiple times, see below for examples                                                                                 | N/A                     |
-| `--template-vars-prefix`                                 | Prefix to use for template variables                                                                                                                                  | "TMPL_"                 |
+| `--template-vars-prefix`                                 | Prefix to use for template variables                                                                                                                                  | "TMPL\_"                |
 
 ### Defining template values
 
@@ -109,13 +109,13 @@ Additionally, Algorand Python functions that create AVM bytecode, such as [compi
 
 The table below illustrates how different variables and values can be defined:
 
-| Variable Type                     | Example Algorand Python                          | Value definition example |
-|--------------------------|-------------------------------------------|--------------------------|
+| Variable Type            | Example Algorand Python                   | Value definition example |
+| ------------------------ | ----------------------------------------- | ------------------------ |
 | [UInt64](#algopy.UInt64) | `algopy.TemplateVar[UInt64]("SOME_INT")`  | `SOME_INT=1234`          |
 | [Bytes](#algopy.Bytes)   | `algopy.TemplateVar[Bytes]("SOME_BYTES")` | `SOME_BYTES=0x1A2B`      |
 | [String](#algopy.String) | `algopy.TemplateVar[String]("SOME_STR")`  | `SOME_STR="hello"`       |
 
-All template values specified via the command line are prefixed with "TMPL_" by default. 
+All template values specified via the command line are prefixed with "TMPL\_" by default.
 The default prefix can be modified using the `--template-vars-prefix` option.
 
 ### Advanced options

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,13 +30,13 @@ Alternatively, if you want to start from scratch you can do the following:
     algokit compile py contract.py
     ```
 7. You should now have `HelloWorldContract.approval.teal` and `HelloWorldContract.clear.teal` on the file system!
-8. We generally recommend using ARC-32 and [generated typed clients](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/features/generate.md#1-typed-clients) to have the most optimal deployment and consumption experience; to do this you need to ask PuyaPy to output an ARC-32 compatible app spec file:
+8. We generally recommend using ARC-56 and [generated typed clients](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/features/generate.md#1-typed-clients) to have the most optimal deployment and consumption experience; PuyaPy produces an ARC-56 compatible app spec file by default:
     ```shell
-    algokit compile py contract.py --output-arc32 --no-output-teal
+    algokit compile py contract.py --no-output-teal
     ```
-9. You should now have `HelloWorldContract.arc32.json`, which can be generated into a client e.g. using AlgoKit CLI:
+9. You should now have `HelloWorldContract.arc56.json`, which can be generated into a client e.g. using AlgoKit CLI:
     ```shell
-    algokit generate client HelloWorldContract.arc32.json --output client.py
+    algokit generate client HelloWorldContract.arc56.json --output client.py
     ```
 10. From here you can dive into the [examples](https://github.com/algorandfoundation/puya/tree/main/examples) or look at the [documentation](https://algorandfoundation.github.io/puya/).
 

--- a/docs/lg-calling-apps.md
+++ b/docs/lg-calling-apps.md
@@ -1,6 +1,6 @@
 # Calling other applications
 
-The preferred way to call other smart contracts is using [`algopy.arc4.abi_call`](#algopyarc4abi_call), [`algopy.arc4.arc4_create`](#algopyarc4arc4_create) or 
+The preferred way to call other smart contracts is using [`algopy.arc4.abi_call`](#algopyarc4abi_call), [`algopy.arc4.arc4_create`](#algopyarc4arc4_create) or
 [`algopy.arc4.arc4_update`](#algopyarc4arc4_update). These methods support type checking and encoding of arguments, decoding of results, group transactions,
 and in the case of `arc4_create` and `arc4_update` automatic inclusion of approval and clear state programs.
 
@@ -8,7 +8,7 @@ and in the case of `arc4_create` and `arc4_update` automatic inclusion of approv
 
 [`algopy.arc4.abi_call`](#algopy.arc4.abi_call) can be used to call other ARC-4 contracts, the first argument should refer to
 an ARC-4 method either by referencing an Algorand Python [`algopy.arc4.ARC4Contract`](#algopy.arc4.ARC4Contract) method,
-an [`algopy.arc4.ARC4Client`](#algopy.arc4.ARC4Client) method generated from an ARC-32 app spec, or a string representing
+an [`algopy.arc4.ARC4Client`](#algopy.arc4.ARC4Client) method generated from an ARC-32/ARC-56 app spec, or a string representing
 the ARC-4 method signature or name.
 The following arguments should then be the arguments required for the call, these arguments will be type checked and converted where appropriate.
 Any other related transaction parameters such as `app_id`, `fee` etc. can also be provided as keyword arguments.
@@ -20,7 +20,7 @@ If the ARC-4 method does not return a result, or if the result type is not fully
 from algopy import Application, ARC4Contract, String, arc4, subroutine
 
 class HelloWorld(ARC4Contract):
-    
+
     @arc4.abimethod()
     def greet(self, name: String) -> String:
         return "Hello " + name
@@ -28,29 +28,28 @@ class HelloWorld(ARC4Contract):
 @subroutine
 def call_existing_application(app: Application) -> None:
     greeting, greet_txn = arc4.abi_call(HelloWorld.greet, "there", app_id=app)
-    
+
     assert greeting == "Hello there"
     assert greet_txn.app_id == 1234
 ```
 
-
 ### Alternative ways to use `arc4.abi_call`
 
-#### ARC4Client method 
+#### ARC4Client method
 
 A ARC4Client client represents the ARC-4 abimethods of a smart contract and can be used to call abimethods in a type safe way
 
-ARC4Client's can be produced by using `puyapy --output-client=True` when compiling a smart contract 
+ARC4Client's can be produced by using `puyapy --output-client=True` when compiling a smart contract
 (this would be useful if you wanted to publish a client for consumption by other smart contracts)
-An ARC4Client can also be be generated from an ARC-32 application.json using `puyapy-clientgen` 
-e.g. `puyapy-clientgen examples/hello_world_arc4/out/HelloWorldContract.arc32.json`, this would be
+An ARC4Client can also be be generated from an ARC-32/ARC-56 application.json using `puyapy-clientgen`
+e.g. `puyapy-clientgen examples/hello_world_arc4/out/HelloWorldContract.arc56.json`, this would be
 the recommended approach for calling another smart contract that is not written in Algorand Python or does not provide the source
 
 ```python
 from algopy import arc4, subroutine
 
 class HelloWorldClient(arc4.ARC4Client):
-    
+
     def hello(self, name: arc4.String) -> arc4.String: ...
 
 @subroutine
@@ -74,12 +73,11 @@ def call_another_contract() -> None:
     # can reference a method selector
     result, txn = arc4.abi_call[arc4.String]("hello(string)string", arc4.String("Algo"), app=...)
     assert result == "Hello, Algo"
-    
+
     # can reference a method name, the method selector is inferred from arguments and return type
     result, txn = arc4.abi_call[arc4.String]("hello", "There", app=...)
     assert result == "Hello, There"
 ```
-
 
 ## `algopy.arc4.arc4_create`
 
@@ -87,14 +85,14 @@ def call_another_contract() -> None:
 
 Like [`algopy.arc4.abi_call`](lg-transactions.md#arc4-application-calls) it handles ARC-4 arguments and provides ARC-4 return values.
 
-If the compiled programs and state allocation fields need to be customized (for example due to [template variables](#within-other-contracts)), 
+If the compiled programs and state allocation fields need to be customized (for example due to [template variables](#within-other-contracts)),
 this can be done by passing a [`algopy.CompiledContract`](#algopy.CompiledContract) via the `compiled` keyword argument.
 
 ```python
 from algopy import ARC4Contract, String, arc4, subroutine
 
 class HelloWorld(ARC4Contract):
-    
+
     @arc4.abimethod()
     def greet(self, name: String) -> String:
         return "Hello " + name
@@ -104,7 +102,7 @@ def create_new_application() -> None:
     hello_world_app = arc4.arc4_create(HelloWorld).created_app
 
     greeting, _txn = arc4.abi_call(HelloWorld.greet, "there", app_id=hello_world_app)
-    
+
     assert greeting == "Hello there"
 ```
 
@@ -114,14 +112,14 @@ def create_new_application() -> None:
 
 Like [`algopy.arc4.abi_call`](lg-transactions.md#arc4-application-calls) it handles ARC-4 arguments and provides ARC-4 return values.
 
-If the compiled programs need to be customized (for example due to (for example due to [template variables](#within-other-contracts)), 
+If the compiled programs need to be customized (for example due to (for example due to [template variables](#within-other-contracts)),
 this can be done by passing a [`algopy.CompiledContract`](#algopy.CompiledContract) via the `compiled` keyword argument.
 
 ```python
 from algopy import Application, ARC4Contract, String, arc4, subroutine
 
 class NewApp(ARC4Contract):
-    
+
     @arc4.abimethod()
     def greet(self, name: String) -> String:
         return "Hello " + name
@@ -129,9 +127,9 @@ class NewApp(ARC4Contract):
 @subroutine
 def update_existing_application(existing_app: Application) -> None:
     hello_world_app = arc4.arc4_update(NewApp, app_id=existing_app)
-    
+
     greeting, _txn = arc4.abi_call(NewApp.greet, "there", app_id=hello_world_app)
-    
+
     assert greeting == "Hello there"
 ```
 
@@ -139,4 +137,4 @@ def update_existing_application(existing_app: Application) -> None:
 
 If the application being called is not an ARC-4 contract, or an application specification is not available,
 then [`algopy.itxn.ApplicationCall`](#algopy.itxn.ApplicationCall) can be used. This approach is generally more verbose
-than the above approaches, so should only be used if required. See [here](./lg-transactions.md#create-an-arc4-application-and-then-call-it) for an example 
+than the above approaches, so should only be used if required. See [here](./lg-transactions.md#create-an-arc4-application-and-then-call-it) for an example

--- a/docs/lg-storage.md
+++ b/docs/lg-storage.md
@@ -23,7 +23,7 @@ This is represented in Algorand Python by either:
 1. Assigning any [Algorand Python typed](./lg-types.md) value to an instance variable (e.g. `self.value = UInt64(3)`).
     - Use this approach if you just require a terse API for getting and setting a state value
 2. Using an instance of `GlobalState`, which gives [some extra features](./api-algopy.md#algopy.GlobalState) to understand
-   and control the value and the metadata of it (which propagates to the ARC-32 app spec file)
+   and control the value and the metadata of it (which propagates to the ARC-32/ARC-56 app spec file)
     - Use this approach if you need to:
         - Omit a default/initial value
         - Delete the stored value
@@ -48,7 +48,7 @@ error_if_not_set = self.global_int_no_default.value
 ```
 
 These values can be assigned anywhere you have access to `self` i.e. any instance methods/subroutines. The information about
-global storage is automatically included in the ARC-32 app spec file and thus will automatically appear within
+global storage is automatically included in the ARC-32/ARC-56 app spec file and thus will automatically appear within
 any [generated typed clients](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/features/generate.md#1-typed-clients).
 
 ## Local storage
@@ -89,7 +89,7 @@ def delete_data(self, for_account: Account) -> None:
 ```
 
 These values can be assigned anywhere you have access to `self` i.e. any instance methods/subroutines. The information about
-local storage is automatically included in the ARC-32 app spec file and thus will automatically appear within
+local storage is automatically included in the ARC-32/ARC-56 app spec file and thus will automatically appear within
 any [generated typed clients](https://github.com/algorandfoundation/algokit-cli/blob/main/docs/features/generate.md#1-typed-clients).
 
 ## Box storage

--- a/docs/lg-structure.md
+++ b/docs/lg-structure.md
@@ -138,11 +138,11 @@ base class [per the API documentation](./api-algopy.md#algopy.Contract).
 Namely you can pass in:
 
 -   `name` - Which will affect the output TEAL file name if there are multiple non-abstract contracts
-    in the same file and will also be used as the contract name in the ARC-32 application.json instead of the class name.
+    in the same file and will also be used as the contract name in the ARC-32/ARC-56 application.json instead of the class name.
 -   `scratch_slots` - Which allows you to mark a slot ID or range of slot IDs as "off limits" to Puya
     so you can manually use them.
 -   `state_totals` - Which allows defining what values should be used for global and local uint and bytes storage values
-    when creating a contract and will appear in ARC-32 app spec.
+    when creating a contract and will appear in ARC-32/ARC-56 app spec.
 
 Full example:
 

--- a/scripts/compile_all_examples.py
+++ b/scripts/compile_all_examples.py
@@ -290,12 +290,14 @@ def _compile_for_level(arg: tuple[Path, int]) -> tuple[CompilationResult, int]:
         flags = [
             "-O0",
             "--no-output-arc32",
+            "--no-output-arc56",
         ]
         out_suffix = SUFFIX_O0
     elif optimization_level == 2:
         flags = [
             "-O2",
             "--no-output-arc32",
+            "--no-output-arc56",
             "-g0",
         ]
         out_suffix = SUFFIX_O2
@@ -309,7 +311,6 @@ def _compile_for_level(arg: tuple[Path, int]) -> tuple[CompilationResult, int]:
             "--output-memory-ir",
             "--output-client",
             "--output-source-map",
-            "--output-arc56",
         ]
         out_suffix = SUFFIX_O1
     result = checked_compile(p, flags=flags, out_suffix=out_suffix)

--- a/src/puyapy/__main__.py
+++ b/src/puyapy/__main__.py
@@ -47,7 +47,7 @@ def main() -> None:
     parser.add_argument(
         "--output-arc56",
         action=argparse.BooleanOptionalAction,
-        default=False,
+        default=True,
         help="Output {contract}.arc56.json ARC-56 app spec file",
     )
     parser.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,7 @@ def run_puyapy(args: list[str | Path], *, check: bool = True) -> subprocess.Comp
             "--no-output-source-map",
             "--no-output-client",
             "--no-output-arc32",
+            "--no-output-arc56",
             *map(str, args),
         ],
         check=check,


### PR DESCRIPTION
## Proposed Changes

- produce ARC56 app spec artefact by default when compiling
- also, produce ARC32 app spec artefact by default when compiling (existing behaviour)