### PR TITLE
feat(internal): Add SetInnerTransactionFields node 

### DIFF
--- a/src/puya/awst/function_traverser.py
+++ b/src/puya/awst/function_traverser.py
@@ -165,6 +165,13 @@ class FunctionTraverser(
             value.accept(self)
 
     @typing.override
+    def visit_set_inner_transaction_fields(
+        self, node: awst_nodes.SetInnerTransactionFields
+    ) -> None:
+        for expr in node.itxns:
+            expr.accept(self)
+
+    @typing.override
     def visit_submit_inner_transaction(self, call: awst_nodes.SubmitInnerTransaction) -> None:
         for expr in call.itxns:
             expr.accept(self)

--- a/src/puya/awst/to_code_visitor.py
+++ b/src/puya/awst/to_code_visitor.py
@@ -469,6 +469,13 @@ class ToCodeVisitor(
         return f"update_inner_transaction({expr.itxn.accept(self)},{', '.join(fields)})"
 
     @typing.override
+    def visit_set_inner_transaction_fields(self, node: nodes.SetInnerTransactionFields) -> str:
+        begin_or_next = "begin" if node.start_with_begin else "next"
+        itxns = f'{", ".join(itxn.accept(self) for itxn in node.itxns)}'
+
+        return f"{begin_or_next}_txn({itxns})"
+
+    @typing.override
     def visit_submit_inner_transaction(self, call: nodes.SubmitInnerTransaction) -> str:
         itxns = f'{", ".join(itxn.accept(self) for itxn in call.itxns)}'
         return f"submit_txn({itxns})"

--- a/src/puya/awst/visitors.py
+++ b/src/puya/awst/visitors.py
@@ -154,6 +154,11 @@ class ExpressionVisitor[T](ABC):
     ) -> T: ...
 
     @abstractmethod
+    def visit_set_inner_transaction_fields(
+        self, node: puya.awst.nodes.SetInnerTransactionFields
+    ) -> T: ...
+
+    @abstractmethod
     def visit_submit_inner_transaction(
         self, submit: puya.awst.nodes.SubmitInnerTransaction
     ) -> T: ...

--- a/src/puya/ir/builder/main.py
+++ b/src/puya/ir/builder/main.py
@@ -666,6 +666,11 @@ class FunctionIRBuilder(
             "statement has no effect, did you forget to submit?", location=call.source_location
         )
 
+    def visit_set_inner_transaction_fields(
+        self, node: awst_nodes.SetInnerTransactionFields
+    ) -> None:
+        self._itxn.handle_set_inner_transaction_fields(node)
+
     def visit_submit_inner_transaction(
         self, submit: awst_nodes.SubmitInnerTransaction
     ) -> TExpression:

--- a/tests/from_awst/itxn_compose/module.awst.json
+++ b/tests/from_awst/itxn_compose/module.awst.json
@@ -1,0 +1,5434 @@
+[
+  {
+    "_type": "Contract",
+    "source_location": {
+      "file": "%DIR%/precompiled-apps.algo.ts",
+      "line": 29,
+      "end_line": 29,
+      "column": 0,
+      "end_column": 38
+    },
+    "id": "tests/approvals/precompiled-apps.algo.ts::Hello",
+    "name": "Hello",
+    "description": null,
+    "method_resolution_order": [
+      "tests/approvals/precompiled-apps.algo.ts::HelloBase",
+      "@algorandfoundation/algorand-typescript/arc4/index.d.ts::Contract",
+      "@algorandfoundation/algorand-typescript/base-contract.d.ts::BaseContract"
+    ],
+    "approval_program": {
+      "_type": "ContractMethod",
+      "source_location": {
+        "_type": "SourceLocation",
+        "file": null,
+        "line": 1,
+        "end_line": 1,
+        "column": 0,
+        "end_column": 1
+      },
+      "args": [],
+      "return_type": {
+        "_type": "WType",
+        "name": "bool",
+        "immutable": true
+      },
+      "body": {
+        "_type": "Block",
+        "source_location": {
+          "_type": "SourceLocation",
+          "file": null,
+          "line": 1,
+          "end_line": 1,
+          "column": 0,
+          "end_column": 1
+        },
+        "body": [
+          {
+            "_type": "IfElse",
+            "source_location": {
+              "_type": "SourceLocation",
+              "file": null,
+              "line": 1,
+              "end_line": 1,
+              "column": 0,
+              "end_column": 1
+            },
+            "condition": {
+              "_type": "Not",
+              "source_location": {
+                "_type": "SourceLocation",
+                "file": null,
+                "line": 1,
+                "end_line": 1,
+                "column": 0,
+                "end_column": 1
+              },
+              "wtype": {
+                "_type": "WType",
+                "name": "bool",
+                "immutable": true
+              },
+              "expr": {
+                "_type": "ReinterpretCast",
+                "source_location": {
+                  "_type": "SourceLocation",
+                  "file": null,
+                  "line": 1,
+                  "end_line": 1,
+                  "column": 0,
+                  "end_column": 1
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "bool",
+                  "immutable": true
+                },
+                "expr": {
+                  "_type": "IntrinsicCall",
+                  "source_location": {
+                    "_type": "SourceLocation",
+                    "file": null,
+                    "line": 1,
+                    "end_line": 1,
+                    "column": 0,
+                    "end_column": 1
+                  },
+                  "wtype": {
+                    "_type": "WType",
+                    "name": "uint64",
+                    "immutable": true
+                  },
+                  "op_code": "txn",
+                  "immediates": [
+                    "ApplicationID"
+                  ],
+                  "stack_args": []
+                }
+              }
+            },
+            "if_branch": {
+              "_type": "Block",
+              "source_location": {
+                "_type": "SourceLocation",
+                "file": null,
+                "line": 1,
+                "end_line": 1,
+                "column": 0,
+                "end_column": 1
+              },
+              "body": [
+                {
+                  "_type": "ExpressionStatement",
+                  "source_location": {
+                    "_type": "SourceLocation",
+                    "file": null,
+                    "line": 1,
+                    "end_line": 1,
+                    "column": 0,
+                    "end_column": 1
+                  },
+                  "expr": {
+                    "_type": "SubroutineCallExpression",
+                    "source_location": {
+                      "_type": "SourceLocation",
+                      "file": null,
+                      "line": 1,
+                      "end_line": 1,
+                      "column": 0,
+                      "end_column": 1
+                    },
+                    "wtype": {
+                      "_type": "WType",
+                      "name": "void",
+                      "immutable": true
+                    },
+                    "target": {
+                      "_type": "InstanceMethodTarget",
+                      "member_name": "constructor"
+                    },
+                    "args": []
+                  }
+                }
+              ],
+              "label": null,
+              "comment": null
+            },
+            "else_branch": null
+          },
+          {
+            "_type": "Block",
+            "source_location": {
+              "_type": "SourceLocation",
+              "file": null,
+              "line": 1,
+              "end_line": 1,
+              "column": 0,
+              "end_column": 1
+            },
+            "body": [
+              {
+                "_type": "ReturnStatement",
+                "source_location": {
+                  "_type": "SourceLocation",
+                  "file": null,
+                  "line": 1,
+                  "end_line": 1,
+                  "column": 0,
+                  "end_column": 1
+                },
+                "value": {
+                  "_type": "ARC4Router",
+                  "source_location": {
+                    "_type": "SourceLocation",
+                    "file": null,
+                    "line": 1,
+                    "end_line": 1,
+                    "column": 0,
+                    "end_column": 1
+                  },
+                  "wtype": {
+                    "_type": "WType",
+                    "name": "bool",
+                    "immutable": true
+                  }
+                }
+              }
+            ],
+            "label": null,
+            "comment": null
+          }
+        ],
+        "label": null,
+        "comment": null
+      },
+      "documentation": {
+        "_type": "MethodDocumentation",
+        "description": null,
+        "args": {},
+        "returns": null
+      },
+      "inline": null,
+      "cref": "@algorandfoundation/algorand-typescript/arc4/index.d.ts::Contract",
+      "member_name": "approvalProgram",
+      "arc4_method_config": null
+    },
+    "clear_program": {
+      "_type": "ContractMethod",
+      "source_location": {
+        "_type": "SourceLocation",
+        "file": null,
+        "line": 1,
+        "end_line": 1,
+        "column": 0,
+        "end_column": 1
+      },
+      "args": [],
+      "return_type": {
+        "_type": "WType",
+        "name": "bool",
+        "immutable": true
+      },
+      "body": {
+        "_type": "Block",
+        "source_location": {
+          "_type": "SourceLocation",
+          "file": null,
+          "line": 1,
+          "end_line": 1,
+          "column": 0,
+          "end_column": 1
+        },
+        "body": [
+          {
+            "_type": "ReturnStatement",
+            "source_location": {
+              "_type": "SourceLocation",
+              "file": null,
+              "line": 1,
+              "end_line": 1,
+              "column": 0,
+              "end_column": 1
+            },
+            "value": {
+              "_type": "BoolConstant",
+              "source_location": {
+                "_type": "SourceLocation",
+                "file": null,
+                "line": 1,
+                "end_line": 1,
+                "column": 0,
+                "end_column": 1
+              },
+              "wtype": {
+                "_type": "WType",
+                "name": "bool",
+                "immutable": true
+              },
+              "value": true
+            }
+          }
+        ],
+        "label": null,
+        "comment": null
+      },
+      "documentation": {
+        "_type": "MethodDocumentation",
+        "description": null,
+        "args": {},
+        "returns": null
+      },
+      "inline": null,
+      "cref": "@algorandfoundation/algorand-typescript/base-contract.d.ts::BaseContract",
+      "member_name": "clearStateProgram",
+      "arc4_method_config": null
+    },
+    "methods": [
+      {
+        "_type": "ContractMethod",
+        "source_location": {
+          "file": "%DIR%/precompiled-apps.algo.ts",
+          "line": 30,
+          "end_line": 31,
+          "column": 2,
+          "end_column": 26
+        },
+        "args": [
+          {
+            "_type": "SubroutineArgument",
+            "name": "greeting",
+            "source_location": {
+              "file": "%DIR%/precompiled-apps.algo.ts",
+              "line": 31,
+              "end_line": 31,
+              "column": 9,
+              "end_column": 25
+            },
+            "wtype": {
+              "_type": "WType",
+              "name": "string",
+              "immutable": true
+            }
+          }
+        ],
+        "return_type": {
+          "_type": "WType",
+          "name": "void",
+          "immutable": true
+        },
+        "body": {
+          "_type": "Block",
+          "source_location": {
+            "file": "%DIR%/precompiled-apps.algo.ts",
+            "line": 31,
+            "end_line": 33,
+            "column": 27,
+            "end_column": 3
+          },
+          "body": [
+            {
+              "_type": "AssignmentStatement",
+              "source_location": {
+                "file": "%DIR%/precompiled-apps.algo.ts",
+                "line": 32,
+                "end_line": 32,
+                "column": 4,
+                "end_column": 34
+              },
+              "target": {
+                "_type": "AppStateExpression",
+                "source_location": {
+                  "file": "%DIR%/precompiled-apps.algo.ts",
+                  "line": 16,
+                  "end_line": 16,
+                  "column": 2,
+                  "end_column": 10
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "string",
+                  "immutable": true
+                },
+                "key": {
+                  "_type": "BytesConstant",
+                  "source_location": {
+                    "file": "%DIR%/precompiled-apps.algo.ts",
+                    "line": 16,
+                    "end_line": 16,
+                    "column": 2,
+                    "end_column": 10
+                  },
+                  "wtype": {
+                    "_type": "WType",
+                    "name": "state_key",
+                    "immutable": true
+                  },
+                  "value": "XL4m_bZKs9",
+                  "encoding": "utf8"
+                },
+                "exists_assertion_message": "check GlobalState exists"
+              },
+              "value": {
+                "_type": "VarExpression",
+                "source_location": {
+                  "file": "%DIR%/precompiled-apps.algo.ts",
+                  "line": 32,
+                  "end_line": 32,
+                  "column": 26,
+                  "end_column": 34
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "string",
+                  "immutable": true
+                },
+                "name": "greeting"
+              }
+            }
+          ],
+          "label": null,
+          "comment": null
+        },
+        "documentation": {
+          "_type": "MethodDocumentation",
+          "description": null,
+          "args": {},
+          "returns": null
+        },
+        "inline": null,
+        "cref": "tests/approvals/precompiled-apps.algo.ts::Hello",
+        "member_name": "create",
+        "arc4_method_config": {
+          "_type": "ARC4ABIMethodConfig",
+          "source_location": {
+            "file": "%DIR%/precompiled-apps.algo.ts",
+            "line": 30,
+            "end_line": 30,
+            "column": 3,
+            "end_column": 58
+          },
+          "allowed_completion_types": [
+            0
+          ],
+          "create": 2,
+          "name": "helloCreate",
+          "readonly": false,
+          "default_args": {}
+        }
+      },
+      {
+        "_type": "ContractMethod",
+        "source_location": {
+          "file": "%DIR%/precompiled-apps.algo.ts",
+          "line": 18,
+          "end_line": 19,
+          "column": 2,
+          "end_column": 10
+        },
+        "args": [],
+        "return_type": {
+          "_type": "WType",
+          "name": "void",
+          "immutable": true
+        },
+        "body": {
+          "_type": "Block",
+          "source_location": {
+            "file": "%DIR%/precompiled-apps.algo.ts",
+            "line": 19,
+            "end_line": 19,
+            "column": 11,
+            "end_column": 13
+          },
+          "body": [],
+          "label": null,
+          "comment": null
+        },
+        "documentation": {
+          "_type": "MethodDocumentation",
+          "description": null,
+          "args": {},
+          "returns": null
+        },
+        "inline": null,
+        "cref": "tests/approvals/precompiled-apps.algo.ts::HelloBase",
+        "member_name": "delete",
+        "arc4_method_config": {
+          "_type": "ARC4ABIMethodConfig",
+          "source_location": {
+            "file": "%DIR%/precompiled-apps.algo.ts",
+            "line": 18,
+            "end_line": 18,
+            "column": 3,
+            "end_column": 51
+          },
+          "allowed_completion_types": [
+            5
+          ],
+          "create": 3,
+          "name": "delete",
+          "readonly": false,
+          "default_args": {}
+        }
+      },
+      {
+        "_type": "ContractMethod",
+        "source_location": {
+          "file": "%DIR%/precompiled-apps.algo.ts",
+          "line": 21,
+          "end_line": 22,
+          "column": 2,
+          "end_column": 10
+        },
+        "args": [],
+        "return_type": {
+          "_type": "WType",
+          "name": "void",
+          "immutable": true
+        },
+        "body": {
+          "_type": "Block",
+          "source_location": {
+            "file": "%DIR%/precompiled-apps.algo.ts",
+            "line": 22,
+            "end_line": 22,
+            "column": 11,
+            "end_column": 13
+          },
+          "body": [],
+          "label": null,
+          "comment": null
+        },
+        "documentation": {
+          "_type": "MethodDocumentation",
+          "description": null,
+          "args": {},
+          "returns": null
+        },
+        "inline": null,
+        "cref": "tests/approvals/precompiled-apps.algo.ts::HelloBase",
+        "member_name": "update",
+        "arc4_method_config": {
+          "_type": "ARC4ABIMethodConfig",
+          "source_location": {
+            "file": "%DIR%/precompiled-apps.algo.ts",
+            "line": 21,
+            "end_line": 21,
+            "column": 3,
+            "end_column": 51
+          },
+          "allowed_completion_types": [
+            4
+          ],
+          "create": 3,
+          "name": "update",
+          "readonly": false,
+          "default_args": {}
+        }
+      },
+      {
+        "_type": "ContractMethod",
+        "source_location": {
+          "file": "%DIR%/precompiled-apps.algo.ts",
+          "line": 24,
+          "end_line": 24,
+          "column": 2,
+          "end_column": 29
+        },
+        "args": [
+          {
+            "_type": "SubroutineArgument",
+            "name": "name",
+            "source_location": {
+              "file": "%DIR%/precompiled-apps.algo.ts",
+              "line": 24,
+              "end_line": 24,
+              "column": 8,
+              "end_column": 20
+            },
+            "wtype": {
+              "_type": "WType",
+              "name": "string",
+              "immutable": true
+            }
+          }
+        ],
+        "return_type": {
+          "_type": "WType",
+          "name": "string",
+          "immutable": true
+        },
+        "body": {
+          "_type": "Block",
+          "source_location": {
+            "file": "%DIR%/precompiled-apps.algo.ts",
+            "line": 24,
+            "end_line": 26,
+            "column": 30,
+            "end_column": 3
+          },
+          "body": [
+            {
+              "_type": "ReturnStatement",
+              "source_location": {
+                "file": "%DIR%/precompiled-apps.algo.ts",
+                "line": 25,
+                "end_line": 25,
+                "column": 4,
+                "end_column": 43
+              },
+              "value": {
+                "_type": "BytesBinaryOperation",
+                "source_location": {
+                  "file": "%DIR%/precompiled-apps.algo.ts",
+                  "line": 25,
+                  "end_line": 25,
+                  "column": 11,
+                  "end_column": 43
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "string",
+                  "immutable": true
+                },
+                "left": {
+                  "_type": "BytesBinaryOperation",
+                  "source_location": {
+                    "file": "%DIR%/precompiled-apps.algo.ts",
+                    "line": 25,
+                    "end_line": 25,
+                    "column": 11,
+                    "end_column": 43
+                  },
+                  "wtype": {
+                    "_type": "WType",
+                    "name": "string",
+                    "immutable": true
+                  },
+                  "left": {
+                    "_type": "BytesBinaryOperation",
+                    "source_location": {
+                      "file": "%DIR%/precompiled-apps.algo.ts",
+                      "line": 25,
+                      "end_line": 25,
+                      "column": 11,
+                      "end_column": 43
+                    },
+                    "wtype": {
+                      "_type": "WType",
+                      "name": "string",
+                      "immutable": true
+                    },
+                    "left": {
+                      "_type": "StringConstant",
+                      "source_location": {
+                        "file": "%DIR%/precompiled-apps.algo.ts",
+                        "line": 25,
+                        "end_line": 25,
+                        "column": 11,
+                        "end_column": 43
+                      },
+                      "wtype": {
+                        "_type": "WType",
+                        "name": "string",
+                        "immutable": true
+                      },
+                      "value": ""
+                    },
+                    "op": "+",
+                    "right": {
+                      "_type": "AppStateExpression",
+                      "source_location": {
+                        "file": "%DIR%/precompiled-apps.algo.ts",
+                        "line": 16,
+                        "end_line": 16,
+                        "column": 2,
+                        "end_column": 10
+                      },
+                      "wtype": {
+                        "_type": "WType",
+                        "name": "string",
+                        "immutable": true
+                      },
+                      "key": {
+                        "_type": "BytesConstant",
+                        "source_location": {
+                          "file": "%DIR%/precompiled-apps.algo.ts",
+                          "line": 16,
+                          "end_line": 16,
+                          "column": 2,
+                          "end_column": 10
+                        },
+                        "wtype": {
+                          "_type": "WType",
+                          "name": "state_key",
+                          "immutable": true
+                        },
+                        "value": "XL4m_bZKs9",
+                        "encoding": "utf8"
+                      },
+                      "exists_assertion_message": "check GlobalState exists"
+                    }
+                  },
+                  "op": "+",
+                  "right": {
+                    "_type": "StringConstant",
+                    "source_location": {
+                      "file": "%DIR%/precompiled-apps.algo.ts",
+                      "line": 25,
+                      "end_line": 25,
+                      "column": 11,
+                      "end_column": 43
+                    },
+                    "wtype": {
+                      "_type": "WType",
+                      "name": "string",
+                      "immutable": true
+                    },
+                    "value": " "
+                  }
+                },
+                "op": "+",
+                "right": {
+                  "_type": "VarExpression",
+                  "source_location": {
+                    "file": "%DIR%/precompiled-apps.algo.ts",
+                    "line": 25,
+                    "end_line": 25,
+                    "column": 37,
+                    "end_column": 41
+                  },
+                  "wtype": {
+                    "_type": "WType",
+                    "name": "string",
+                    "immutable": true
+                  },
+                  "name": "name"
+                }
+              }
+            }
+          ],
+          "label": null,
+          "comment": null
+        },
+        "documentation": {
+          "_type": "MethodDocumentation",
+          "description": null,
+          "args": {},
+          "returns": null
+        },
+        "inline": null,
+        "cref": "tests/approvals/precompiled-apps.algo.ts::HelloBase",
+        "member_name": "greet",
+        "arc4_method_config": {
+          "_type": "ARC4ABIMethodConfig",
+          "source_location": {
+            "file": "%DIR%/precompiled-apps.algo.ts",
+            "line": 24,
+            "end_line": 24,
+            "column": 2,
+            "end_column": 29
+          },
+          "allowed_completion_types": [
+            0
+          ],
+          "create": 3,
+          "name": "greet",
+          "readonly": false,
+          "default_args": {}
+        }
+      },
+      {
+        "_type": "ContractMethod",
+        "source_location": {
+          "file": "%DIR%/precompiled-apps.algo.ts",
+          "line": 15,
+          "end_line": 15,
+          "column": 0,
+          "end_column": 43
+        },
+        "args": [],
+        "return_type": {
+          "_type": "WType",
+          "name": "void",
+          "immutable": true
+        },
+        "body": {
+          "_type": "Block",
+          "source_location": {
+            "file": "%DIR%/precompiled-apps.algo.ts",
+            "line": 15,
+            "end_line": 15,
+            "column": 0,
+            "end_column": 43
+          },
+          "body": [
+            {
+              "_type": "ExpressionStatement",
+              "source_location": {
+                "file": "%DIR%/precompiled-apps.algo.ts",
+                "line": 15,
+                "end_line": 15,
+                "column": 0,
+                "end_column": 43
+              },
+              "expr": {
+                "_type": "SubroutineCallExpression",
+                "source_location": {
+                  "file": "%DIR%/precompiled-apps.algo.ts",
+                  "line": 15,
+                  "end_line": 15,
+                  "column": 0,
+                  "end_column": 43
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "void",
+                  "immutable": true
+                },
+                "target": {
+                  "_type": "InstanceSuperMethodTarget",
+                  "member_name": "constructor"
+                },
+                "args": []
+              }
+            },
+            {
+              "_type": "AssignmentStatement",
+              "source_location": {
+                "file": "%DIR%/precompiled-apps.algo.ts",
+                "line": 16,
+                "end_line": 16,
+                "column": 2,
+                "end_column": 46
+              },
+              "target": {
+                "_type": "AppStateExpression",
+                "source_location": {
+                  "file": "%DIR%/precompiled-apps.algo.ts",
+                  "line": 16,
+                  "end_line": 16,
+                  "column": 2,
+                  "end_column": 10
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "string",
+                  "immutable": true
+                },
+                "key": {
+                  "_type": "BytesConstant",
+                  "source_location": {
+                    "file": "%DIR%/precompiled-apps.algo.ts",
+                    "line": 16,
+                    "end_line": 16,
+                    "column": 2,
+                    "end_column": 10
+                  },
+                  "wtype": {
+                    "_type": "WType",
+                    "name": "state_key",
+                    "immutable": true
+                  },
+                  "value": "XL4m_bZKs9",
+                  "encoding": "utf8"
+                },
+                "exists_assertion_message": null
+              },
+              "value": {
+                "_type": "StringConstant",
+                "source_location": {
+                  "file": "%DIR%/precompiled-apps.algo.ts",
+                  "line": 16,
+                  "end_line": 16,
+                  "column": 41,
+                  "end_column": 43
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "string",
+                  "immutable": true
+                },
+                "value": ""
+              }
+            }
+          ],
+          "label": null,
+          "comment": null
+        },
+        "documentation": {
+          "_type": "MethodDocumentation",
+          "description": null,
+          "args": {},
+          "returns": null
+        },
+        "inline": null,
+        "cref": "tests/approvals/precompiled-apps.algo.ts::HelloBase",
+        "member_name": "constructor",
+        "arc4_method_config": null
+      },
+      {
+        "_type": "ContractMethod",
+        "source_location": {
+          "_type": "SourceLocation",
+          "file": null,
+          "line": 1,
+          "end_line": 1,
+          "column": 0,
+          "end_column": 1
+        },
+        "args": [],
+        "return_type": {
+          "_type": "WType",
+          "name": "void",
+          "immutable": true
+        },
+        "body": {
+          "_type": "Block",
+          "source_location": {
+            "_type": "SourceLocation",
+            "file": null,
+            "line": 1,
+            "end_line": 1,
+            "column": 0,
+            "end_column": 1
+          },
+          "body": [],
+          "label": null,
+          "comment": null
+        },
+        "documentation": {
+          "_type": "MethodDocumentation",
+          "description": null,
+          "args": {},
+          "returns": null
+        },
+        "inline": true,
+        "cref": "@algorandfoundation/algorand-typescript/base-contract.d.ts::BaseContract",
+        "member_name": "constructor",
+        "arc4_method_config": null
+      }
+    ],
+    "app_state": [
+      {
+        "_type": "AppStorageDefinition",
+        "source_location": {
+          "file": "%DIR%/precompiled-apps.algo.ts",
+          "line": 16,
+          "end_line": 16,
+          "column": 2,
+          "end_column": 10
+        },
+        "member_name": "greeting",
+        "kind": 1,
+        "storage_wtype": {
+          "_type": "WType",
+          "name": "string",
+          "immutable": true
+        },
+        "key_wtype": null,
+        "key": {
+          "_type": "BytesConstant",
+          "source_location": {
+            "file": "%DIR%/precompiled-apps.algo.ts",
+            "line": 16,
+            "end_line": 16,
+            "column": 2,
+            "end_column": 10
+          },
+          "wtype": {
+            "_type": "WType",
+            "name": "state_key",
+            "immutable": true
+          },
+          "value": "XL4m_bZKs9",
+          "encoding": "utf8"
+        },
+        "description": null
+      }
+    ],
+    "state_totals": {
+      "_type": "StateTotals",
+      "global_uints": null,
+      "local_uints": null,
+      "global_bytes": null,
+      "local_bytes": null
+    },
+    "reserved_scratch_space": [],
+    "avm_version": null
+  },
+  {
+    "_type": "Contract",
+    "source_location": {
+      "file": "%DIR%/itxn-compose.algo.ts",
+      "line": 18,
+      "end_line": 18,
+      "column": 0,
+      "end_column": 40
+    },
+    "id": "tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo",
+    "name": "ItxnComposeAlgo",
+    "description": null,
+    "method_resolution_order": [
+      "@algorandfoundation/algorand-typescript/arc4/index.d.ts::Contract",
+      "@algorandfoundation/algorand-typescript/base-contract.d.ts::BaseContract"
+    ],
+    "approval_program": {
+      "_type": "ContractMethod",
+      "source_location": {
+        "_type": "SourceLocation",
+        "file": null,
+        "line": 1,
+        "end_line": 1,
+        "column": 0,
+        "end_column": 1
+      },
+      "args": [],
+      "return_type": {
+        "_type": "WType",
+        "name": "bool",
+        "immutable": true
+      },
+      "body": {
+        "_type": "Block",
+        "source_location": {
+          "_type": "SourceLocation",
+          "file": null,
+          "line": 1,
+          "end_line": 1,
+          "column": 0,
+          "end_column": 1
+        },
+        "body": [
+          {
+            "_type": "ReturnStatement",
+            "source_location": {
+              "_type": "SourceLocation",
+              "file": null,
+              "line": 1,
+              "end_line": 1,
+              "column": 0,
+              "end_column": 1
+            },
+            "value": {
+              "_type": "ARC4Router",
+              "source_location": {
+                "_type": "SourceLocation",
+                "file": null,
+                "line": 1,
+                "end_line": 1,
+                "column": 0,
+                "end_column": 1
+              },
+              "wtype": {
+                "_type": "WType",
+                "name": "bool",
+                "immutable": true
+              }
+            }
+          }
+        ],
+        "label": null,
+        "comment": null
+      },
+      "documentation": {
+        "_type": "MethodDocumentation",
+        "description": null,
+        "args": {},
+        "returns": null
+      },
+      "inline": null,
+      "cref": "@algorandfoundation/algorand-typescript/arc4/index.d.ts::Contract",
+      "member_name": "approvalProgram",
+      "arc4_method_config": null
+    },
+    "clear_program": {
+      "_type": "ContractMethod",
+      "source_location": {
+        "_type": "SourceLocation",
+        "file": null,
+        "line": 1,
+        "end_line": 1,
+        "column": 0,
+        "end_column": 1
+      },
+      "args": [],
+      "return_type": {
+        "_type": "WType",
+        "name": "bool",
+        "immutable": true
+      },
+      "body": {
+        "_type": "Block",
+        "source_location": {
+          "_type": "SourceLocation",
+          "file": null,
+          "line": 1,
+          "end_line": 1,
+          "column": 0,
+          "end_column": 1
+        },
+        "body": [
+          {
+            "_type": "ReturnStatement",
+            "source_location": {
+              "_type": "SourceLocation",
+              "file": null,
+              "line": 1,
+              "end_line": 1,
+              "column": 0,
+              "end_column": 1
+            },
+            "value": {
+              "_type": "BoolConstant",
+              "source_location": {
+                "_type": "SourceLocation",
+                "file": null,
+                "line": 1,
+                "end_line": 1,
+                "column": 0,
+                "end_column": 1
+              },
+              "wtype": {
+                "_type": "WType",
+                "name": "bool",
+                "immutable": true
+              },
+              "value": true
+            }
+          }
+        ],
+        "label": null,
+        "comment": null
+      },
+      "documentation": {
+        "_type": "MethodDocumentation",
+        "description": null,
+        "args": {},
+        "returns": null
+      },
+      "inline": null,
+      "cref": "@algorandfoundation/algorand-typescript/base-contract.d.ts::BaseContract",
+      "member_name": "clearStateProgram",
+      "arc4_method_config": null
+    },
+    "methods": [
+      {
+        "_type": "ContractMethod",
+        "source_location": {
+          "file": "%DIR%/itxn-compose.algo.ts",
+          "line": 19,
+          "end_line": 19,
+          "column": 2,
+          "end_column": 81
+        },
+        "args": [
+          {
+            "_type": "SubroutineArgument",
+            "name": "addresses",
+            "source_location": {
+              "file": "%DIR%/itxn-compose.algo.ts",
+              "line": 19,
+              "end_line": 19,
+              "column": 13,
+              "end_column": 33
+            },
+            "wtype": {
+              "_type": "StackArray",
+              "name": "stack_array<arc4.static_array<arc4.byte>>",
+              "immutable": true,
+              "element_type": {
+                "_type": "ARC4StaticArray",
+                "name": "arc4.static_array<arc4.byte>",
+                "immutable": true,
+                "arc4_alias": "address",
+                "element_type": {
+                  "_type": "ARC4UIntN",
+                  "name": "arc4.byte",
+                  "immutable": true,
+                  "arc4_alias": "byte",
+                  "n": 8
+                },
+                "source_location": null,
+                "array_size": 32
+              },
+              "source_location": null
+            }
+          },
+          {
+            "_type": "SubroutineArgument",
+            "name": "funds",
+            "source_location": {
+              "file": "%DIR%/itxn-compose.algo.ts",
+              "line": 19,
+              "end_line": 19,
+              "column": 35,
+              "end_column": 57
+            },
+            "wtype": {
+              "_type": "WGroupTransaction",
+              "name": "group_transaction_pay",
+              "immutable": true,
+              "transaction_type": 1,
+              "arc4_alias": "pay"
+            }
+          },
+          {
+            "_type": "SubroutineArgument",
+            "name": "verifier",
+            "source_location": {
+              "file": "%DIR%/itxn-compose.algo.ts",
+              "line": 19,
+              "end_line": 19,
+              "column": 59,
+              "end_column": 80
+            },
+            "wtype": {
+              "_type": "WType",
+              "name": "application",
+              "immutable": true
+            }
+          }
+        ],
+        "return_type": {
+          "_type": "WType",
+          "name": "void",
+          "immutable": true
+        },
+        "body": {
+          "_type": "Block",
+          "source_location": {
+            "file": "%DIR%/itxn-compose.algo.ts",
+            "line": 19,
+            "end_line": 52,
+            "column": 82,
+            "end_column": 3
+          },
+          "body": [
+            {
+              "_type": "ExpressionStatement",
+              "source_location": {
+                "file": "%DIR%/itxn-compose.algo.ts",
+                "line": 20,
+                "end_line": 22,
+                "column": 4,
+                "end_column": 6
+              },
+              "expr": {
+                "_type": "AssertExpression",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 20,
+                  "end_line": 22,
+                  "column": 4,
+                  "end_column": 6
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "void",
+                  "immutable": true
+                },
+                "condition": {
+                  "_type": "BytesComparisonExpression",
+                  "source_location": {
+                    "file": "%DIR%/itxn-compose.algo.ts",
+                    "line": 20,
+                    "end_line": 22,
+                    "column": 4,
+                    "end_column": 6
+                  },
+                  "wtype": {
+                    "_type": "WType",
+                    "name": "bool",
+                    "immutable": true
+                  },
+                  "lhs": {
+                    "_type": "IntrinsicCall",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 20,
+                      "end_line": 22,
+                      "column": 4,
+                      "end_column": 6
+                    },
+                    "wtype": {
+                      "_type": "WType",
+                      "name": "account",
+                      "immutable": true
+                    },
+                    "op_code": "gtxns",
+                    "immediates": [
+                      "Receiver"
+                    ],
+                    "stack_args": [
+                      {
+                        "_type": "VarExpression",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 20,
+                          "end_line": 20,
+                          "column": 16,
+                          "end_column": 21
+                        },
+                        "wtype": {
+                          "_type": "WGroupTransaction",
+                          "name": "group_transaction_pay",
+                          "immutable": true,
+                          "transaction_type": 1,
+                          "arc4_alias": "pay"
+                        },
+                        "name": "funds"
+                      }
+                    ]
+                  },
+                  "operator": "==",
+                  "rhs": {
+                    "_type": "IntrinsicCall",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 21,
+                      "end_line": 21,
+                      "column": 23,
+                      "end_column": 48
+                    },
+                    "wtype": {
+                      "_type": "WType",
+                      "name": "account",
+                      "immutable": true
+                    },
+                    "op_code": "global",
+                    "immediates": [
+                      "CurrentApplicationAddress"
+                    ],
+                    "stack_args": []
+                  }
+                },
+                "error_message": "assert target is match for conditions"
+              }
+            },
+            {
+              "_type": "ExpressionStatement",
+              "source_location": {
+                "file": "%DIR%/itxn-compose.algo.ts",
+                "line": 23,
+                "end_line": 23,
+                "column": 4,
+                "end_column": 58
+              },
+              "expr": {
+                "_type": "AssertExpression",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 23,
+                  "end_line": 23,
+                  "column": 4,
+                  "end_column": 58
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "void",
+                  "immutable": true
+                },
+                "condition": {
+                  "_type": "ReinterpretCast",
+                  "source_location": {
+                    "file": "%DIR%/itxn-compose.algo.ts",
+                    "line": 23,
+                    "end_line": 23,
+                    "column": 4,
+                    "end_column": 58
+                  },
+                  "wtype": {
+                    "_type": "WType",
+                    "name": "bool",
+                    "immutable": true
+                  },
+                  "expr": {
+                    "_type": "ArrayLength",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 23,
+                      "end_line": 23,
+                      "column": 21,
+                      "end_column": 27
+                    },
+                    "wtype": {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    "array": {
+                      "_type": "VarExpression",
+                      "source_location": {
+                        "file": "%DIR%/itxn-compose.algo.ts",
+                        "line": 23,
+                        "end_line": 23,
+                        "column": 11,
+                        "end_column": 20
+                      },
+                      "wtype": {
+                        "_type": "StackArray",
+                        "name": "stack_array<arc4.static_array<arc4.byte>>",
+                        "immutable": true,
+                        "element_type": {
+                          "_type": "ARC4StaticArray",
+                          "name": "arc4.static_array<arc4.byte>",
+                          "immutable": true,
+                          "arc4_alias": "address",
+                          "element_type": {
+                            "_type": "ARC4UIntN",
+                            "name": "arc4.byte",
+                            "immutable": true,
+                            "arc4_alias": "byte",
+                            "n": 8
+                          },
+                          "source_location": null,
+                          "array_size": 32
+                        },
+                        "source_location": null
+                      },
+                      "name": "addresses"
+                    }
+                  }
+                },
+                "error_message": "must provide some accounts"
+              }
+            },
+            {
+              "_type": "AssignmentStatement",
+              "source_location": {
+                "file": "%DIR%/itxn-compose.algo.ts",
+                "line": 24,
+                "end_line": 24,
+                "column": 10,
+                "end_column": 57
+              },
+              "target": {
+                "_type": "VarExpression",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 24,
+                  "end_line": 24,
+                  "column": 10,
+                  "end_column": 15
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "uint64",
+                  "immutable": true
+                },
+                "name": "share"
+              },
+              "value": {
+                "_type": "UInt64BinaryOperation",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 24,
+                  "end_line": 24,
+                  "column": 26,
+                  "end_column": 57
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "uint64",
+                  "immutable": true
+                },
+                "left": {
+                  "_type": "IntrinsicCall",
+                  "source_location": {
+                    "file": "%DIR%/itxn-compose.algo.ts",
+                    "line": 24,
+                    "end_line": 24,
+                    "column": 32,
+                    "end_column": 38
+                  },
+                  "wtype": {
+                    "_type": "WType",
+                    "name": "uint64",
+                    "immutable": true
+                  },
+                  "op_code": "gtxns",
+                  "immediates": [
+                    "Amount"
+                  ],
+                  "stack_args": [
+                    {
+                      "_type": "VarExpression",
+                      "source_location": {
+                        "file": "%DIR%/itxn-compose.algo.ts",
+                        "line": 24,
+                        "end_line": 24,
+                        "column": 26,
+                        "end_column": 31
+                      },
+                      "wtype": {
+                        "_type": "WGroupTransaction",
+                        "name": "group_transaction_pay",
+                        "immutable": true,
+                        "transaction_type": 1,
+                        "arc4_alias": "pay"
+                      },
+                      "name": "funds"
+                    }
+                  ]
+                },
+                "op": "//",
+                "right": {
+                  "_type": "ArrayLength",
+                  "source_location": {
+                    "file": "%DIR%/itxn-compose.algo.ts",
+                    "line": 24,
+                    "end_line": 24,
+                    "column": 51,
+                    "end_column": 57
+                  },
+                  "wtype": {
+                    "_type": "WType",
+                    "name": "uint64",
+                    "immutable": true
+                  },
+                  "array": {
+                    "_type": "VarExpression",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 24,
+                      "end_line": 24,
+                      "column": 41,
+                      "end_column": 50
+                    },
+                    "wtype": {
+                      "_type": "StackArray",
+                      "name": "stack_array<arc4.static_array<arc4.byte>>",
+                      "immutable": true,
+                      "element_type": {
+                        "_type": "ARC4StaticArray",
+                        "name": "arc4.static_array<arc4.byte>",
+                        "immutable": true,
+                        "arc4_alias": "address",
+                        "element_type": {
+                          "_type": "ARC4UIntN",
+                          "name": "arc4.byte",
+                          "immutable": true,
+                          "arc4_alias": "byte",
+                          "n": 8
+                        },
+                        "source_location": null,
+                        "array_size": 32
+                      },
+                      "source_location": null
+                    },
+                    "name": "addresses"
+                  }
+                }
+              }
+            },
+            {
+              "_type": "AssignmentStatement",
+              "source_location": {
+                "file": "%DIR%/itxn-compose.algo.ts",
+                "line": 26,
+                "end_line": 30,
+                "column": 10,
+                "end_column": 36
+              },
+              "target": {
+                "_type": "VarExpression",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 26,
+                  "end_line": 26,
+                  "column": 10,
+                  "end_column": 19
+                },
+                "wtype": {
+                  "_type": "WTuple",
+                  "name": "lib.d.ts::object",
+                  "immutable": true,
+                  "types": [
+                    {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    {
+                      "_type": "BytesWType",
+                      "name": "bytes",
+                      "immutable": true,
+                      "length": null
+                    }
+                  ],
+                  "names": [
+                    "type",
+                    "amount",
+                    "receiver"
+                  ]
+                },
+                "name": "payFields"
+              },
+              "value": {
+                "_type": "TupleExpression",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 26,
+                  "end_line": 30,
+                  "column": 22,
+                  "end_column": 5
+                },
+                "wtype": {
+                  "_type": "WTuple",
+                  "name": "lib.d.ts::object",
+                  "immutable": true,
+                  "types": [
+                    {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    {
+                      "_type": "BytesWType",
+                      "name": "bytes",
+                      "immutable": true,
+                      "length": null
+                    }
+                  ],
+                  "names": [
+                    "type",
+                    "amount",
+                    "receiver"
+                  ]
+                },
+                "items": [
+                  {
+                    "_type": "IntegerConstant",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 27,
+                      "end_line": 27,
+                      "column": 28,
+                      "end_column": 35
+                    },
+                    "wtype": {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    "value": 1,
+                    "teal_alias": null
+                  },
+                  {
+                    "_type": "VarExpression",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 28,
+                      "end_line": 28,
+                      "column": 14,
+                      "end_column": 19
+                    },
+                    "wtype": {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    "name": "share"
+                  },
+                  {
+                    "_type": "ReinterpretCast",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 29,
+                      "end_line": 29,
+                      "column": 29,
+                      "end_column": 34
+                    },
+                    "wtype": {
+                      "_type": "BytesWType",
+                      "name": "bytes",
+                      "immutable": true,
+                      "length": null
+                    },
+                    "expr": {
+                      "_type": "IndexExpression",
+                      "source_location": {
+                        "file": "%DIR%/itxn-compose.algo.ts",
+                        "line": 29,
+                        "end_line": 29,
+                        "column": 16,
+                        "end_column": 28
+                      },
+                      "wtype": {
+                        "_type": "ARC4StaticArray",
+                        "name": "arc4.static_array<arc4.byte>",
+                        "immutable": true,
+                        "arc4_alias": "address",
+                        "element_type": {
+                          "_type": "ARC4UIntN",
+                          "name": "arc4.byte",
+                          "immutable": true,
+                          "arc4_alias": "byte",
+                          "n": 8
+                        },
+                        "source_location": null,
+                        "array_size": 32
+                      },
+                      "base": {
+                        "_type": "VarExpression",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 29,
+                          "end_line": 29,
+                          "column": 16,
+                          "end_column": 25
+                        },
+                        "wtype": {
+                          "_type": "StackArray",
+                          "name": "stack_array<arc4.static_array<arc4.byte>>",
+                          "immutable": true,
+                          "element_type": {
+                            "_type": "ARC4StaticArray",
+                            "name": "arc4.static_array<arc4.byte>",
+                            "immutable": true,
+                            "arc4_alias": "address",
+                            "element_type": {
+                              "_type": "ARC4UIntN",
+                              "name": "arc4.byte",
+                              "immutable": true,
+                              "arc4_alias": "byte",
+                              "n": 8
+                            },
+                            "source_location": null,
+                            "array_size": 32
+                          },
+                          "source_location": null
+                        },
+                        "name": "addresses"
+                      },
+                      "index": {
+                        "_type": "IntegerConstant",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 29,
+                          "end_line": 29,
+                          "column": 26,
+                          "end_column": 27
+                        },
+                        "wtype": {
+                          "_type": "WType",
+                          "name": "uint64",
+                          "immutable": true
+                        },
+                        "value": 0,
+                        "teal_alias": null
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "_type": "ExpressionStatement",
+              "source_location": {
+                "file": "%DIR%/itxn-compose.algo.ts",
+                "line": 31,
+                "end_line": 31,
+                "column": 4,
+                "end_column": 32
+              },
+              "expr": {
+                "_type": "SetInnerTransactionFields",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 31,
+                  "end_line": 31,
+                  "column": 4,
+                  "end_column": 32
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "void",
+                  "immutable": true
+                },
+                "itxns": [
+                  {
+                    "_type": "CreateInnerTransaction",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 31,
+                      "end_line": 31,
+                      "column": 4,
+                      "end_column": 32
+                    },
+                    "wtype": {
+                      "_type": "WInnerTransactionFields",
+                      "name": "inner_transaction_fields_pay",
+                      "immutable": true,
+                      "transaction_type": 1
+                    },
+                    "fields": {
+                      "Fee": {
+                        "_type": "IntegerConstant",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 31,
+                          "end_line": 31,
+                          "column": 4,
+                          "end_column": 32
+                        },
+                        "wtype": {
+                          "_type": "WType",
+                          "name": "uint64",
+                          "immutable": true
+                        },
+                        "value": 0,
+                        "teal_alias": null
+                      },
+                      "TypeEnum": {
+                        "_type": "FieldExpression",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 31,
+                          "end_line": 31,
+                          "column": 4,
+                          "end_column": 32
+                        },
+                        "wtype": {
+                          "_type": "WType",
+                          "name": "uint64",
+                          "immutable": true
+                        },
+                        "base": {
+                          "_type": "VarExpression",
+                          "source_location": {
+                            "file": "%DIR%/itxn-compose.algo.ts",
+                            "line": 31,
+                            "end_line": 31,
+                            "column": 22,
+                            "end_column": 31
+                          },
+                          "wtype": {
+                            "_type": "WTuple",
+                            "name": "lib.d.ts::object",
+                            "immutable": true,
+                            "types": [
+                              {
+                                "_type": "WType",
+                                "name": "uint64",
+                                "immutable": true
+                              },
+                              {
+                                "_type": "WType",
+                                "name": "uint64",
+                                "immutable": true
+                              },
+                              {
+                                "_type": "BytesWType",
+                                "name": "bytes",
+                                "immutable": true,
+                                "length": null
+                              }
+                            ],
+                            "names": [
+                              "type",
+                              "amount",
+                              "receiver"
+                            ]
+                          },
+                          "name": "payFields"
+                        },
+                        "name": "type"
+                      },
+                      "Amount": {
+                        "_type": "FieldExpression",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 31,
+                          "end_line": 31,
+                          "column": 4,
+                          "end_column": 32
+                        },
+                        "wtype": {
+                          "_type": "WType",
+                          "name": "uint64",
+                          "immutable": true
+                        },
+                        "base": {
+                          "_type": "VarExpression",
+                          "source_location": {
+                            "file": "%DIR%/itxn-compose.algo.ts",
+                            "line": 31,
+                            "end_line": 31,
+                            "column": 22,
+                            "end_column": 31
+                          },
+                          "wtype": {
+                            "_type": "WTuple",
+                            "name": "lib.d.ts::object",
+                            "immutable": true,
+                            "types": [
+                              {
+                                "_type": "WType",
+                                "name": "uint64",
+                                "immutable": true
+                              },
+                              {
+                                "_type": "WType",
+                                "name": "uint64",
+                                "immutable": true
+                              },
+                              {
+                                "_type": "BytesWType",
+                                "name": "bytes",
+                                "immutable": true,
+                                "length": null
+                              }
+                            ],
+                            "names": [
+                              "type",
+                              "amount",
+                              "receiver"
+                            ]
+                          },
+                          "name": "payFields"
+                        },
+                        "name": "amount"
+                      },
+                      "Receiver": {
+                        "_type": "ReinterpretCast",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 31,
+                          "end_line": 31,
+                          "column": 4,
+                          "end_column": 32
+                        },
+                        "wtype": {
+                          "_type": "WType",
+                          "name": "account",
+                          "immutable": true
+                        },
+                        "expr": {
+                          "_type": "FieldExpression",
+                          "source_location": {
+                            "file": "%DIR%/itxn-compose.algo.ts",
+                            "line": 31,
+                            "end_line": 31,
+                            "column": 4,
+                            "end_column": 32
+                          },
+                          "wtype": {
+                            "_type": "BytesWType",
+                            "name": "bytes",
+                            "immutable": true,
+                            "length": null
+                          },
+                          "base": {
+                            "_type": "VarExpression",
+                            "source_location": {
+                              "file": "%DIR%/itxn-compose.algo.ts",
+                              "line": 31,
+                              "end_line": 31,
+                              "column": 22,
+                              "end_column": 31
+                            },
+                            "wtype": {
+                              "_type": "WTuple",
+                              "name": "lib.d.ts::object",
+                              "immutable": true,
+                              "types": [
+                                {
+                                  "_type": "WType",
+                                  "name": "uint64",
+                                  "immutable": true
+                                },
+                                {
+                                  "_type": "WType",
+                                  "name": "uint64",
+                                  "immutable": true
+                                },
+                                {
+                                  "_type": "BytesWType",
+                                  "name": "bytes",
+                                  "immutable": true,
+                                  "length": null
+                                }
+                              ],
+                              "names": [
+                                "type",
+                                "amount",
+                                "receiver"
+                              ]
+                            },
+                            "name": "payFields"
+                          },
+                          "name": "receiver"
+                        }
+                      }
+                    }
+                  }
+                ],
+                "start_with_begin": true
+              }
+            },
+            {
+              "_type": "Block",
+              "source_location": {
+                "file": "%DIR%/itxn-compose.algo.ts",
+                "line": 32,
+                "end_line": 32,
+                "column": 4,
+                "end_column": 48
+              },
+              "body": [
+                {
+                  "_type": "ForInLoop",
+                  "source_location": {
+                    "file": "%DIR%/itxn-compose.algo.ts",
+                    "line": 32,
+                    "end_line": 32,
+                    "column": 4,
+                    "end_column": 48
+                  },
+                  "sequence": {
+                    "_type": "Range",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 32,
+                      "end_line": 32,
+                      "column": 20,
+                      "end_column": 47
+                    },
+                    "wtype": {
+                      "_type": "WType",
+                      "name": "uint64_range",
+                      "immutable": true
+                    },
+                    "start": {
+                      "_type": "IntegerConstant",
+                      "source_location": {
+                        "file": "%DIR%/itxn-compose.algo.ts",
+                        "line": 32,
+                        "end_line": 32,
+                        "column": 27,
+                        "end_column": 28
+                      },
+                      "wtype": {
+                        "_type": "WType",
+                        "name": "uint64",
+                        "immutable": true
+                      },
+                      "value": 1,
+                      "teal_alias": null
+                    },
+                    "stop": {
+                      "_type": "ArrayLength",
+                      "source_location": {
+                        "file": "%DIR%/itxn-compose.algo.ts",
+                        "line": 32,
+                        "end_line": 32,
+                        "column": 40,
+                        "end_column": 46
+                      },
+                      "wtype": {
+                        "_type": "WType",
+                        "name": "uint64",
+                        "immutable": true
+                      },
+                      "array": {
+                        "_type": "VarExpression",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 32,
+                          "end_line": 32,
+                          "column": 30,
+                          "end_column": 39
+                        },
+                        "wtype": {
+                          "_type": "StackArray",
+                          "name": "stack_array<arc4.static_array<arc4.byte>>",
+                          "immutable": true,
+                          "element_type": {
+                            "_type": "ARC4StaticArray",
+                            "name": "arc4.static_array<arc4.byte>",
+                            "immutable": true,
+                            "arc4_alias": "address",
+                            "element_type": {
+                              "_type": "ARC4UIntN",
+                              "name": "arc4.byte",
+                              "immutable": true,
+                              "arc4_alias": "byte",
+                              "n": 8
+                            },
+                            "source_location": null,
+                            "array_size": 32
+                          },
+                          "source_location": null
+                        },
+                        "name": "addresses"
+                      }
+                    },
+                    "step": {
+                      "_type": "IntegerConstant",
+                      "source_location": {
+                        "file": "%DIR%/itxn-compose.algo.ts",
+                        "line": 32,
+                        "end_line": 32,
+                        "column": 20,
+                        "end_column": 47
+                      },
+                      "wtype": {
+                        "_type": "WType",
+                        "name": "uint64",
+                        "immutable": true
+                      },
+                      "value": 1,
+                      "teal_alias": null
+                    }
+                  },
+                  "items": {
+                    "_type": "VarExpression",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 32,
+                      "end_line": 32,
+                      "column": 15,
+                      "end_column": 16
+                    },
+                    "wtype": {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    "name": "i"
+                  },
+                  "loop_body": {
+                    "_type": "Block",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 32,
+                      "end_line": 32,
+                      "column": 4,
+                      "end_column": 48
+                    },
+                    "body": [
+                      {
+                        "_type": "Block",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 32,
+                          "end_line": 39,
+                          "column": 49,
+                          "end_column": 5
+                        },
+                        "body": [
+                          {
+                            "_type": "AssignmentStatement",
+                            "source_location": {
+                              "file": "%DIR%/itxn-compose.algo.ts",
+                              "line": 33,
+                              "end_line": 33,
+                              "column": 12,
+                              "end_column": 31
+                            },
+                            "target": {
+                              "_type": "VarExpression",
+                              "source_location": {
+                                "file": "%DIR%/itxn-compose.algo.ts",
+                                "line": 33,
+                                "end_line": 33,
+                                "column": 12,
+                                "end_column": 16
+                              },
+                              "wtype": {
+                                "_type": "ARC4StaticArray",
+                                "name": "arc4.static_array<arc4.byte>",
+                                "immutable": true,
+                                "arc4_alias": "address",
+                                "element_type": {
+                                  "_type": "ARC4UIntN",
+                                  "name": "arc4.byte",
+                                  "immutable": true,
+                                  "arc4_alias": "byte",
+                                  "n": 8
+                                },
+                                "source_location": null,
+                                "array_size": 32
+                              },
+                              "name": "addr"
+                            },
+                            "value": {
+                              "_type": "IndexExpression",
+                              "source_location": {
+                                "file": "%DIR%/itxn-compose.algo.ts",
+                                "line": 33,
+                                "end_line": 33,
+                                "column": 19,
+                                "end_column": 31
+                              },
+                              "wtype": {
+                                "_type": "ARC4StaticArray",
+                                "name": "arc4.static_array<arc4.byte>",
+                                "immutable": true,
+                                "arc4_alias": "address",
+                                "element_type": {
+                                  "_type": "ARC4UIntN",
+                                  "name": "arc4.byte",
+                                  "immutable": true,
+                                  "arc4_alias": "byte",
+                                  "n": 8
+                                },
+                                "source_location": null,
+                                "array_size": 32
+                              },
+                              "base": {
+                                "_type": "VarExpression",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 33,
+                                  "end_line": 33,
+                                  "column": 19,
+                                  "end_column": 28
+                                },
+                                "wtype": {
+                                  "_type": "StackArray",
+                                  "name": "stack_array<arc4.static_array<arc4.byte>>",
+                                  "immutable": true,
+                                  "element_type": {
+                                    "_type": "ARC4StaticArray",
+                                    "name": "arc4.static_array<arc4.byte>",
+                                    "immutable": true,
+                                    "arc4_alias": "address",
+                                    "element_type": {
+                                      "_type": "ARC4UIntN",
+                                      "name": "arc4.byte",
+                                      "immutable": true,
+                                      "arc4_alias": "byte",
+                                      "n": 8
+                                    },
+                                    "source_location": null,
+                                    "array_size": 32
+                                  },
+                                  "source_location": null
+                                },
+                                "name": "addresses"
+                              },
+                              "index": {
+                                "_type": "VarExpression",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 33,
+                                  "end_line": 33,
+                                  "column": 29,
+                                  "end_column": 30
+                                },
+                                "wtype": {
+                                  "_type": "WType",
+                                  "name": "uint64",
+                                  "immutable": true
+                                },
+                                "name": "i"
+                              }
+                            }
+                          },
+                          {
+                            "_type": "ExpressionStatement",
+                            "source_location": {
+                              "file": "%DIR%/itxn-compose.algo.ts",
+                              "line": 34,
+                              "end_line": 38,
+                              "column": 6,
+                              "end_column": 8
+                            },
+                            "expr": {
+                              "_type": "SetInnerTransactionFields",
+                              "source_location": {
+                                "file": "%DIR%/itxn-compose.algo.ts",
+                                "line": 34,
+                                "end_line": 38,
+                                "column": 6,
+                                "end_column": 8
+                              },
+                              "wtype": {
+                                "_type": "WType",
+                                "name": "void",
+                                "immutable": true
+                              },
+                              "itxns": [
+                                {
+                                  "_type": "CreateInnerTransaction",
+                                  "source_location": {
+                                    "file": "%DIR%/itxn-compose.algo.ts",
+                                    "line": 34,
+                                    "end_line": 38,
+                                    "column": 6,
+                                    "end_column": 8
+                                  },
+                                  "wtype": {
+                                    "_type": "WInnerTransactionFields",
+                                    "name": "inner_transaction_fields_pay",
+                                    "immutable": true,
+                                    "transaction_type": 1
+                                  },
+                                  "fields": {
+                                    "Fee": {
+                                      "_type": "IntegerConstant",
+                                      "source_location": {
+                                        "file": "%DIR%/itxn-compose.algo.ts",
+                                        "line": 34,
+                                        "end_line": 38,
+                                        "column": 6,
+                                        "end_column": 8
+                                      },
+                                      "wtype": {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      "value": 0,
+                                      "teal_alias": null
+                                    },
+                                    "Receiver": {
+                                      "_type": "ReinterpretCast",
+                                      "source_location": {
+                                        "file": "%DIR%/itxn-compose.algo.ts",
+                                        "line": 37,
+                                        "end_line": 37,
+                                        "column": 23,
+                                        "end_column": 28
+                                      },
+                                      "wtype": {
+                                        "_type": "WType",
+                                        "name": "account",
+                                        "immutable": true
+                                      },
+                                      "expr": {
+                                        "_type": "ReinterpretCast",
+                                        "source_location": {
+                                          "file": "%DIR%/itxn-compose.algo.ts",
+                                          "line": 37,
+                                          "end_line": 37,
+                                          "column": 23,
+                                          "end_column": 28
+                                        },
+                                        "wtype": {
+                                          "_type": "BytesWType",
+                                          "name": "bytes",
+                                          "immutable": true,
+                                          "length": null
+                                        },
+                                        "expr": {
+                                          "_type": "VarExpression",
+                                          "source_location": {
+                                            "file": "%DIR%/itxn-compose.algo.ts",
+                                            "line": 37,
+                                            "end_line": 37,
+                                            "column": 18,
+                                            "end_column": 22
+                                          },
+                                          "wtype": {
+                                            "_type": "ARC4StaticArray",
+                                            "name": "arc4.static_array<arc4.byte>",
+                                            "immutable": true,
+                                            "arc4_alias": "address",
+                                            "element_type": {
+                                              "_type": "ARC4UIntN",
+                                              "name": "arc4.byte",
+                                              "immutable": true,
+                                              "arc4_alias": "byte",
+                                              "n": 8
+                                            },
+                                            "source_location": null,
+                                            "array_size": 32
+                                          },
+                                          "name": "addr"
+                                        }
+                                      }
+                                    },
+                                    "TypeEnum": {
+                                      "_type": "FieldExpression",
+                                      "source_location": {
+                                        "file": "%DIR%/itxn-compose.algo.ts",
+                                        "line": 34,
+                                        "end_line": 38,
+                                        "column": 6,
+                                        "end_column": 8
+                                      },
+                                      "wtype": {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      "base": {
+                                        "_type": "VarExpression",
+                                        "source_location": {
+                                          "file": "%DIR%/itxn-compose.algo.ts",
+                                          "line": 35,
+                                          "end_line": 35,
+                                          "column": 11,
+                                          "end_column": 20
+                                        },
+                                        "wtype": {
+                                          "_type": "WTuple",
+                                          "name": "lib.d.ts::object",
+                                          "immutable": true,
+                                          "types": [
+                                            {
+                                              "_type": "WType",
+                                              "name": "uint64",
+                                              "immutable": true
+                                            },
+                                            {
+                                              "_type": "WType",
+                                              "name": "uint64",
+                                              "immutable": true
+                                            },
+                                            {
+                                              "_type": "BytesWType",
+                                              "name": "bytes",
+                                              "immutable": true,
+                                              "length": null
+                                            }
+                                          ],
+                                          "names": [
+                                            "type",
+                                            "amount",
+                                            "receiver"
+                                          ]
+                                        },
+                                        "name": "payFields"
+                                      },
+                                      "name": "type"
+                                    },
+                                    "Amount": {
+                                      "_type": "FieldExpression",
+                                      "source_location": {
+                                        "file": "%DIR%/itxn-compose.algo.ts",
+                                        "line": 34,
+                                        "end_line": 38,
+                                        "column": 6,
+                                        "end_column": 8
+                                      },
+                                      "wtype": {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      "base": {
+                                        "_type": "VarExpression",
+                                        "source_location": {
+                                          "file": "%DIR%/itxn-compose.algo.ts",
+                                          "line": 35,
+                                          "end_line": 35,
+                                          "column": 11,
+                                          "end_column": 20
+                                        },
+                                        "wtype": {
+                                          "_type": "WTuple",
+                                          "name": "lib.d.ts::object",
+                                          "immutable": true,
+                                          "types": [
+                                            {
+                                              "_type": "WType",
+                                              "name": "uint64",
+                                              "immutable": true
+                                            },
+                                            {
+                                              "_type": "WType",
+                                              "name": "uint64",
+                                              "immutable": true
+                                            },
+                                            {
+                                              "_type": "BytesWType",
+                                              "name": "bytes",
+                                              "immutable": true,
+                                              "length": null
+                                            }
+                                          ],
+                                          "names": [
+                                            "type",
+                                            "amount",
+                                            "receiver"
+                                          ]
+                                        },
+                                        "name": "payFields"
+                                      },
+                                      "name": "amount"
+                                    }
+                                  }
+                                }
+                              ],
+                              "start_with_begin": false
+                            }
+                          }
+                        ],
+                        "label": null,
+                        "comment": null
+                      }
+                    ],
+                    "label": null,
+                    "comment": null
+                  }
+                }
+              ],
+              "label": null,
+              "comment": null
+            },
+            {
+              "_type": "ExpressionStatement",
+              "source_location": {
+                "file": "%DIR%/itxn-compose.algo.ts",
+                "line": 41,
+                "end_line": 43,
+                "column": 4,
+                "end_column": 6
+              },
+              "expr": {
+                "_type": "SetInnerTransactionFields",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 41,
+                  "end_line": 43,
+                  "column": 4,
+                  "end_column": 6
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "void",
+                  "immutable": true
+                },
+                "itxns": [
+                  {
+                    "_type": "CreateInnerTransaction",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 41,
+                      "end_line": 43,
+                      "column": 4,
+                      "end_column": 6
+                    },
+                    "wtype": {
+                      "_type": "WInnerTransactionFields",
+                      "name": "inner_transaction_fields_appl",
+                      "immutable": true,
+                      "transaction_type": 6
+                    },
+                    "fields": {
+                      "Fee": {
+                        "_type": "IntegerConstant",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 41,
+                          "end_line": 43,
+                          "column": 4,
+                          "end_column": 6
+                        },
+                        "wtype": {
+                          "_type": "WType",
+                          "name": "uint64",
+                          "immutable": true
+                        },
+                        "value": 0,
+                        "teal_alias": null
+                      },
+                      "TypeEnum": {
+                        "_type": "IntegerConstant",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 41,
+                          "end_line": 43,
+                          "column": 4,
+                          "end_column": 6
+                        },
+                        "wtype": {
+                          "_type": "WType",
+                          "name": "uint64",
+                          "immutable": true
+                        },
+                        "value": 6,
+                        "teal_alias": "appl"
+                      },
+                      "ApplicationID": {
+                        "_type": "VarExpression",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 42,
+                          "end_line": 42,
+                          "column": 13,
+                          "end_column": 21
+                        },
+                        "wtype": {
+                          "_type": "WType",
+                          "name": "application",
+                          "immutable": true
+                        },
+                        "name": "verifier"
+                      },
+                      "ApplicationArgs": {
+                        "_type": "TupleExpression",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 41,
+                          "end_line": 43,
+                          "column": 4,
+                          "end_column": 6
+                        },
+                        "wtype": {
+                          "_type": "WTuple",
+                          "name": "tuple",
+                          "immutable": true,
+                          "types": [
+                            {
+                              "_type": "BytesWType",
+                              "name": "bytes[4]",
+                              "immutable": true,
+                              "length": 4
+                            }
+                          ]
+                        },
+                        "items": [
+                          {
+                            "_type": "MethodConstant",
+                            "source_location": {
+                              "file": "%DIR%/itxn-compose.algo.ts",
+                              "line": 41,
+                              "end_line": 43,
+                              "column": 4,
+                              "end_column": 6
+                            },
+                            "wtype": {
+                              "_type": "BytesWType",
+                              "name": "bytes[4]",
+                              "immutable": true,
+                              "length": 4
+                            },
+                            "value": "verify()void"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ],
+                "start_with_begin": false
+              }
+            },
+            {
+              "_type": "ExpressionStatement",
+              "source_location": {
+                "file": "%DIR%/itxn-compose.algo.ts",
+                "line": 45,
+                "end_line": 49,
+                "column": 4,
+                "end_column": 5
+              },
+              "expr": {
+                "_type": "SetInnerTransactionFields",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 45,
+                  "end_line": 49,
+                  "column": 4,
+                  "end_column": 5
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "void",
+                  "immutable": true
+                },
+                "itxns": [
+                  {
+                    "_type": "CreateInnerTransaction",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 46,
+                      "end_line": 48,
+                      "column": 6,
+                      "end_column": 8
+                    },
+                    "wtype": {
+                      "_type": "WInnerTransactionFields",
+                      "name": "inner_transaction_fields_acfg",
+                      "immutable": true,
+                      "transaction_type": 3
+                    },
+                    "fields": {
+                      "Fee": {
+                        "_type": "IntegerConstant",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 46,
+                          "end_line": 48,
+                          "column": 6,
+                          "end_column": 8
+                        },
+                        "wtype": {
+                          "_type": "WType",
+                          "name": "uint64",
+                          "immutable": true
+                        },
+                        "value": 0,
+                        "teal_alias": null
+                      },
+                      "TypeEnum": {
+                        "_type": "IntegerConstant",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 46,
+                          "end_line": 48,
+                          "column": 6,
+                          "end_column": 8
+                        },
+                        "wtype": {
+                          "_type": "WType",
+                          "name": "uint64",
+                          "immutable": true
+                        },
+                        "value": 3,
+                        "teal_alias": null
+                      },
+                      "ConfigAssetName": {
+                        "_type": "BytesConstant",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 47,
+                          "end_line": 47,
+                          "column": 19,
+                          "end_column": 24
+                        },
+                        "wtype": {
+                          "_type": "BytesWType",
+                          "name": "bytes",
+                          "immutable": true,
+                          "length": null
+                        },
+                        "value": "VPaz",
+                        "encoding": "utf8"
+                      }
+                    }
+                  }
+                ],
+                "start_with_begin": false
+              }
+            },
+            {
+              "_type": "ExpressionStatement",
+              "source_location": {
+                "file": "%DIR%/itxn-compose.algo.ts",
+                "line": 51,
+                "end_line": 51,
+                "column": 4,
+                "end_column": 24
+              },
+              "expr": {
+                "_type": "IntrinsicCall",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 51,
+                  "end_line": 51,
+                  "column": 4,
+                  "end_column": 24
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "void",
+                  "immutable": true
+                },
+                "op_code": "itxn_submit",
+                "immediates": [],
+                "stack_args": []
+              }
+            }
+          ],
+          "label": null,
+          "comment": null
+        },
+        "documentation": {
+          "_type": "MethodDocumentation",
+          "description": null,
+          "args": {},
+          "returns": null
+        },
+        "inline": null,
+        "cref": "tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo",
+        "member_name": "distribute",
+        "arc4_method_config": {
+          "_type": "ARC4ABIMethodConfig",
+          "source_location": {
+            "file": "%DIR%/itxn-compose.algo.ts",
+            "line": 19,
+            "end_line": 19,
+            "column": 2,
+            "end_column": 81
+          },
+          "allowed_completion_types": [
+            0
+          ],
+          "create": 3,
+          "name": "distribute",
+          "readonly": false,
+          "default_args": {}
+        }
+      },
+      {
+        "_type": "ContractMethod",
+        "source_location": {
+          "file": "%DIR%/itxn-compose.algo.ts",
+          "line": 53,
+          "end_line": 53,
+          "column": 2,
+          "end_column": 33
+        },
+        "args": [
+          {
+            "_type": "SubroutineArgument",
+            "name": "count",
+            "source_location": {
+              "file": "%DIR%/itxn-compose.algo.ts",
+              "line": 53,
+              "end_line": 53,
+              "column": 19,
+              "end_column": 32
+            },
+            "wtype": {
+              "_type": "WType",
+              "name": "uint64",
+              "immutable": true
+            }
+          }
+        ],
+        "return_type": {
+          "_type": "WType",
+          "name": "void",
+          "immutable": true
+        },
+        "body": {
+          "_type": "Block",
+          "source_location": {
+            "file": "%DIR%/itxn-compose.algo.ts",
+            "line": 53,
+            "end_line": 65,
+            "column": 34,
+            "end_column": 3
+          },
+          "body": [
+            {
+              "_type": "AssignmentStatement",
+              "source_location": {
+                "file": "%DIR%/itxn-compose.algo.ts",
+                "line": 54,
+                "end_line": 54,
+                "column": 10,
+                "end_column": 36
+              },
+              "target": {
+                "_type": "VarExpression",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 54,
+                  "end_line": 54,
+                  "column": 10,
+                  "end_column": 15
+                },
+                "wtype": {
+                  "_type": "WTuple",
+                  "name": "@algorandfoundation/algorand-typescript/compiled.d.ts::CompiledContract",
+                  "immutable": true,
+                  "types": [
+                    {
+                      "_type": "WTuple",
+                      "name": "tuple",
+                      "immutable": true,
+                      "types": [
+                        {
+                          "_type": "BytesWType",
+                          "name": "bytes",
+                          "immutable": true,
+                          "length": null
+                        },
+                        {
+                          "_type": "BytesWType",
+                          "name": "bytes",
+                          "immutable": true,
+                          "length": null
+                        }
+                      ]
+                    },
+                    {
+                      "_type": "WTuple",
+                      "name": "tuple",
+                      "immutable": true,
+                      "types": [
+                        {
+                          "_type": "BytesWType",
+                          "name": "bytes",
+                          "immutable": true,
+                          "length": null
+                        },
+                        {
+                          "_type": "BytesWType",
+                          "name": "bytes",
+                          "immutable": true,
+                          "length": null
+                        }
+                      ]
+                    },
+                    {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    }
+                  ],
+                  "names": [
+                    "approvalProgram",
+                    "clearStateProgram",
+                    "extraProgramPages",
+                    "globalUints",
+                    "globalBytes",
+                    "localUints",
+                    "localBytes"
+                  ]
+                },
+                "name": "hello"
+              },
+              "value": {
+                "_type": "CompiledContract",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 54,
+                  "end_line": 54,
+                  "column": 18,
+                  "end_column": 36
+                },
+                "wtype": {
+                  "_type": "WTuple",
+                  "name": "@algorandfoundation/algorand-typescript/compiled.d.ts::CompiledContract",
+                  "immutable": true,
+                  "types": [
+                    {
+                      "_type": "WTuple",
+                      "name": "tuple",
+                      "immutable": true,
+                      "types": [
+                        {
+                          "_type": "BytesWType",
+                          "name": "bytes",
+                          "immutable": true,
+                          "length": null
+                        },
+                        {
+                          "_type": "BytesWType",
+                          "name": "bytes",
+                          "immutable": true,
+                          "length": null
+                        }
+                      ]
+                    },
+                    {
+                      "_type": "WTuple",
+                      "name": "tuple",
+                      "immutable": true,
+                      "types": [
+                        {
+                          "_type": "BytesWType",
+                          "name": "bytes",
+                          "immutable": true,
+                          "length": null
+                        },
+                        {
+                          "_type": "BytesWType",
+                          "name": "bytes",
+                          "immutable": true,
+                          "length": null
+                        }
+                      ]
+                    },
+                    {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    }
+                  ],
+                  "names": [
+                    "approvalProgram",
+                    "clearStateProgram",
+                    "extraProgramPages",
+                    "globalUints",
+                    "globalBytes",
+                    "localUints",
+                    "localBytes"
+                  ]
+                },
+                "contract": "tests/approvals/precompiled-apps.algo.ts::Hello",
+                "allocation_overrides": {},
+                "prefix": null,
+                "template_variables": {}
+              }
+            },
+            {
+              "_type": "AssignmentStatement",
+              "source_location": {
+                "file": "%DIR%/itxn-compose.algo.ts",
+                "line": 55,
+                "end_line": 55,
+                "column": 10,
+                "end_column": 69
+              },
+              "target": {
+                "_type": "VarExpression",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 55,
+                  "end_line": 55,
+                  "column": 10,
+                  "end_column": 15
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "application",
+                  "immutable": true
+                },
+                "name": "appId"
+              },
+              "value": {
+                "_type": "InnerTransactionField",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 55,
+                  "end_line": 55,
+                  "column": 59,
+                  "end_column": 69
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "application",
+                  "immutable": true
+                },
+                "itxn": {
+                  "_type": "FieldExpression",
+                  "source_location": {
+                    "file": "%DIR%/itxn-compose.algo.ts",
+                    "line": 55,
+                    "end_line": 55,
+                    "column": 54,
+                    "end_column": 58
+                  },
+                  "wtype": {
+                    "_type": "WInnerTransaction",
+                    "name": "inner_transaction_appl",
+                    "immutable": true,
+                    "transaction_type": 6
+                  },
+                  "base": {
+                    "_type": "TupleExpression",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 55,
+                      "end_line": 55,
+                      "column": 18,
+                      "end_column": 53
+                    },
+                    "wtype": {
+                      "_type": "WTuple",
+                      "name": "@algorandfoundation/algorand-typescript/arc4/c2c.d.ts::TypedApplicationCallResponseType<void>",
+                      "immutable": true,
+                      "types": [
+                        {
+                          "_type": "WInnerTransaction",
+                          "name": "inner_transaction_appl",
+                          "immutable": true,
+                          "transaction_type": 6
+                        }
+                      ],
+                      "names": [
+                        "itxn"
+                      ]
+                    },
+                    "items": [
+                      {
+                        "_type": "SubmitInnerTransaction",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 55,
+                          "end_line": 55,
+                          "column": 18,
+                          "end_column": 53
+                        },
+                        "wtype": {
+                          "_type": "WInnerTransaction",
+                          "name": "inner_transaction_appl",
+                          "immutable": true,
+                          "transaction_type": 6
+                        },
+                        "itxns": [
+                          {
+                            "_type": "CreateInnerTransaction",
+                            "source_location": {
+                              "file": "%DIR%/itxn-compose.algo.ts",
+                              "line": 55,
+                              "end_line": 55,
+                              "column": 18,
+                              "end_column": 53
+                            },
+                            "wtype": {
+                              "_type": "WInnerTransactionFields",
+                              "name": "inner_transaction_fields_appl",
+                              "immutable": true,
+                              "transaction_type": 6
+                            },
+                            "fields": {
+                              "Fee": {
+                                "_type": "IntegerConstant",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 55,
+                                  "end_line": 55,
+                                  "column": 18,
+                                  "end_column": 53
+                                },
+                                "wtype": {
+                                  "_type": "WType",
+                                  "name": "uint64",
+                                  "immutable": true
+                                },
+                                "value": 0,
+                                "teal_alias": null
+                              },
+                              "TypeEnum": {
+                                "_type": "IntegerConstant",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 55,
+                                  "end_line": 55,
+                                  "column": 18,
+                                  "end_column": 53
+                                },
+                                "wtype": {
+                                  "_type": "WType",
+                                  "name": "uint64",
+                                  "immutable": true
+                                },
+                                "value": 6,
+                                "teal_alias": "appl"
+                              },
+                              "OnCompletion": {
+                                "_type": "IntegerConstant",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 55,
+                                  "end_line": 55,
+                                  "column": 18,
+                                  "end_column": 53
+                                },
+                                "wtype": {
+                                  "_type": "WType",
+                                  "name": "uint64",
+                                  "immutable": true
+                                },
+                                "value": 0,
+                                "teal_alias": null
+                              },
+                              "ApprovalProgramPages": {
+                                "_type": "FieldExpression",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 55,
+                                  "end_line": 55,
+                                  "column": 18,
+                                  "end_column": 53
+                                },
+                                "wtype": {
+                                  "_type": "WTuple",
+                                  "name": "tuple",
+                                  "immutable": true,
+                                  "types": [
+                                    {
+                                      "_type": "BytesWType",
+                                      "name": "bytes",
+                                      "immutable": true,
+                                      "length": null
+                                    },
+                                    {
+                                      "_type": "BytesWType",
+                                      "name": "bytes",
+                                      "immutable": true,
+                                      "length": null
+                                    }
+                                  ]
+                                },
+                                "base": {
+                                  "_type": "VarExpression",
+                                  "source_location": {
+                                    "file": "%DIR%/itxn-compose.algo.ts",
+                                    "line": 55,
+                                    "end_line": 55,
+                                    "column": 18,
+                                    "end_column": 23
+                                  },
+                                  "wtype": {
+                                    "_type": "WTuple",
+                                    "name": "@algorandfoundation/algorand-typescript/compiled.d.ts::CompiledContract",
+                                    "immutable": true,
+                                    "types": [
+                                      {
+                                        "_type": "WTuple",
+                                        "name": "tuple",
+                                        "immutable": true,
+                                        "types": [
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          },
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "WTuple",
+                                        "name": "tuple",
+                                        "immutable": true,
+                                        "types": [
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          },
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      }
+                                    ],
+                                    "names": [
+                                      "approvalProgram",
+                                      "clearStateProgram",
+                                      "extraProgramPages",
+                                      "globalUints",
+                                      "globalBytes",
+                                      "localUints",
+                                      "localBytes"
+                                    ]
+                                  },
+                                  "name": "hello"
+                                },
+                                "name": "approvalProgram"
+                              },
+                              "ClearStateProgramPages": {
+                                "_type": "FieldExpression",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 55,
+                                  "end_line": 55,
+                                  "column": 18,
+                                  "end_column": 53
+                                },
+                                "wtype": {
+                                  "_type": "WTuple",
+                                  "name": "tuple",
+                                  "immutable": true,
+                                  "types": [
+                                    {
+                                      "_type": "BytesWType",
+                                      "name": "bytes",
+                                      "immutable": true,
+                                      "length": null
+                                    },
+                                    {
+                                      "_type": "BytesWType",
+                                      "name": "bytes",
+                                      "immutable": true,
+                                      "length": null
+                                    }
+                                  ]
+                                },
+                                "base": {
+                                  "_type": "VarExpression",
+                                  "source_location": {
+                                    "file": "%DIR%/itxn-compose.algo.ts",
+                                    "line": 55,
+                                    "end_line": 55,
+                                    "column": 18,
+                                    "end_column": 23
+                                  },
+                                  "wtype": {
+                                    "_type": "WTuple",
+                                    "name": "@algorandfoundation/algorand-typescript/compiled.d.ts::CompiledContract",
+                                    "immutable": true,
+                                    "types": [
+                                      {
+                                        "_type": "WTuple",
+                                        "name": "tuple",
+                                        "immutable": true,
+                                        "types": [
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          },
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "WTuple",
+                                        "name": "tuple",
+                                        "immutable": true,
+                                        "types": [
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          },
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      }
+                                    ],
+                                    "names": [
+                                      "approvalProgram",
+                                      "clearStateProgram",
+                                      "extraProgramPages",
+                                      "globalUints",
+                                      "globalBytes",
+                                      "localUints",
+                                      "localBytes"
+                                    ]
+                                  },
+                                  "name": "hello"
+                                },
+                                "name": "clearStateProgram"
+                              },
+                              "GlobalNumUint": {
+                                "_type": "FieldExpression",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 55,
+                                  "end_line": 55,
+                                  "column": 18,
+                                  "end_column": 53
+                                },
+                                "wtype": {
+                                  "_type": "WType",
+                                  "name": "uint64",
+                                  "immutable": true
+                                },
+                                "base": {
+                                  "_type": "VarExpression",
+                                  "source_location": {
+                                    "file": "%DIR%/itxn-compose.algo.ts",
+                                    "line": 55,
+                                    "end_line": 55,
+                                    "column": 18,
+                                    "end_column": 23
+                                  },
+                                  "wtype": {
+                                    "_type": "WTuple",
+                                    "name": "@algorandfoundation/algorand-typescript/compiled.d.ts::CompiledContract",
+                                    "immutable": true,
+                                    "types": [
+                                      {
+                                        "_type": "WTuple",
+                                        "name": "tuple",
+                                        "immutable": true,
+                                        "types": [
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          },
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "WTuple",
+                                        "name": "tuple",
+                                        "immutable": true,
+                                        "types": [
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          },
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      }
+                                    ],
+                                    "names": [
+                                      "approvalProgram",
+                                      "clearStateProgram",
+                                      "extraProgramPages",
+                                      "globalUints",
+                                      "globalBytes",
+                                      "localUints",
+                                      "localBytes"
+                                    ]
+                                  },
+                                  "name": "hello"
+                                },
+                                "name": "globalUints"
+                              },
+                              "GlobalNumByteSlice": {
+                                "_type": "FieldExpression",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 55,
+                                  "end_line": 55,
+                                  "column": 18,
+                                  "end_column": 53
+                                },
+                                "wtype": {
+                                  "_type": "WType",
+                                  "name": "uint64",
+                                  "immutable": true
+                                },
+                                "base": {
+                                  "_type": "VarExpression",
+                                  "source_location": {
+                                    "file": "%DIR%/itxn-compose.algo.ts",
+                                    "line": 55,
+                                    "end_line": 55,
+                                    "column": 18,
+                                    "end_column": 23
+                                  },
+                                  "wtype": {
+                                    "_type": "WTuple",
+                                    "name": "@algorandfoundation/algorand-typescript/compiled.d.ts::CompiledContract",
+                                    "immutable": true,
+                                    "types": [
+                                      {
+                                        "_type": "WTuple",
+                                        "name": "tuple",
+                                        "immutable": true,
+                                        "types": [
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          },
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "WTuple",
+                                        "name": "tuple",
+                                        "immutable": true,
+                                        "types": [
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          },
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      }
+                                    ],
+                                    "names": [
+                                      "approvalProgram",
+                                      "clearStateProgram",
+                                      "extraProgramPages",
+                                      "globalUints",
+                                      "globalBytes",
+                                      "localUints",
+                                      "localBytes"
+                                    ]
+                                  },
+                                  "name": "hello"
+                                },
+                                "name": "globalBytes"
+                              },
+                              "LocalNumByteSlice": {
+                                "_type": "FieldExpression",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 55,
+                                  "end_line": 55,
+                                  "column": 18,
+                                  "end_column": 53
+                                },
+                                "wtype": {
+                                  "_type": "WType",
+                                  "name": "uint64",
+                                  "immutable": true
+                                },
+                                "base": {
+                                  "_type": "VarExpression",
+                                  "source_location": {
+                                    "file": "%DIR%/itxn-compose.algo.ts",
+                                    "line": 55,
+                                    "end_line": 55,
+                                    "column": 18,
+                                    "end_column": 23
+                                  },
+                                  "wtype": {
+                                    "_type": "WTuple",
+                                    "name": "@algorandfoundation/algorand-typescript/compiled.d.ts::CompiledContract",
+                                    "immutable": true,
+                                    "types": [
+                                      {
+                                        "_type": "WTuple",
+                                        "name": "tuple",
+                                        "immutable": true,
+                                        "types": [
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          },
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "WTuple",
+                                        "name": "tuple",
+                                        "immutable": true,
+                                        "types": [
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          },
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      }
+                                    ],
+                                    "names": [
+                                      "approvalProgram",
+                                      "clearStateProgram",
+                                      "extraProgramPages",
+                                      "globalUints",
+                                      "globalBytes",
+                                      "localUints",
+                                      "localBytes"
+                                    ]
+                                  },
+                                  "name": "hello"
+                                },
+                                "name": "localBytes"
+                              },
+                              "LocalNumUint": {
+                                "_type": "FieldExpression",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 55,
+                                  "end_line": 55,
+                                  "column": 18,
+                                  "end_column": 53
+                                },
+                                "wtype": {
+                                  "_type": "WType",
+                                  "name": "uint64",
+                                  "immutable": true
+                                },
+                                "base": {
+                                  "_type": "VarExpression",
+                                  "source_location": {
+                                    "file": "%DIR%/itxn-compose.algo.ts",
+                                    "line": 55,
+                                    "end_line": 55,
+                                    "column": 18,
+                                    "end_column": 23
+                                  },
+                                  "wtype": {
+                                    "_type": "WTuple",
+                                    "name": "@algorandfoundation/algorand-typescript/compiled.d.ts::CompiledContract",
+                                    "immutable": true,
+                                    "types": [
+                                      {
+                                        "_type": "WTuple",
+                                        "name": "tuple",
+                                        "immutable": true,
+                                        "types": [
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          },
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "WTuple",
+                                        "name": "tuple",
+                                        "immutable": true,
+                                        "types": [
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          },
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      }
+                                    ],
+                                    "names": [
+                                      "approvalProgram",
+                                      "clearStateProgram",
+                                      "extraProgramPages",
+                                      "globalUints",
+                                      "globalBytes",
+                                      "localUints",
+                                      "localBytes"
+                                    ]
+                                  },
+                                  "name": "hello"
+                                },
+                                "name": "localUints"
+                              },
+                              "ExtraProgramPages": {
+                                "_type": "FieldExpression",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 55,
+                                  "end_line": 55,
+                                  "column": 18,
+                                  "end_column": 53
+                                },
+                                "wtype": {
+                                  "_type": "WType",
+                                  "name": "uint64",
+                                  "immutable": true
+                                },
+                                "base": {
+                                  "_type": "VarExpression",
+                                  "source_location": {
+                                    "file": "%DIR%/itxn-compose.algo.ts",
+                                    "line": 55,
+                                    "end_line": 55,
+                                    "column": 18,
+                                    "end_column": 23
+                                  },
+                                  "wtype": {
+                                    "_type": "WTuple",
+                                    "name": "@algorandfoundation/algorand-typescript/compiled.d.ts::CompiledContract",
+                                    "immutable": true,
+                                    "types": [
+                                      {
+                                        "_type": "WTuple",
+                                        "name": "tuple",
+                                        "immutable": true,
+                                        "types": [
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          },
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "WTuple",
+                                        "name": "tuple",
+                                        "immutable": true,
+                                        "types": [
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          },
+                                          {
+                                            "_type": "BytesWType",
+                                            "name": "bytes",
+                                            "immutable": true,
+                                            "length": null
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      },
+                                      {
+                                        "_type": "WType",
+                                        "name": "uint64",
+                                        "immutable": true
+                                      }
+                                    ],
+                                    "names": [
+                                      "approvalProgram",
+                                      "clearStateProgram",
+                                      "extraProgramPages",
+                                      "globalUints",
+                                      "globalBytes",
+                                      "localUints",
+                                      "localBytes"
+                                    ]
+                                  },
+                                  "name": "hello"
+                                },
+                                "name": "extraProgramPages"
+                              },
+                              "ApplicationArgs": {
+                                "_type": "TupleExpression",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 55,
+                                  "end_line": 55,
+                                  "column": 18,
+                                  "end_column": 53
+                                },
+                                "wtype": {
+                                  "_type": "WTuple",
+                                  "name": "tuple",
+                                  "immutable": true,
+                                  "types": [
+                                    {
+                                      "_type": "BytesWType",
+                                      "name": "bytes[4]",
+                                      "immutable": true,
+                                      "length": 4
+                                    },
+                                    {
+                                      "_type": "ARC4DynamicArray",
+                                      "name": "arc4.dynamic_array<arc4.byte>",
+                                      "immutable": true,
+                                      "arc4_alias": "string",
+                                      "element_type": {
+                                        "_type": "ARC4UIntN",
+                                        "name": "arc4.byte",
+                                        "immutable": true,
+                                        "arc4_alias": "byte",
+                                        "n": 8
+                                      },
+                                      "source_location": null
+                                    }
+                                  ]
+                                },
+                                "items": [
+                                  {
+                                    "_type": "MethodConstant",
+                                    "source_location": {
+                                      "file": "%DIR%/itxn-compose.algo.ts",
+                                      "line": 55,
+                                      "end_line": 55,
+                                      "column": 18,
+                                      "end_column": 53
+                                    },
+                                    "wtype": {
+                                      "_type": "BytesWType",
+                                      "name": "bytes[4]",
+                                      "immutable": true,
+                                      "length": 4
+                                    },
+                                    "value": "helloCreate(string)void"
+                                  },
+                                  {
+                                    "_type": "ARC4Encode",
+                                    "source_location": {
+                                      "file": "%DIR%/itxn-compose.algo.ts",
+                                      "line": 55,
+                                      "end_line": 55,
+                                      "column": 45,
+                                      "end_column": 49
+                                    },
+                                    "wtype": {
+                                      "_type": "ARC4DynamicArray",
+                                      "name": "arc4.dynamic_array<arc4.byte>",
+                                      "immutable": true,
+                                      "arc4_alias": "string",
+                                      "element_type": {
+                                        "_type": "ARC4UIntN",
+                                        "name": "arc4.byte",
+                                        "immutable": true,
+                                        "arc4_alias": "byte",
+                                        "n": 8
+                                      },
+                                      "source_location": null
+                                    },
+                                    "value": {
+                                      "_type": "StringConstant",
+                                      "source_location": {
+                                        "file": "%DIR%/itxn-compose.algo.ts",
+                                        "line": 55,
+                                        "end_line": 55,
+                                        "column": 45,
+                                        "end_column": 49
+                                      },
+                                      "wtype": {
+                                        "_type": "WType",
+                                        "name": "string",
+                                        "immutable": true
+                                      },
+                                      "value": "Hi"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "name": "itxn"
+                },
+                "field": "CreatedApplicationID",
+                "array_index": null
+              }
+            },
+            {
+              "_type": "Block",
+              "source_location": {
+                "file": "%DIR%/itxn-compose.algo.ts",
+                "line": 57,
+                "end_line": 57,
+                "column": 4,
+                "end_column": 34
+              },
+              "body": [
+                {
+                  "_type": "ForInLoop",
+                  "source_location": {
+                    "file": "%DIR%/itxn-compose.algo.ts",
+                    "line": 57,
+                    "end_line": 57,
+                    "column": 4,
+                    "end_column": 34
+                  },
+                  "sequence": {
+                    "_type": "Range",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 57,
+                      "end_line": 57,
+                      "column": 20,
+                      "end_column": 33
+                    },
+                    "wtype": {
+                      "_type": "WType",
+                      "name": "uint64_range",
+                      "immutable": true
+                    },
+                    "start": {
+                      "_type": "IntegerConstant",
+                      "source_location": {
+                        "file": "%DIR%/itxn-compose.algo.ts",
+                        "line": 57,
+                        "end_line": 57,
+                        "column": 20,
+                        "end_column": 33
+                      },
+                      "wtype": {
+                        "_type": "WType",
+                        "name": "uint64",
+                        "immutable": true
+                      },
+                      "value": 0,
+                      "teal_alias": null
+                    },
+                    "stop": {
+                      "_type": "VarExpression",
+                      "source_location": {
+                        "file": "%DIR%/itxn-compose.algo.ts",
+                        "line": 57,
+                        "end_line": 57,
+                        "column": 27,
+                        "end_column": 32
+                      },
+                      "wtype": {
+                        "_type": "WType",
+                        "name": "uint64",
+                        "immutable": true
+                      },
+                      "name": "count"
+                    },
+                    "step": {
+                      "_type": "IntegerConstant",
+                      "source_location": {
+                        "file": "%DIR%/itxn-compose.algo.ts",
+                        "line": 57,
+                        "end_line": 57,
+                        "column": 20,
+                        "end_column": 33
+                      },
+                      "wtype": {
+                        "_type": "WType",
+                        "name": "uint64",
+                        "immutable": true
+                      },
+                      "value": 1,
+                      "teal_alias": null
+                    }
+                  },
+                  "items": {
+                    "_type": "VarExpression",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 57,
+                      "end_line": 57,
+                      "column": 15,
+                      "end_column": 16
+                    },
+                    "wtype": {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true
+                    },
+                    "name": "i"
+                  },
+                  "loop_body": {
+                    "_type": "Block",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 57,
+                      "end_line": 57,
+                      "column": 4,
+                      "end_column": 34
+                    },
+                    "body": [
+                      {
+                        "_type": "Block",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 57,
+                          "end_line": 63,
+                          "column": 35,
+                          "end_column": 5
+                        },
+                        "body": [
+                          {
+                            "_type": "IfElse",
+                            "source_location": {
+                              "file": "%DIR%/itxn-compose.algo.ts",
+                              "line": 58,
+                              "end_line": 58,
+                              "column": 6,
+                              "end_column": 18
+                            },
+                            "condition": {
+                              "_type": "NumericComparisonExpression",
+                              "source_location": {
+                                "file": "%DIR%/itxn-compose.algo.ts",
+                                "line": 58,
+                                "end_line": 58,
+                                "column": 10,
+                                "end_column": 17
+                              },
+                              "wtype": {
+                                "_type": "WType",
+                                "name": "bool",
+                                "immutable": true
+                              },
+                              "lhs": {
+                                "_type": "VarExpression",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 58,
+                                  "end_line": 58,
+                                  "column": 10,
+                                  "end_column": 11
+                                },
+                                "wtype": {
+                                  "_type": "WType",
+                                  "name": "uint64",
+                                  "immutable": true
+                                },
+                                "name": "i"
+                              },
+                              "operator": "==",
+                              "rhs": {
+                                "_type": "IntegerConstant",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 58,
+                                  "end_line": 58,
+                                  "column": 16,
+                                  "end_column": 17
+                                },
+                                "wtype": {
+                                  "_type": "WType",
+                                  "name": "uint64",
+                                  "immutable": true
+                                },
+                                "value": 0,
+                                "teal_alias": null
+                              }
+                            },
+                            "if_branch": {
+                              "_type": "Block",
+                              "source_location": {
+                                "file": "%DIR%/itxn-compose.algo.ts",
+                                "line": 58,
+                                "end_line": 60,
+                                "column": 19,
+                                "end_column": 7
+                              },
+                              "body": [
+                                {
+                                  "_type": "Block",
+                                  "source_location": {
+                                    "file": "%DIR%/itxn-compose.algo.ts",
+                                    "line": 58,
+                                    "end_line": 60,
+                                    "column": 19,
+                                    "end_column": 7
+                                  },
+                                  "body": [
+                                    {
+                                      "_type": "ExpressionStatement",
+                                      "source_location": {
+                                        "file": "%DIR%/itxn-compose.algo.ts",
+                                        "line": 59,
+                                        "end_line": 59,
+                                        "column": 8,
+                                        "end_column": 73
+                                      },
+                                      "expr": {
+                                        "_type": "SetInnerTransactionFields",
+                                        "source_location": {
+                                          "file": "%DIR%/itxn-compose.algo.ts",
+                                          "line": 59,
+                                          "end_line": 59,
+                                          "column": 8,
+                                          "end_column": 73
+                                        },
+                                        "wtype": {
+                                          "_type": "WType",
+                                          "name": "void",
+                                          "immutable": true
+                                        },
+                                        "itxns": [
+                                          {
+                                            "_type": "CreateInnerTransaction",
+                                            "source_location": {
+                                              "file": "%DIR%/itxn-compose.algo.ts",
+                                              "line": 59,
+                                              "end_line": 59,
+                                              "column": 8,
+                                              "end_column": 73
+                                            },
+                                            "wtype": {
+                                              "_type": "WInnerTransactionFields",
+                                              "name": "inner_transaction_fields_appl",
+                                              "immutable": true,
+                                              "transaction_type": 6
+                                            },
+                                            "fields": {
+                                              "Fee": {
+                                                "_type": "IntegerConstant",
+                                                "source_location": {
+                                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                                  "line": 59,
+                                                  "end_line": 59,
+                                                  "column": 8,
+                                                  "end_column": 73
+                                                },
+                                                "wtype": {
+                                                  "_type": "WType",
+                                                  "name": "uint64",
+                                                  "immutable": true
+                                                },
+                                                "value": 0,
+                                                "teal_alias": null
+                                              },
+                                              "TypeEnum": {
+                                                "_type": "IntegerConstant",
+                                                "source_location": {
+                                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                                  "line": 59,
+                                                  "end_line": 59,
+                                                  "column": 8,
+                                                  "end_column": 73
+                                                },
+                                                "wtype": {
+                                                  "_type": "WType",
+                                                  "name": "uint64",
+                                                  "immutable": true
+                                                },
+                                                "value": 6,
+                                                "teal_alias": "appl"
+                                              },
+                                              "ApplicationID": {
+                                                "_type": "VarExpression",
+                                                "source_location": {
+                                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                                  "line": 59,
+                                                  "end_line": 59,
+                                                  "column": 51,
+                                                  "end_column": 56
+                                                },
+                                                "wtype": {
+                                                  "_type": "WType",
+                                                  "name": "application",
+                                                  "immutable": true
+                                                },
+                                                "name": "appId"
+                                              },
+                                              "ApplicationArgs": {
+                                                "_type": "TupleExpression",
+                                                "source_location": {
+                                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                                  "line": 59,
+                                                  "end_line": 59,
+                                                  "column": 8,
+                                                  "end_column": 73
+                                                },
+                                                "wtype": {
+                                                  "_type": "WTuple",
+                                                  "name": "tuple",
+                                                  "immutable": true,
+                                                  "types": [
+                                                    {
+                                                      "_type": "BytesWType",
+                                                      "name": "bytes[4]",
+                                                      "immutable": true,
+                                                      "length": 4
+                                                    },
+                                                    {
+                                                      "_type": "ARC4DynamicArray",
+                                                      "name": "arc4.dynamic_array<arc4.byte>",
+                                                      "immutable": true,
+                                                      "arc4_alias": "string",
+                                                      "element_type": {
+                                                        "_type": "ARC4UIntN",
+                                                        "name": "arc4.byte",
+                                                        "immutable": true,
+                                                        "arc4_alias": "byte",
+                                                        "n": 8
+                                                      },
+                                                      "source_location": null
+                                                    }
+                                                  ]
+                                                },
+                                                "items": [
+                                                  {
+                                                    "_type": "MethodConstant",
+                                                    "source_location": {
+                                                      "file": "%DIR%/itxn-compose.algo.ts",
+                                                      "line": 59,
+                                                      "end_line": 59,
+                                                      "column": 8,
+                                                      "end_column": 73
+                                                    },
+                                                    "wtype": {
+                                                      "_type": "BytesWType",
+                                                      "name": "bytes[4]",
+                                                      "immutable": true,
+                                                      "length": 4
+                                                    },
+                                                    "value": "greet(string)string"
+                                                  },
+                                                  {
+                                                    "_type": "ARC4Encode",
+                                                    "source_location": {
+                                                      "file": "%DIR%/itxn-compose.algo.ts",
+                                                      "line": 59,
+                                                      "end_line": 59,
+                                                      "column": 65,
+                                                      "end_column": 69
+                                                    },
+                                                    "wtype": {
+                                                      "_type": "ARC4DynamicArray",
+                                                      "name": "arc4.dynamic_array<arc4.byte>",
+                                                      "immutable": true,
+                                                      "arc4_alias": "string",
+                                                      "element_type": {
+                                                        "_type": "ARC4UIntN",
+                                                        "name": "arc4.byte",
+                                                        "immutable": true,
+                                                        "arc4_alias": "byte",
+                                                        "n": 8
+                                                      },
+                                                      "source_location": null
+                                                    },
+                                                    "value": {
+                                                      "_type": "StringConstant",
+                                                      "source_location": {
+                                                        "file": "%DIR%/itxn-compose.algo.ts",
+                                                        "line": 59,
+                                                        "end_line": 59,
+                                                        "column": 65,
+                                                        "end_column": 69
+                                                      },
+                                                      "wtype": {
+                                                        "_type": "WType",
+                                                        "name": "string",
+                                                        "immutable": true
+                                                      },
+                                                      "value": "ho"
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "start_with_begin": true
+                                      }
+                                    }
+                                  ],
+                                  "label": null,
+                                  "comment": null
+                                }
+                              ],
+                              "label": null,
+                              "comment": null
+                            },
+                            "else_branch": {
+                              "_type": "Block",
+                              "source_location": {
+                                "file": "%DIR%/itxn-compose.algo.ts",
+                                "line": 60,
+                                "end_line": 62,
+                                "column": 13,
+                                "end_column": 7
+                              },
+                              "body": [
+                                {
+                                  "_type": "Block",
+                                  "source_location": {
+                                    "file": "%DIR%/itxn-compose.algo.ts",
+                                    "line": 60,
+                                    "end_line": 62,
+                                    "column": 13,
+                                    "end_column": 7
+                                  },
+                                  "body": [
+                                    {
+                                      "_type": "ExpressionStatement",
+                                      "source_location": {
+                                        "file": "%DIR%/itxn-compose.algo.ts",
+                                        "line": 61,
+                                        "end_line": 61,
+                                        "column": 8,
+                                        "end_column": 72
+                                      },
+                                      "expr": {
+                                        "_type": "SetInnerTransactionFields",
+                                        "source_location": {
+                                          "file": "%DIR%/itxn-compose.algo.ts",
+                                          "line": 61,
+                                          "end_line": 61,
+                                          "column": 8,
+                                          "end_column": 72
+                                        },
+                                        "wtype": {
+                                          "_type": "WType",
+                                          "name": "void",
+                                          "immutable": true
+                                        },
+                                        "itxns": [
+                                          {
+                                            "_type": "CreateInnerTransaction",
+                                            "source_location": {
+                                              "file": "%DIR%/itxn-compose.algo.ts",
+                                              "line": 61,
+                                              "end_line": 61,
+                                              "column": 8,
+                                              "end_column": 72
+                                            },
+                                            "wtype": {
+                                              "_type": "WInnerTransactionFields",
+                                              "name": "inner_transaction_fields_appl",
+                                              "immutable": true,
+                                              "transaction_type": 6
+                                            },
+                                            "fields": {
+                                              "Fee": {
+                                                "_type": "IntegerConstant",
+                                                "source_location": {
+                                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                                  "line": 61,
+                                                  "end_line": 61,
+                                                  "column": 8,
+                                                  "end_column": 72
+                                                },
+                                                "wtype": {
+                                                  "_type": "WType",
+                                                  "name": "uint64",
+                                                  "immutable": true
+                                                },
+                                                "value": 0,
+                                                "teal_alias": null
+                                              },
+                                              "TypeEnum": {
+                                                "_type": "IntegerConstant",
+                                                "source_location": {
+                                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                                  "line": 61,
+                                                  "end_line": 61,
+                                                  "column": 8,
+                                                  "end_column": 72
+                                                },
+                                                "wtype": {
+                                                  "_type": "WType",
+                                                  "name": "uint64",
+                                                  "immutable": true
+                                                },
+                                                "value": 6,
+                                                "teal_alias": "appl"
+                                              },
+                                              "ApplicationID": {
+                                                "_type": "VarExpression",
+                                                "source_location": {
+                                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                                  "line": 61,
+                                                  "end_line": 61,
+                                                  "column": 50,
+                                                  "end_column": 55
+                                                },
+                                                "wtype": {
+                                                  "_type": "WType",
+                                                  "name": "application",
+                                                  "immutable": true
+                                                },
+                                                "name": "appId"
+                                              },
+                                              "ApplicationArgs": {
+                                                "_type": "TupleExpression",
+                                                "source_location": {
+                                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                                  "line": 61,
+                                                  "end_line": 61,
+                                                  "column": 8,
+                                                  "end_column": 72
+                                                },
+                                                "wtype": {
+                                                  "_type": "WTuple",
+                                                  "name": "tuple",
+                                                  "immutable": true,
+                                                  "types": [
+                                                    {
+                                                      "_type": "BytesWType",
+                                                      "name": "bytes[4]",
+                                                      "immutable": true,
+                                                      "length": 4
+                                                    },
+                                                    {
+                                                      "_type": "ARC4DynamicArray",
+                                                      "name": "arc4.dynamic_array<arc4.byte>",
+                                                      "immutable": true,
+                                                      "arc4_alias": "string",
+                                                      "element_type": {
+                                                        "_type": "ARC4UIntN",
+                                                        "name": "arc4.byte",
+                                                        "immutable": true,
+                                                        "arc4_alias": "byte",
+                                                        "n": 8
+                                                      },
+                                                      "source_location": null
+                                                    }
+                                                  ]
+                                                },
+                                                "items": [
+                                                  {
+                                                    "_type": "MethodConstant",
+                                                    "source_location": {
+                                                      "file": "%DIR%/itxn-compose.algo.ts",
+                                                      "line": 61,
+                                                      "end_line": 61,
+                                                      "column": 8,
+                                                      "end_column": 72
+                                                    },
+                                                    "wtype": {
+                                                      "_type": "BytesWType",
+                                                      "name": "bytes[4]",
+                                                      "immutable": true,
+                                                      "length": 4
+                                                    },
+                                                    "value": "greet(string)string"
+                                                  },
+                                                  {
+                                                    "_type": "ARC4Encode",
+                                                    "source_location": {
+                                                      "file": "%DIR%/itxn-compose.algo.ts",
+                                                      "line": 61,
+                                                      "end_line": 61,
+                                                      "column": 64,
+                                                      "end_column": 68
+                                                    },
+                                                    "wtype": {
+                                                      "_type": "ARC4DynamicArray",
+                                                      "name": "arc4.dynamic_array<arc4.byte>",
+                                                      "immutable": true,
+                                                      "arc4_alias": "string",
+                                                      "element_type": {
+                                                        "_type": "ARC4UIntN",
+                                                        "name": "arc4.byte",
+                                                        "immutable": true,
+                                                        "arc4_alias": "byte",
+                                                        "n": 8
+                                                      },
+                                                      "source_location": null
+                                                    },
+                                                    "value": {
+                                                      "_type": "StringConstant",
+                                                      "source_location": {
+                                                        "file": "%DIR%/itxn-compose.algo.ts",
+                                                        "line": 61,
+                                                        "end_line": 61,
+                                                        "column": 64,
+                                                        "end_column": 68
+                                                      },
+                                                      "wtype": {
+                                                        "_type": "WType",
+                                                        "name": "string",
+                                                        "immutable": true
+                                                      },
+                                                      "value": "ho"
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "start_with_begin": false
+                                      }
+                                    }
+                                  ],
+                                  "label": null,
+                                  "comment": null
+                                }
+                              ],
+                              "label": null,
+                              "comment": null
+                            }
+                          }
+                        ],
+                        "label": null,
+                        "comment": null
+                      }
+                    ],
+                    "label": null,
+                    "comment": null
+                  }
+                }
+              ],
+              "label": null,
+              "comment": null
+            },
+            {
+              "_type": "ExpressionStatement",
+              "source_location": {
+                "file": "%DIR%/itxn-compose.algo.ts",
+                "line": 64,
+                "end_line": 64,
+                "column": 4,
+                "end_column": 24
+              },
+              "expr": {
+                "_type": "IntrinsicCall",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 64,
+                  "end_line": 64,
+                  "column": 4,
+                  "end_column": 24
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "void",
+                  "immutable": true
+                },
+                "op_code": "itxn_submit",
+                "immediates": [],
+                "stack_args": []
+              }
+            }
+          ],
+          "label": null,
+          "comment": null
+        },
+        "documentation": {
+          "_type": "MethodDocumentation",
+          "description": null,
+          "args": {},
+          "returns": null
+        },
+        "inline": null,
+        "cref": "tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo",
+        "member_name": "conditionalBegin",
+        "arc4_method_config": {
+          "_type": "ARC4ABIMethodConfig",
+          "source_location": {
+            "file": "%DIR%/itxn-compose.algo.ts",
+            "line": 53,
+            "end_line": 53,
+            "column": 2,
+            "end_column": 33
+          },
+          "allowed_completion_types": [
+            0
+          ],
+          "create": 3,
+          "name": "conditionalBegin",
+          "readonly": false,
+          "default_args": {}
+        }
+      },
+      {
+        "_type": "ContractMethod",
+        "source_location": {
+          "file": "%DIR%/itxn-compose.algo.ts",
+          "line": 18,
+          "end_line": 18,
+          "column": 0,
+          "end_column": 40
+        },
+        "args": [],
+        "return_type": {
+          "_type": "WType",
+          "name": "void",
+          "immutable": true
+        },
+        "body": {
+          "_type": "Block",
+          "source_location": {
+            "file": "%DIR%/itxn-compose.algo.ts",
+            "line": 18,
+            "end_line": 18,
+            "column": 0,
+            "end_column": 40
+          },
+          "body": [],
+          "label": null,
+          "comment": null
+        },
+        "documentation": {
+          "_type": "MethodDocumentation",
+          "description": "Implicitly generated create method",
+          "args": {},
+          "returns": null
+        },
+        "inline": null,
+        "cref": "tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo",
+        "member_name": "__algots__.defaultCreate",
+        "arc4_method_config": {
+          "_type": "ARC4BareMethodConfig",
+          "source_location": {
+            "file": "%DIR%/itxn-compose.algo.ts",
+            "line": 18,
+            "end_line": 18,
+            "column": 0,
+            "end_column": 40
+          },
+          "allowed_completion_types": [
+            0
+          ],
+          "create": 2
+        }
+      }
+    ],
+    "app_state": [],
+    "state_totals": {
+      "_type": "StateTotals",
+      "global_uints": null,
+      "local_uints": null,
+      "global_bytes": null,
+      "local_bytes": null
+    },
+    "reserved_scratch_space": [],
+    "avm_version": null
+  },
+  {
+    "_type": "Contract",
+    "source_location": {
+      "file": "%DIR%/itxn-compose.algo.ts",
+      "line": 68,
+      "end_line": 68,
+      "column": 0,
+      "end_column": 41
+    },
+    "id": "tests/approvals/itxn-compose.algo.ts::VerifierContract",
+    "name": "VerifierContract",
+    "description": null,
+    "method_resolution_order": [
+      "@algorandfoundation/algorand-typescript/arc4/index.d.ts::Contract",
+      "@algorandfoundation/algorand-typescript/base-contract.d.ts::BaseContract"
+    ],
+    "approval_program": {
+      "_type": "ContractMethod",
+      "source_location": {
+        "_type": "SourceLocation",
+        "file": null,
+        "line": 1,
+        "end_line": 1,
+        "column": 0,
+        "end_column": 1
+      },
+      "args": [],
+      "return_type": {
+        "_type": "WType",
+        "name": "bool",
+        "immutable": true
+      },
+      "body": {
+        "_type": "Block",
+        "source_location": {
+          "_type": "SourceLocation",
+          "file": null,
+          "line": 1,
+          "end_line": 1,
+          "column": 0,
+          "end_column": 1
+        },
+        "body": [
+          {
+            "_type": "ReturnStatement",
+            "source_location": {
+              "_type": "SourceLocation",
+              "file": null,
+              "line": 1,
+              "end_line": 1,
+              "column": 0,
+              "end_column": 1
+            },
+            "value": {
+              "_type": "ARC4Router",
+              "source_location": {
+                "_type": "SourceLocation",
+                "file": null,
+                "line": 1,
+                "end_line": 1,
+                "column": 0,
+                "end_column": 1
+              },
+              "wtype": {
+                "_type": "WType",
+                "name": "bool",
+                "immutable": true
+              }
+            }
+          }
+        ],
+        "label": null,
+        "comment": null
+      },
+      "documentation": {
+        "_type": "MethodDocumentation",
+        "description": null,
+        "args": {},
+        "returns": null
+      },
+      "inline": null,
+      "cref": "@algorandfoundation/algorand-typescript/arc4/index.d.ts::Contract",
+      "member_name": "approvalProgram",
+      "arc4_method_config": null
+    },
+    "clear_program": {
+      "_type": "ContractMethod",
+      "source_location": {
+        "_type": "SourceLocation",
+        "file": null,
+        "line": 1,
+        "end_line": 1,
+        "column": 0,
+        "end_column": 1
+      },
+      "args": [],
+      "return_type": {
+        "_type": "WType",
+        "name": "bool",
+        "immutable": true
+      },
+      "body": {
+        "_type": "Block",
+        "source_location": {
+          "_type": "SourceLocation",
+          "file": null,
+          "line": 1,
+          "end_line": 1,
+          "column": 0,
+          "end_column": 1
+        },
+        "body": [
+          {
+            "_type": "ReturnStatement",
+            "source_location": {
+              "_type": "SourceLocation",
+              "file": null,
+              "line": 1,
+              "end_line": 1,
+              "column": 0,
+              "end_column": 1
+            },
+            "value": {
+              "_type": "BoolConstant",
+              "source_location": {
+                "_type": "SourceLocation",
+                "file": null,
+                "line": 1,
+                "end_line": 1,
+                "column": 0,
+                "end_column": 1
+              },
+              "wtype": {
+                "_type": "WType",
+                "name": "bool",
+                "immutable": true
+              },
+              "value": true
+            }
+          }
+        ],
+        "label": null,
+        "comment": null
+      },
+      "documentation": {
+        "_type": "MethodDocumentation",
+        "description": null,
+        "args": {},
+        "returns": null
+      },
+      "inline": null,
+      "cref": "@algorandfoundation/algorand-typescript/base-contract.d.ts::BaseContract",
+      "member_name": "clearStateProgram",
+      "arc4_method_config": null
+    },
+    "methods": [
+      {
+        "_type": "ContractMethod",
+        "source_location": {
+          "file": "%DIR%/itxn-compose.algo.ts",
+          "line": 69,
+          "end_line": 69,
+          "column": 2,
+          "end_column": 10
+        },
+        "args": [],
+        "return_type": {
+          "_type": "WType",
+          "name": "void",
+          "immutable": true
+        },
+        "body": {
+          "_type": "Block",
+          "source_location": {
+            "file": "%DIR%/itxn-compose.algo.ts",
+            "line": 69,
+            "end_line": 74,
+            "column": 11,
+            "end_column": 3
+          },
+          "body": [
+            {
+              "_type": "AssignmentStatement",
+              "source_location": {
+                "file": "%DIR%/itxn-compose.algo.ts",
+                "line": 70,
+                "end_line": 70,
+                "column": 13,
+                "end_column": 26
+              },
+              "target": {
+                "_type": "VarExpression",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 70,
+                  "end_line": 70,
+                  "column": 13,
+                  "end_column": 14
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "uint64",
+                  "immutable": true
+                },
+                "name": "i"
+              },
+              "value": {
+                "_type": "IntegerConstant",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 70,
+                  "end_line": 70,
+                  "column": 25,
+                  "end_column": 26
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "uint64",
+                  "immutable": true
+                },
+                "value": 0,
+                "teal_alias": null
+              }
+            },
+            {
+              "_type": "WhileLoop",
+              "source_location": {
+                "file": "%DIR%/itxn-compose.algo.ts",
+                "line": 70,
+                "end_line": 70,
+                "column": 4,
+                "end_column": 52
+              },
+              "condition": {
+                "_type": "NumericComparisonExpression",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 70,
+                  "end_line": 70,
+                  "column": 28,
+                  "end_column": 46
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "bool",
+                  "immutable": true
+                },
+                "lhs": {
+                  "_type": "VarExpression",
+                  "source_location": {
+                    "file": "%DIR%/itxn-compose.algo.ts",
+                    "line": 70,
+                    "end_line": 70,
+                    "column": 28,
+                    "end_column": 29
+                  },
+                  "wtype": {
+                    "_type": "WType",
+                    "name": "uint64",
+                    "immutable": true
+                  },
+                  "name": "i"
+                },
+                "operator": "<",
+                "rhs": {
+                  "_type": "IntrinsicCall",
+                  "source_location": {
+                    "file": "%DIR%/itxn-compose.algo.ts",
+                    "line": 70,
+                    "end_line": 70,
+                    "column": 36,
+                    "end_column": 46
+                  },
+                  "wtype": {
+                    "_type": "WType",
+                    "name": "uint64",
+                    "immutable": true
+                  },
+                  "op_code": "txn",
+                  "immediates": [
+                    "GroupIndex"
+                  ],
+                  "stack_args": []
+                }
+              },
+              "loop_body": {
+                "_type": "Block",
+                "source_location": {
+                  "file": "%DIR%/itxn-compose.algo.ts",
+                  "line": 70,
+                  "end_line": 70,
+                  "column": 4,
+                  "end_column": 52
+                },
+                "body": [
+                  {
+                    "_type": "Block",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 70,
+                      "end_line": 73,
+                      "column": 53,
+                      "end_column": 5
+                    },
+                    "body": [
+                      {
+                        "_type": "AssignmentStatement",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 71,
+                          "end_line": 71,
+                          "column": 12,
+                          "end_column": 37
+                        },
+                        "target": {
+                          "_type": "VarExpression",
+                          "source_location": {
+                            "file": "%DIR%/itxn-compose.algo.ts",
+                            "line": 71,
+                            "end_line": 71,
+                            "column": 12,
+                            "end_column": 15
+                          },
+                          "wtype": {
+                            "_type": "WGroupTransaction",
+                            "name": "group_transaction",
+                            "immutable": true,
+                            "transaction_type": null,
+                            "arc4_alias": "txn"
+                          },
+                          "name": "txn"
+                        },
+                        "value": {
+                          "_type": "GroupTransactionReference",
+                          "source_location": {
+                            "file": "%DIR%/itxn-compose.algo.ts",
+                            "line": 71,
+                            "end_line": 71,
+                            "column": 18,
+                            "end_column": 37
+                          },
+                          "wtype": {
+                            "_type": "WGroupTransaction",
+                            "name": "group_transaction",
+                            "immutable": true,
+                            "transaction_type": null,
+                            "arc4_alias": "txn"
+                          },
+                          "index": {
+                            "_type": "VarExpression",
+                            "source_location": {
+                              "file": "%DIR%/itxn-compose.algo.ts",
+                              "line": 71,
+                              "end_line": 71,
+                              "column": 35,
+                              "end_column": 36
+                            },
+                            "wtype": {
+                              "_type": "WType",
+                              "name": "uint64",
+                              "immutable": true
+                            },
+                            "name": "i"
+                          }
+                        }
+                      },
+                      {
+                        "_type": "ExpressionStatement",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 72,
+                          "end_line": 72,
+                          "column": 6,
+                          "end_column": 69
+                        },
+                        "expr": {
+                          "_type": "AssertExpression",
+                          "source_location": {
+                            "file": "%DIR%/itxn-compose.algo.ts",
+                            "line": 72,
+                            "end_line": 72,
+                            "column": 6,
+                            "end_column": 69
+                          },
+                          "wtype": {
+                            "_type": "WType",
+                            "name": "void",
+                            "immutable": true
+                          },
+                          "condition": {
+                            "_type": "NumericComparisonExpression",
+                            "source_location": {
+                              "file": "%DIR%/itxn-compose.algo.ts",
+                              "line": 72,
+                              "end_line": 72,
+                              "column": 13,
+                              "end_column": 49
+                            },
+                            "wtype": {
+                              "_type": "WType",
+                              "name": "bool",
+                              "immutable": true
+                            },
+                            "lhs": {
+                              "_type": "IntrinsicCall",
+                              "source_location": {
+                                "file": "%DIR%/itxn-compose.algo.ts",
+                                "line": 72,
+                                "end_line": 72,
+                                "column": 17,
+                                "end_column": 21
+                              },
+                              "wtype": {
+                                "_type": "WType",
+                                "name": "uint64",
+                                "immutable": true
+                              },
+                              "op_code": "gtxns",
+                              "immediates": [
+                                "TypeEnum"
+                              ],
+                              "stack_args": [
+                                {
+                                  "_type": "VarExpression",
+                                  "source_location": {
+                                    "file": "%DIR%/itxn-compose.algo.ts",
+                                    "line": 72,
+                                    "end_line": 72,
+                                    "column": 13,
+                                    "end_column": 16
+                                  },
+                                  "wtype": {
+                                    "_type": "WGroupTransaction",
+                                    "name": "group_transaction",
+                                    "immutable": true,
+                                    "transaction_type": null,
+                                    "arc4_alias": "txn"
+                                  },
+                                  "name": "txn"
+                                }
+                              ]
+                            },
+                            "operator": "==",
+                            "rhs": {
+                              "_type": "ReinterpretCast",
+                              "source_location": {
+                                "file": "%DIR%/itxn-compose.algo.ts",
+                                "line": 72,
+                                "end_line": 72,
+                                "column": 42,
+                                "end_column": 49
+                              },
+                              "wtype": {
+                                "_type": "WType",
+                                "name": "uint64",
+                                "immutable": true
+                              },
+                              "expr": {
+                                "_type": "IntegerConstant",
+                                "source_location": {
+                                  "file": "%DIR%/itxn-compose.algo.ts",
+                                  "line": 72,
+                                  "end_line": 72,
+                                  "column": 42,
+                                  "end_column": 49
+                                },
+                                "wtype": {
+                                  "_type": "WType",
+                                  "name": "uint64",
+                                  "immutable": true
+                                },
+                                "value": 1,
+                                "teal_alias": null
+                              }
+                            }
+                          },
+                          "error_message": "Txn must be pay"
+                        }
+                      }
+                    ],
+                    "label": null,
+                    "comment": null
+                  },
+                  {
+                    "_type": "ExpressionStatement",
+                    "source_location": {
+                      "file": "%DIR%/itxn-compose.algo.ts",
+                      "line": 70,
+                      "end_line": 70,
+                      "column": 48,
+                      "end_column": 51
+                    },
+                    "expr": {
+                      "_type": "UInt64PostfixUnaryOperation",
+                      "source_location": {
+                        "file": "%DIR%/itxn-compose.algo.ts",
+                        "line": 70,
+                        "end_line": 70,
+                        "column": 48,
+                        "end_column": 51
+                      },
+                      "wtype": {
+                        "_type": "WType",
+                        "name": "uint64",
+                        "immutable": true
+                      },
+                      "op": "++",
+                      "target": {
+                        "_type": "VarExpression",
+                        "source_location": {
+                          "file": "%DIR%/itxn-compose.algo.ts",
+                          "line": 70,
+                          "end_line": 70,
+                          "column": 48,
+                          "end_column": 49
+                        },
+                        "wtype": {
+                          "_type": "WType",
+                          "name": "uint64",
+                          "immutable": true
+                        },
+                        "name": "i"
+                      }
+                    }
+                  }
+                ],
+                "label": null,
+                "comment": null
+              }
+            }
+          ],
+          "label": null,
+          "comment": null
+        },
+        "documentation": {
+          "_type": "MethodDocumentation",
+          "description": null,
+          "args": {},
+          "returns": null
+        },
+        "inline": null,
+        "cref": "tests/approvals/itxn-compose.algo.ts::VerifierContract",
+        "member_name": "verify",
+        "arc4_method_config": {
+          "_type": "ARC4ABIMethodConfig",
+          "source_location": {
+            "file": "%DIR%/itxn-compose.algo.ts",
+            "line": 69,
+            "end_line": 69,
+            "column": 2,
+            "end_column": 10
+          },
+          "allowed_completion_types": [
+            0
+          ],
+          "create": 3,
+          "name": "verify",
+          "readonly": false,
+          "default_args": {}
+        }
+      },
+      {
+        "_type": "ContractMethod",
+        "source_location": {
+          "file": "%DIR%/itxn-compose.algo.ts",
+          "line": 68,
+          "end_line": 68,
+          "column": 0,
+          "end_column": 41
+        },
+        "args": [],
+        "return_type": {
+          "_type": "WType",
+          "name": "void",
+          "immutable": true
+        },
+        "body": {
+          "_type": "Block",
+          "source_location": {
+            "file": "%DIR%/itxn-compose.algo.ts",
+            "line": 68,
+            "end_line": 68,
+            "column": 0,
+            "end_column": 41
+          },
+          "body": [],
+          "label": null,
+          "comment": null
+        },
+        "documentation": {
+          "_type": "MethodDocumentation",
+          "description": "Implicitly generated create method",
+          "args": {},
+          "returns": null
+        },
+        "inline": null,
+        "cref": "tests/approvals/itxn-compose.algo.ts::VerifierContract",
+        "member_name": "__algots__.defaultCreate",
+        "arc4_method_config": {
+          "_type": "ARC4BareMethodConfig",
+          "source_location": {
+            "file": "%DIR%/itxn-compose.algo.ts",
+            "line": 68,
+            "end_line": 68,
+            "column": 0,
+            "end_column": 41
+          },
+          "allowed_completion_types": [
+            0
+          ],
+          "create": 2
+        }
+      }
+    ],
+    "app_state": [],
+    "state_totals": {
+      "_type": "StateTotals",
+      "global_uints": null,
+      "local_uints": null,
+      "global_bytes": null,
+      "local_bytes": null
+    },
+    "reserved_scratch_space": [],
+    "avm_version": null
+  }
+]

--- a/tests/from_awst/itxn_compose/out/ItxnComposeAlgo.approval.teal
+++ b/tests/from_awst/itxn_compose/out/ItxnComposeAlgo.approval.teal
@@ -1,0 +1,207 @@
+#pragma version 10
+#pragma typetrack false
+
+// @algorandfoundation/algorand-typescript/arc4/index.d.ts::Contract.approvalProgram() -> uint64:
+main:
+    intcblock 0 1 6 32
+    bytecblock 0xd0a28200 0x0002686f
+    txn NumAppArgs
+    bz main_bare_routing@7
+    pushbytess 0x2ef58e27 0x90d29762 // method "distribute(address[],pay,application)void", method "conditionalBegin(uint64)void"
+    txna ApplicationArgs 0
+    match main_distribute_route@3 main_conditionalBegin_route@4
+
+main_after_if_else@11:
+    intc_0 // 0
+    return
+
+main_conditionalBegin_route@4:
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    txna ApplicationArgs 1
+    btoi
+    callsub conditionalBegin
+    intc_1 // 1
+    return
+
+main_distribute_route@3:
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    txna ApplicationArgs 1
+    txn GroupIndex
+    intc_1 // 1
+    -
+    dup
+    gtxns TypeEnum
+    intc_1 // pay
+    ==
+    assert // transaction type is pay
+    txna ApplicationArgs 2
+    btoi
+    txnas Applications
+    callsub distribute
+    intc_1 // 1
+    return
+
+main_bare_routing@7:
+    txn OnCompletion
+    bnz main_after_if_else@11
+    txn ApplicationID
+    !
+    assert // can only call when creating
+    intc_1 // 1
+    return
+
+
+// tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo.distribute(addresses: bytes, funds: uint64, verifier: uint64) -> void:
+distribute:
+    proto 3 0
+    frame_dig -2
+    gtxns Receiver
+    global CurrentApplicationAddress
+    ==
+    assert // assert target is match for conditions
+    frame_dig -3
+    intc_0 // 0
+    extract_uint16
+    dupn 2
+    assert // must provide some accounts
+    frame_dig -2
+    gtxns Amount
+    swap
+    /
+    dup
+    frame_dig -3
+    extract 2 0
+    swap
+    frame_dig -3
+    extract 2 32
+    itxn_begin
+    itxn_field Receiver
+    itxn_field Amount
+    intc_1 // 1
+    itxn_field TypeEnum
+    intc_0 // 0
+    itxn_field Fee
+    intc_1 // 1
+
+distribute_for_header@1:
+    frame_dig 3
+    frame_dig 0
+    <
+    bz distribute_after_for@4
+    frame_dig 3
+    dup
+    intc_3 // 32
+    *
+    frame_dig 2
+    swap
+    intc_3 // 32
+    extract3 // on error: Index access is out of bounds
+    itxn_next
+    frame_dig 1
+    itxn_field Amount
+    intc_1 // 1
+    itxn_field TypeEnum
+    itxn_field Receiver
+    intc_0 // 0
+    itxn_field Fee
+    intc_1 // 1
+    +
+    frame_bury 3
+    b distribute_for_header@1
+
+distribute_after_for@4:
+    itxn_next
+    pushbytes 0x65a9aecc // method "verify()void"
+    itxn_field ApplicationArgs
+    frame_dig -1
+    itxn_field ApplicationID
+    intc_2 // appl
+    itxn_field TypeEnum
+    intc_0 // 0
+    itxn_field Fee
+    itxn_next
+    pushbytes "abc"
+    itxn_field ConfigAssetName
+    pushint 3 // 3
+    itxn_field TypeEnum
+    intc_0 // 0
+    itxn_field Fee
+    itxn_submit
+    retsub
+
+
+// tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo.conditionalBegin(count: uint64) -> void:
+conditionalBegin:
+    proto 1 0
+    itxn_begin
+    pushbytes 0x009225ae // method "helloCreate(string)void"
+    itxn_field ApplicationArgs
+    pushbytes 0x00024869
+    itxn_field ApplicationArgs
+    intc_1 // 1
+    itxn_field GlobalNumByteSlice
+    pushbytes base64(CoEBQw==)
+    itxn_field ClearStateProgramPages
+    pushbytes base64(CiACAQAmAQhncmVldGluZzEYQAAEKIAAZzEbQQAjggQEAJIlrgQkN408BKDoGHIE0KKCADYaAI4EADsAMAAlAAIjQzEZFEQxGEQ2GgFXAgCIAERJFRZXBgJMUIAEFR98dUxQsCJDMRmBBBJEMRhEIkMxGYEFEkQxGEQiQzEZFEQxGBRENhoBVwIAiAACIkOKAQAoi/9niYoBASMoZUSAASBQi/9QiQ==)
+    itxn_field ApprovalProgramPages
+    intc_0 // 0
+    itxn_field OnCompletion
+    intc_2 // appl
+    itxn_field TypeEnum
+    intc_0 // 0
+    itxn_field Fee
+    itxn_submit
+    gitxn 0 CreatedApplicationID
+    intc_0 // 0
+
+conditionalBegin_for_header@2:
+    frame_dig 1
+    frame_dig -1
+    <
+    bz conditionalBegin_after_for@8
+    frame_dig 1
+    bnz conditionalBegin_else_body@5
+    itxn_begin
+    bytec_0 // method "greet(string)string"
+    itxn_field ApplicationArgs
+    bytec_1 // 0x0002686f
+    itxn_field ApplicationArgs
+    frame_dig 0
+    itxn_field ApplicationID
+    intc_2 // appl
+    itxn_field TypeEnum
+    intc_0 // 0
+    itxn_field Fee
+
+conditionalBegin_after_if_else@6:
+    frame_dig 1
+    intc_1 // 1
+    +
+    frame_bury 1
+    b conditionalBegin_for_header@2
+
+conditionalBegin_else_body@5:
+    itxn_next
+    bytec_0 // method "greet(string)string"
+    itxn_field ApplicationArgs
+    bytec_1 // 0x0002686f
+    itxn_field ApplicationArgs
+    frame_dig 0
+    itxn_field ApplicationID
+    intc_2 // appl
+    itxn_field TypeEnum
+    intc_0 // 0
+    itxn_field Fee
+    b conditionalBegin_after_if_else@6
+
+conditionalBegin_after_for@8:
+    itxn_submit
+    retsub

--- a/tests/from_awst/itxn_compose/out/ItxnComposeAlgo.arc32.json
+++ b/tests/from_awst/itxn_compose/out/ItxnComposeAlgo.arc32.json
@@ -1,0 +1,81 @@
+{
+    "hints": {
+        "distribute(address[],pay,application)void": {
+            "call_config": {
+                "no_op": "CALL"
+            }
+        },
+        "conditionalBegin(uint64)void": {
+            "call_config": {
+                "no_op": "CALL"
+            }
+        }
+    },
+    "source": {
+        "approval": "I3ByYWdtYSB2ZXJzaW9uIDEwCiNwcmFnbWEgdHlwZXRyYWNrIGZhbHNlCgovLyBAYWxnb3JhbmRmb3VuZGF0aW9uL2FsZ29yYW5kLXR5cGVzY3JpcHQvYXJjNC9pbmRleC5kLnRzOjpDb250cmFjdC5hcHByb3ZhbFByb2dyYW0oKSAtPiB1aW50NjQ6Cm1haW46CiAgICBpbnRjYmxvY2sgMCAxIDYgMzIKICAgIGJ5dGVjYmxvY2sgMHhkMGEyODIwMCAweDAwMDI2ODZmCiAgICB0eG4gTnVtQXBwQXJncwogICAgYnogbWFpbl9iYXJlX3JvdXRpbmdANwogICAgcHVzaGJ5dGVzcyAweDJlZjU4ZTI3IDB4OTBkMjk3NjIgLy8gbWV0aG9kICJkaXN0cmlidXRlKGFkZHJlc3NbXSxwYXksYXBwbGljYXRpb24pdm9pZCIsIG1ldGhvZCAiY29uZGl0aW9uYWxCZWdpbih1aW50NjQpdm9pZCIKICAgIHR4bmEgQXBwbGljYXRpb25BcmdzIDAKICAgIG1hdGNoIG1haW5fZGlzdHJpYnV0ZV9yb3V0ZUAzIG1haW5fY29uZGl0aW9uYWxCZWdpbl9yb3V0ZUA0CgptYWluX2FmdGVyX2lmX2Vsc2VAMTE6CiAgICBpbnRjXzAgLy8gMAogICAgcmV0dXJuCgptYWluX2NvbmRpdGlvbmFsQmVnaW5fcm91dGVANDoKICAgIHR4biBPbkNvbXBsZXRpb24KICAgICEKICAgIGFzc2VydCAvLyBPbkNvbXBsZXRpb24gaXMgbm90IE5vT3AKICAgIHR4biBBcHBsaWNhdGlvbklECiAgICBhc3NlcnQgLy8gY2FuIG9ubHkgY2FsbCB3aGVuIG5vdCBjcmVhdGluZwogICAgdHhuYSBBcHBsaWNhdGlvbkFyZ3MgMQogICAgYnRvaQogICAgY2FsbHN1YiBjb25kaXRpb25hbEJlZ2luCiAgICBpbnRjXzEgLy8gMQogICAgcmV0dXJuCgptYWluX2Rpc3RyaWJ1dGVfcm91dGVAMzoKICAgIHR4biBPbkNvbXBsZXRpb24KICAgICEKICAgIGFzc2VydCAvLyBPbkNvbXBsZXRpb24gaXMgbm90IE5vT3AKICAgIHR4biBBcHBsaWNhdGlvbklECiAgICBhc3NlcnQgLy8gY2FuIG9ubHkgY2FsbCB3aGVuIG5vdCBjcmVhdGluZwogICAgdHhuYSBBcHBsaWNhdGlvbkFyZ3MgMQogICAgdHhuIEdyb3VwSW5kZXgKICAgIGludGNfMSAvLyAxCiAgICAtCiAgICBkdXAKICAgIGd0eG5zIFR5cGVFbnVtCiAgICBpbnRjXzEgLy8gcGF5CiAgICA9PQogICAgYXNzZXJ0IC8vIHRyYW5zYWN0aW9uIHR5cGUgaXMgcGF5CiAgICB0eG5hIEFwcGxpY2F0aW9uQXJncyAyCiAgICBidG9pCiAgICB0eG5hcyBBcHBsaWNhdGlvbnMKICAgIGNhbGxzdWIgZGlzdHJpYnV0ZQogICAgaW50Y18xIC8vIDEKICAgIHJldHVybgoKbWFpbl9iYXJlX3JvdXRpbmdANzoKICAgIHR4biBPbkNvbXBsZXRpb24KICAgIGJueiBtYWluX2FmdGVyX2lmX2Vsc2VAMTEKICAgIHR4biBBcHBsaWNhdGlvbklECiAgICAhCiAgICBhc3NlcnQgLy8gY2FuIG9ubHkgY2FsbCB3aGVuIGNyZWF0aW5nCiAgICBpbnRjXzEgLy8gMQogICAgcmV0dXJuCgoKLy8gdGVzdHMvYXBwcm92YWxzL2l0eG4tY29tcG9zZS5hbGdvLnRzOjpJdHhuQ29tcG9zZUFsZ28uZGlzdHJpYnV0ZShhZGRyZXNzZXM6IGJ5dGVzLCBmdW5kczogdWludDY0LCB2ZXJpZmllcjogdWludDY0KSAtPiB2b2lkOgpkaXN0cmlidXRlOgogICAgcHJvdG8gMyAwCiAgICBmcmFtZV9kaWcgLTIKICAgIGd0eG5zIFJlY2VpdmVyCiAgICBnbG9iYWwgQ3VycmVudEFwcGxpY2F0aW9uQWRkcmVzcwogICAgPT0KICAgIGFzc2VydCAvLyBhc3NlcnQgdGFyZ2V0IGlzIG1hdGNoIGZvciBjb25kaXRpb25zCiAgICBmcmFtZV9kaWcgLTMKICAgIGludGNfMCAvLyAwCiAgICBleHRyYWN0X3VpbnQxNgogICAgZHVwbiAyCiAgICBhc3NlcnQgLy8gbXVzdCBwcm92aWRlIHNvbWUgYWNjb3VudHMKICAgIGZyYW1lX2RpZyAtMgogICAgZ3R4bnMgQW1vdW50CiAgICBzd2FwCiAgICAvCiAgICBkdXAKICAgIGZyYW1lX2RpZyAtMwogICAgZXh0cmFjdCAyIDAKICAgIHN3YXAKICAgIGZyYW1lX2RpZyAtMwogICAgZXh0cmFjdCAyIDMyCiAgICBpdHhuX2JlZ2luCiAgICBpdHhuX2ZpZWxkIFJlY2VpdmVyCiAgICBpdHhuX2ZpZWxkIEFtb3VudAogICAgaW50Y18xIC8vIDEKICAgIGl0eG5fZmllbGQgVHlwZUVudW0KICAgIGludGNfMCAvLyAwCiAgICBpdHhuX2ZpZWxkIEZlZQogICAgaW50Y18xIC8vIDEKCmRpc3RyaWJ1dGVfZm9yX2hlYWRlckAxOgogICAgZnJhbWVfZGlnIDMKICAgIGZyYW1lX2RpZyAwCiAgICA8CiAgICBieiBkaXN0cmlidXRlX2FmdGVyX2ZvckA0CiAgICBmcmFtZV9kaWcgMwogICAgZHVwCiAgICBpbnRjXzMgLy8gMzIKICAgICoKICAgIGZyYW1lX2RpZyAyCiAgICBzd2FwCiAgICBpbnRjXzMgLy8gMzIKICAgIGV4dHJhY3QzIC8vIG9uIGVycm9yOiBJbmRleCBhY2Nlc3MgaXMgb3V0IG9mIGJvdW5kcwogICAgaXR4bl9uZXh0CiAgICBmcmFtZV9kaWcgMQogICAgaXR4bl9maWVsZCBBbW91bnQKICAgIGludGNfMSAvLyAxCiAgICBpdHhuX2ZpZWxkIFR5cGVFbnVtCiAgICBpdHhuX2ZpZWxkIFJlY2VpdmVyCiAgICBpbnRjXzAgLy8gMAogICAgaXR4bl9maWVsZCBGZWUKICAgIGludGNfMSAvLyAxCiAgICArCiAgICBmcmFtZV9idXJ5IDMKICAgIGIgZGlzdHJpYnV0ZV9mb3JfaGVhZGVyQDEKCmRpc3RyaWJ1dGVfYWZ0ZXJfZm9yQDQ6CiAgICBpdHhuX25leHQKICAgIHB1c2hieXRlcyAweDY1YTlhZWNjIC8vIG1ldGhvZCAidmVyaWZ5KCl2b2lkIgogICAgaXR4bl9maWVsZCBBcHBsaWNhdGlvbkFyZ3MKICAgIGZyYW1lX2RpZyAtMQogICAgaXR4bl9maWVsZCBBcHBsaWNhdGlvbklECiAgICBpbnRjXzIgLy8gYXBwbAogICAgaXR4bl9maWVsZCBUeXBlRW51bQogICAgaW50Y18wIC8vIDAKICAgIGl0eG5fZmllbGQgRmVlCiAgICBpdHhuX25leHQKICAgIHB1c2hieXRlcyAiYWJjIgogICAgaXR4bl9maWVsZCBDb25maWdBc3NldE5hbWUKICAgIHB1c2hpbnQgMyAvLyAzCiAgICBpdHhuX2ZpZWxkIFR5cGVFbnVtCiAgICBpbnRjXzAgLy8gMAogICAgaXR4bl9maWVsZCBGZWUKICAgIGl0eG5fc3VibWl0CiAgICByZXRzdWIKCgovLyB0ZXN0cy9hcHByb3ZhbHMvaXR4bi1jb21wb3NlLmFsZ28udHM6Okl0eG5Db21wb3NlQWxnby5jb25kaXRpb25hbEJlZ2luKGNvdW50OiB1aW50NjQpIC0+IHZvaWQ6CmNvbmRpdGlvbmFsQmVnaW46CiAgICBwcm90byAxIDAKICAgIGl0eG5fYmVnaW4KICAgIHB1c2hieXRlcyAweDAwOTIyNWFlIC8vIG1ldGhvZCAiaGVsbG9DcmVhdGUoc3RyaW5nKXZvaWQiCiAgICBpdHhuX2ZpZWxkIEFwcGxpY2F0aW9uQXJncwogICAgcHVzaGJ5dGVzIDB4MDAwMjQ4NjkKICAgIGl0eG5fZmllbGQgQXBwbGljYXRpb25BcmdzCiAgICBpbnRjXzEgLy8gMQogICAgaXR4bl9maWVsZCBHbG9iYWxOdW1CeXRlU2xpY2UKICAgIHB1c2hieXRlcyBiYXNlNjQoQ29FQlF3PT0pCiAgICBpdHhuX2ZpZWxkIENsZWFyU3RhdGVQcm9ncmFtUGFnZXMKICAgIHB1c2hieXRlcyBiYXNlNjQoQ2lBQ0FRQW1BUWhuY21WbGRHbHVaekVZUUFBRUtJQUFaekViUVFBamdnUUVBSklscmdRa040MDhCS0RvR0hJRTBLS0NBRFlhQUk0RUFEc0FNQUFsQUFJalF6RVpGRVF4R0VRMkdnRlhBZ0NJQUVSSkZSWlhCZ0pNVUlBRUZSOThkVXhRc0NKRE1SbUJCQkpFTVJoRUlrTXhHWUVGRWtReEdFUWlRekVaRkVReEdCUkVOaG9CVndJQWlBQUNJa09LQVFBb2kvOW5pWW9CQVNNb1pVU0FBU0JRaS85UWlRPT0pCiAgICBpdHhuX2ZpZWxkIEFwcHJvdmFsUHJvZ3JhbVBhZ2VzCiAgICBpbnRjXzAgLy8gMAogICAgaXR4bl9maWVsZCBPbkNvbXBsZXRpb24KICAgIGludGNfMiAvLyBhcHBsCiAgICBpdHhuX2ZpZWxkIFR5cGVFbnVtCiAgICBpbnRjXzAgLy8gMAogICAgaXR4bl9maWVsZCBGZWUKICAgIGl0eG5fc3VibWl0CiAgICBnaXR4biAwIENyZWF0ZWRBcHBsaWNhdGlvbklECiAgICBpbnRjXzAgLy8gMAoKY29uZGl0aW9uYWxCZWdpbl9mb3JfaGVhZGVyQDI6CiAgICBmcmFtZV9kaWcgMQogICAgZnJhbWVfZGlnIC0xCiAgICA8CiAgICBieiBjb25kaXRpb25hbEJlZ2luX2FmdGVyX2ZvckA4CiAgICBmcmFtZV9kaWcgMQogICAgYm56IGNvbmRpdGlvbmFsQmVnaW5fZWxzZV9ib2R5QDUKICAgIGl0eG5fYmVnaW4KICAgIGJ5dGVjXzAgLy8gbWV0aG9kICJncmVldChzdHJpbmcpc3RyaW5nIgogICAgaXR4bl9maWVsZCBBcHBsaWNhdGlvbkFyZ3MKICAgIGJ5dGVjXzEgLy8gMHgwMDAyNjg2ZgogICAgaXR4bl9maWVsZCBBcHBsaWNhdGlvbkFyZ3MKICAgIGZyYW1lX2RpZyAwCiAgICBpdHhuX2ZpZWxkIEFwcGxpY2F0aW9uSUQKICAgIGludGNfMiAvLyBhcHBsCiAgICBpdHhuX2ZpZWxkIFR5cGVFbnVtCiAgICBpbnRjXzAgLy8gMAogICAgaXR4bl9maWVsZCBGZWUKCmNvbmRpdGlvbmFsQmVnaW5fYWZ0ZXJfaWZfZWxzZUA2OgogICAgZnJhbWVfZGlnIDEKICAgIGludGNfMSAvLyAxCiAgICArCiAgICBmcmFtZV9idXJ5IDEKICAgIGIgY29uZGl0aW9uYWxCZWdpbl9mb3JfaGVhZGVyQDIKCmNvbmRpdGlvbmFsQmVnaW5fZWxzZV9ib2R5QDU6CiAgICBpdHhuX25leHQKICAgIGJ5dGVjXzAgLy8gbWV0aG9kICJncmVldChzdHJpbmcpc3RyaW5nIgogICAgaXR4bl9maWVsZCBBcHBsaWNhdGlvbkFyZ3MKICAgIGJ5dGVjXzEgLy8gMHgwMDAyNjg2ZgogICAgaXR4bl9maWVsZCBBcHBsaWNhdGlvbkFyZ3MKICAgIGZyYW1lX2RpZyAwCiAgICBpdHhuX2ZpZWxkIEFwcGxpY2F0aW9uSUQKICAgIGludGNfMiAvLyBhcHBsCiAgICBpdHhuX2ZpZWxkIFR5cGVFbnVtCiAgICBpbnRjXzAgLy8gMAogICAgaXR4bl9maWVsZCBGZWUKICAgIGIgY29uZGl0aW9uYWxCZWdpbl9hZnRlcl9pZl9lbHNlQDYKCmNvbmRpdGlvbmFsQmVnaW5fYWZ0ZXJfZm9yQDg6CiAgICBpdHhuX3N1Ym1pdAogICAgcmV0c3ViCg==",
+        "clear": "I3ByYWdtYSB2ZXJzaW9uIDEwCiNwcmFnbWEgdHlwZXRyYWNrIGZhbHNlCgovLyBAYWxnb3JhbmRmb3VuZGF0aW9uL2FsZ29yYW5kLXR5cGVzY3JpcHQvYmFzZS1jb250cmFjdC5kLnRzOjpCYXNlQ29udHJhY3QuY2xlYXJTdGF0ZVByb2dyYW0oKSAtPiB1aW50NjQ6Cm1haW46CiAgICBwdXNoaW50IDEgLy8gMQogICAgcmV0dXJuCg=="
+    },
+    "state": {
+        "global": {
+            "num_byte_slices": 0,
+            "num_uints": 0
+        },
+        "local": {
+            "num_byte_slices": 0,
+            "num_uints": 0
+        }
+    },
+    "schema": {
+        "global": {
+            "declared": {},
+            "reserved": {}
+        },
+        "local": {
+            "declared": {},
+            "reserved": {}
+        }
+    },
+    "contract": {
+        "name": "ItxnComposeAlgo",
+        "methods": [
+            {
+                "name": "distribute",
+                "args": [
+                    {
+                        "type": "address[]",
+                        "name": "addresses"
+                    },
+                    {
+                        "type": "pay",
+                        "name": "funds"
+                    },
+                    {
+                        "type": "application",
+                        "name": "verifier"
+                    }
+                ],
+                "readonly": false,
+                "returns": {
+                    "type": "void"
+                }
+            },
+            {
+                "name": "conditionalBegin",
+                "args": [
+                    {
+                        "type": "uint64",
+                        "name": "count"
+                    }
+                ],
+                "readonly": false,
+                "returns": {
+                    "type": "void"
+                }
+            }
+        ],
+        "networks": {}
+    },
+    "bare_call_config": {
+        "no_op": "CREATE"
+    }
+}

--- a/tests/from_awst/itxn_compose/out/ItxnComposeAlgo.clear.teal
+++ b/tests/from_awst/itxn_compose/out/ItxnComposeAlgo.clear.teal
@@ -1,0 +1,7 @@
+#pragma version 10
+#pragma typetrack false
+
+// @algorandfoundation/algorand-typescript/base-contract.d.ts::BaseContract.clearStateProgram() -> uint64:
+main:
+    pushint 1 // 1
+    return

--- a/tests/from_awst/itxn_compose/out/ItxnComposeAlgo.ir/ItxnComposeAlgo.approval.0.destructured.ir
+++ b/tests/from_awst/itxn_compose/out/ItxnComposeAlgo.ir/ItxnComposeAlgo.approval.0.destructured.ir
@@ -1,0 +1,142 @@
+main @algorandfoundation/algorand-typescript/arc4/index.d.ts::Contract.approvalProgram:
+    block@0: // L1
+        let tmp%0#1: uint64 = (txn NumAppArgs)
+        goto tmp%0#1 ? block@2 : block@7
+    block@2: // abi_routing_L18
+        let tmp%2#0: bytes = (txna ApplicationArgs 0)
+        switch tmp%2#0 {method "distribute(address[],pay,application)void" => block@3, method "conditionalBegin(uint64)void" => block@4, * => block@11}
+    block@3: // distribute_route_L19
+        let tmp%3#0: uint64 = (txn OnCompletion)
+        let tmp%4#0: bool = (! tmp%3#0)
+        (assert tmp%4#0) // OnCompletion is not NoOp
+        let tmp%5#0: uint64 = (txn ApplicationID)
+        (assert tmp%5#0) // can only call when not creating
+        let reinterpret_bytes[32][]%0#0: bytes[32][] = (txna ApplicationArgs 1)
+        let tmp%7#0: uint64 = (txn GroupIndex)
+        let gtxn_idx%0#0: uint64 = (- tmp%7#0 1u)
+        let gtxn_type%0#0: uint64 = ((gtxns TypeEnum) gtxn_idx%0#0)
+        let gtxn_type_matches%0#0: bool = (== gtxn_type%0#0 pay)
+        (assert gtxn_type_matches%0#0) // transaction type is pay
+        let reinterpret_bytes[1]%0#0: bytes[1] = (txna ApplicationArgs 2)
+        let tmp%8#0: uint64 = (btoi reinterpret_bytes[1]%0#0)
+        let tmp%9#0: uint64 = ((txnas Applications) tmp%8#0)
+        tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo.distribute(reinterpret_bytes[32][]%0#0, gtxn_idx%0#0, tmp%9#0)
+        let tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo.__puya_arc4_router__%0#0
+        goto block@12
+    block@4: // conditionalBegin_route_L53
+        let tmp%10#0: uint64 = (txn OnCompletion)
+        let tmp%11#0: bool = (! tmp%10#0)
+        (assert tmp%11#0) // OnCompletion is not NoOp
+        let tmp%12#0: uint64 = (txn ApplicationID)
+        (assert tmp%12#0) // can only call when not creating
+        let reinterpret_bytes[8]%0#0: bytes[8] = (txna ApplicationArgs 1)
+        let tmp%14#0: uint64 = (btoi reinterpret_bytes[8]%0#0)
+        tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo.conditionalBegin(tmp%14#0)
+        let tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo.__puya_arc4_router__%0#0
+        goto block@12
+    block@7: // bare_routing_L18
+        let tmp%15#0: uint64 = (txn OnCompletion)
+        goto tmp%15#0 ? block@11 : block@8
+    block@8: // __algots__.defaultCreate_L18
+        let tmp%16#0: uint64 = (txn ApplicationID)
+        let tmp%17#0: bool = (! tmp%16#0)
+        (assert tmp%17#0) // can only call when creating
+        let tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo.__puya_arc4_router__%0#0
+        goto block@12
+    block@11: // after_if_else_L18
+        let tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo.__puya_arc4_router__%0#0: bool = 0u
+        let tmp%0#0: bool = tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo.__puya_arc4_router__%0#0
+        goto block@12
+    block@12: // after_inlined_tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo.__puya_arc4_router___L1
+        return tmp%0#0
+
+subroutine tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo.distribute(addresses: bytes[32][], funds: uint64, verifier: uint64) -> void:
+    block@0: // L19
+        let tmp%0#0: bytes[32] = ((gtxns Receiver) funds#0)
+        let tmp%1#0: bytes[32] = (global CurrentApplicationAddress)
+        let tmp%2#0: bool = (== tmp%0#0 tmp%1#0)
+        (assert tmp%2#0) // assert target is match for conditions
+        let reinterpret_bool%0#0: bool = (extract_uint16 addresses#0 0u)
+        (assert reinterpret_bool%0#0) // must provide some accounts
+        let tmp%3#0: uint64 = ((gtxns Amount) funds#0)
+        let share#0: uint64 = (/ tmp%3#0 reinterpret_bool%0#0)
+        let array_head_and_tail%0#0: bytes = ((extract 2 0) addresses#0)
+        let payFields.receiver#0: bytes = ((extract 2 32) addresses#0)
+        itxn_begin
+        ((itxn_field Receiver) payFields.receiver#0)
+        ((itxn_field Amount) share#0)
+        ((itxn_field TypeEnum) 1u)
+        ((itxn_field Fee) 0u)
+        let i#0: uint64 = 1u
+        goto block@1
+    block@1: // for_header_L32
+        let continue_looping%0#0: bool = (< i#0 reinterpret_bool%0#0)
+        goto continue_looping%0#0 ? block@2 : block@4
+    block@2: // for_body_L32
+        let item_offset%1#0: uint64 = (* i#0 32u)
+        let addr#0: bytes[32] = (extract3 array_head_and_tail%0#0 item_offset%1#0 32u) // on error: Index access is out of bounds
+        itxn_next
+        ((itxn_field Amount) share#0)
+        ((itxn_field TypeEnum) 1u)
+        ((itxn_field Receiver) addr#0)
+        ((itxn_field Fee) 0u)
+        let i#0: uint64 = (+ i#0 1u)
+        goto block@1
+    block@4: // after_for_L32
+        itxn_next
+        ((itxn_field ApplicationArgs) method "verify()void")
+        ((itxn_field ApplicationID) verifier#0)
+        ((itxn_field TypeEnum) appl)
+        ((itxn_field Fee) 0u)
+        itxn_next
+        ((itxn_field ConfigAssetName) "abc")
+        ((itxn_field TypeEnum) 3u)
+        ((itxn_field Fee) 0u)
+        itxn_submit
+        return 
+
+subroutine tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo.conditionalBegin(count: uint64) -> void:
+    block@0: // L53
+        itxn_begin
+        ((itxn_field ApplicationArgs) method "helloCreate(string)void")
+        ((itxn_field ApplicationArgs) 0x00024869)
+        ((itxn_field GlobalNumByteSlice) 1u)
+        ((itxn_field ClearStateProgramPages) CoEBQw==)
+        ((itxn_field ApprovalProgramPages) CiACAQAmAQhncmVldGluZzEYQAAEKIAAZzEbQQAjggQEAJIlrgQkN408BKDoGHIE0KKCADYaAI4EADsAMAAlAAIjQzEZFEQxGEQ2GgFXAgCIAERJFRZXBgJMUIAEFR98dUxQsCJDMRmBBBJEMRhEIkMxGYEFEkQxGEQiQzEZFEQxGBRENhoBVwIAiAACIkOKAQAoi/9niYoBASMoZUSAASBQi/9QiQ==)
+        ((itxn_field OnCompletion) 0u)
+        ((itxn_field TypeEnum) appl)
+        ((itxn_field Fee) 0u)
+        itxn_submit
+        let appId#0: uint64 = (gitxn 0 CreatedApplicationID)
+        let i#0: uint64 = 0u
+        goto block@2
+    block@2: // for_header_L57
+        let continue_looping%0#0: bool = (< i#0 count#0)
+        goto continue_looping%0#0 ? block@3 : block@8
+    block@3: // for_body_L57
+        goto i#0 ? block@5 : block@4
+    block@4: // if_body_L58
+        itxn_begin
+        ((itxn_field ApplicationArgs) method "greet(string)string")
+        ((itxn_field ApplicationArgs) 0x0002686f)
+        ((itxn_field ApplicationID) appId#0)
+        ((itxn_field TypeEnum) appl)
+        ((itxn_field Fee) 0u)
+        goto block@6
+    block@5: // else_body_L60
+        itxn_next
+        ((itxn_field ApplicationArgs) method "greet(string)string")
+        ((itxn_field ApplicationArgs) 0x0002686f)
+        ((itxn_field ApplicationID) appId#0)
+        ((itxn_field TypeEnum) appl)
+        ((itxn_field Fee) 0u)
+        goto block@6
+    block@6: // after_if_else_L58
+        let i#0: uint64 = (+ i#0 1u)
+        goto block@2
+    block@8: // after_for_L57
+        itxn_submit
+        return 

--- a/tests/from_awst/itxn_compose/out/ItxnComposeAlgo.ir/ItxnComposeAlgo.clear.0.destructured.ir
+++ b/tests/from_awst/itxn_compose/out/ItxnComposeAlgo.ir/ItxnComposeAlgo.clear.0.destructured.ir
@@ -1,0 +1,3 @@
+main @algorandfoundation/algorand-typescript/base-contract.d.ts::BaseContract.clearStateProgram:
+    block@0: // L1
+        return 1u

--- a/tests/from_awst/itxn_compose/out/VerifierContract.approval.teal
+++ b/tests/from_awst/itxn_compose/out/VerifierContract.approval.teal
@@ -1,0 +1,59 @@
+#pragma version 10
+#pragma typetrack false
+
+// @algorandfoundation/algorand-typescript/arc4/index.d.ts::Contract.approvalProgram() -> uint64:
+main:
+    intcblock 1 0
+    txn NumAppArgs
+    bz main_bare_routing@6
+    pushbytes 0x65a9aecc // method "verify()void"
+    txna ApplicationArgs 0
+    match main_verify_route@3
+
+main_after_if_else@10:
+    intc_1 // 0
+    return
+
+main_verify_route@3:
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    callsub verify
+    intc_0 // 1
+    return
+
+main_bare_routing@6:
+    txn OnCompletion
+    bnz main_after_if_else@10
+    txn ApplicationID
+    !
+    assert // can only call when creating
+    intc_0 // 1
+    return
+
+
+// tests/approvals/itxn-compose.algo.ts::VerifierContract.verify() -> void:
+verify:
+    proto 0 0
+    intc_1 // 0
+
+verify_while_top@1:
+    frame_dig 0
+    txn GroupIndex
+    <
+    bz verify_after_while@3
+    frame_dig 0
+    dup
+    gtxns TypeEnum
+    intc_0 // 1
+    ==
+    assert // Txn must be pay
+    intc_0 // 1
+    +
+    frame_bury 0
+    b verify_while_top@1
+
+verify_after_while@3:
+    retsub

--- a/tests/from_awst/itxn_compose/out/VerifierContract.arc32.json
+++ b/tests/from_awst/itxn_compose/out/VerifierContract.arc32.json
@@ -1,0 +1,50 @@
+{
+    "hints": {
+        "verify()void": {
+            "call_config": {
+                "no_op": "CALL"
+            }
+        }
+    },
+    "source": {
+        "approval": "I3ByYWdtYSB2ZXJzaW9uIDEwCiNwcmFnbWEgdHlwZXRyYWNrIGZhbHNlCgovLyBAYWxnb3JhbmRmb3VuZGF0aW9uL2FsZ29yYW5kLXR5cGVzY3JpcHQvYXJjNC9pbmRleC5kLnRzOjpDb250cmFjdC5hcHByb3ZhbFByb2dyYW0oKSAtPiB1aW50NjQ6Cm1haW46CiAgICBpbnRjYmxvY2sgMSAwCiAgICB0eG4gTnVtQXBwQXJncwogICAgYnogbWFpbl9iYXJlX3JvdXRpbmdANgogICAgcHVzaGJ5dGVzIDB4NjVhOWFlY2MgLy8gbWV0aG9kICJ2ZXJpZnkoKXZvaWQiCiAgICB0eG5hIEFwcGxpY2F0aW9uQXJncyAwCiAgICBtYXRjaCBtYWluX3ZlcmlmeV9yb3V0ZUAzCgptYWluX2FmdGVyX2lmX2Vsc2VAMTA6CiAgICBpbnRjXzEgLy8gMAogICAgcmV0dXJuCgptYWluX3ZlcmlmeV9yb3V0ZUAzOgogICAgdHhuIE9uQ29tcGxldGlvbgogICAgIQogICAgYXNzZXJ0IC8vIE9uQ29tcGxldGlvbiBpcyBub3QgTm9PcAogICAgdHhuIEFwcGxpY2F0aW9uSUQKICAgIGFzc2VydCAvLyBjYW4gb25seSBjYWxsIHdoZW4gbm90IGNyZWF0aW5nCiAgICBjYWxsc3ViIHZlcmlmeQogICAgaW50Y18wIC8vIDEKICAgIHJldHVybgoKbWFpbl9iYXJlX3JvdXRpbmdANjoKICAgIHR4biBPbkNvbXBsZXRpb24KICAgIGJueiBtYWluX2FmdGVyX2lmX2Vsc2VAMTAKICAgIHR4biBBcHBsaWNhdGlvbklECiAgICAhCiAgICBhc3NlcnQgLy8gY2FuIG9ubHkgY2FsbCB3aGVuIGNyZWF0aW5nCiAgICBpbnRjXzAgLy8gMQogICAgcmV0dXJuCgoKLy8gdGVzdHMvYXBwcm92YWxzL2l0eG4tY29tcG9zZS5hbGdvLnRzOjpWZXJpZmllckNvbnRyYWN0LnZlcmlmeSgpIC0+IHZvaWQ6CnZlcmlmeToKICAgIHByb3RvIDAgMAogICAgaW50Y18xIC8vIDAKCnZlcmlmeV93aGlsZV90b3BAMToKICAgIGZyYW1lX2RpZyAwCiAgICB0eG4gR3JvdXBJbmRleAogICAgPAogICAgYnogdmVyaWZ5X2FmdGVyX3doaWxlQDMKICAgIGZyYW1lX2RpZyAwCiAgICBkdXAKICAgIGd0eG5zIFR5cGVFbnVtCiAgICBpbnRjXzAgLy8gMQogICAgPT0KICAgIGFzc2VydCAvLyBUeG4gbXVzdCBiZSBwYXkKICAgIGludGNfMCAvLyAxCiAgICArCiAgICBmcmFtZV9idXJ5IDAKICAgIGIgdmVyaWZ5X3doaWxlX3RvcEAxCgp2ZXJpZnlfYWZ0ZXJfd2hpbGVAMzoKICAgIHJldHN1Ygo=",
+        "clear": "I3ByYWdtYSB2ZXJzaW9uIDEwCiNwcmFnbWEgdHlwZXRyYWNrIGZhbHNlCgovLyBAYWxnb3JhbmRmb3VuZGF0aW9uL2FsZ29yYW5kLXR5cGVzY3JpcHQvYmFzZS1jb250cmFjdC5kLnRzOjpCYXNlQ29udHJhY3QuY2xlYXJTdGF0ZVByb2dyYW0oKSAtPiB1aW50NjQ6Cm1haW46CiAgICBwdXNoaW50IDEgLy8gMQogICAgcmV0dXJuCg=="
+    },
+    "state": {
+        "global": {
+            "num_byte_slices": 0,
+            "num_uints": 0
+        },
+        "local": {
+            "num_byte_slices": 0,
+            "num_uints": 0
+        }
+    },
+    "schema": {
+        "global": {
+            "declared": {},
+            "reserved": {}
+        },
+        "local": {
+            "declared": {},
+            "reserved": {}
+        }
+    },
+    "contract": {
+        "name": "VerifierContract",
+        "methods": [
+            {
+                "name": "verify",
+                "args": [],
+                "readonly": false,
+                "returns": {
+                    "type": "void"
+                }
+            }
+        ],
+        "networks": {}
+    },
+    "bare_call_config": {
+        "no_op": "CREATE"
+    }
+}

--- a/tests/from_awst/itxn_compose/out/VerifierContract.clear.teal
+++ b/tests/from_awst/itxn_compose/out/VerifierContract.clear.teal
@@ -1,0 +1,7 @@
+#pragma version 10
+#pragma typetrack false
+
+// @algorandfoundation/algorand-typescript/base-contract.d.ts::BaseContract.clearStateProgram() -> uint64:
+main:
+    pushint 1 // 1
+    return

--- a/tests/from_awst/itxn_compose/out/VerifierContract.ir/VerifierContract.approval.0.destructured.ir
+++ b/tests/from_awst/itxn_compose/out/VerifierContract.ir/VerifierContract.approval.0.destructured.ir
@@ -1,0 +1,50 @@
+main @algorandfoundation/algorand-typescript/arc4/index.d.ts::Contract.approvalProgram:
+    block@0: // L1
+        let tmp%0#1: uint64 = (txn NumAppArgs)
+        goto tmp%0#1 ? block@2 : block@6
+    block@2: // abi_routing_L68
+        let tmp%2#0: bytes = (txna ApplicationArgs 0)
+        switch tmp%2#0 {method "verify()void" => block@3, * => block@10}
+    block@3: // verify_route_L69
+        let tmp%3#0: uint64 = (txn OnCompletion)
+        let tmp%4#0: bool = (! tmp%3#0)
+        (assert tmp%4#0) // OnCompletion is not NoOp
+        let tmp%5#0: uint64 = (txn ApplicationID)
+        (assert tmp%5#0) // can only call when not creating
+        tests/approvals/itxn-compose.algo.ts::VerifierContract.verify()
+        let tests/approvals/itxn-compose.algo.ts::VerifierContract.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = tests/approvals/itxn-compose.algo.ts::VerifierContract.__puya_arc4_router__%0#0
+        goto block@11
+    block@6: // bare_routing_L68
+        let tmp%7#0: uint64 = (txn OnCompletion)
+        goto tmp%7#0 ? block@10 : block@7
+    block@7: // __algots__.defaultCreate_L68
+        let tmp%8#0: uint64 = (txn ApplicationID)
+        let tmp%9#0: bool = (! tmp%8#0)
+        (assert tmp%9#0) // can only call when creating
+        let tests/approvals/itxn-compose.algo.ts::VerifierContract.__puya_arc4_router__%0#0: bool = 1u
+        let tmp%0#0: bool = tests/approvals/itxn-compose.algo.ts::VerifierContract.__puya_arc4_router__%0#0
+        goto block@11
+    block@10: // after_if_else_L68
+        let tests/approvals/itxn-compose.algo.ts::VerifierContract.__puya_arc4_router__%0#0: bool = 0u
+        let tmp%0#0: bool = tests/approvals/itxn-compose.algo.ts::VerifierContract.__puya_arc4_router__%0#0
+        goto block@11
+    block@11: // after_inlined_tests/approvals/itxn-compose.algo.ts::VerifierContract.__puya_arc4_router___L1
+        return tmp%0#0
+
+subroutine tests/approvals/itxn-compose.algo.ts::VerifierContract.verify() -> void:
+    block@0: // L69
+        let i#0: uint64 = 0u
+        goto block@1
+    block@1: // while_top_L70
+        let tmp%0#0: uint64 = (txn GroupIndex)
+        let tmp%1#0: bool = (< i#0 tmp%0#0)
+        goto tmp%1#0 ? block@2 : block@3
+    block@2: // while_body_L70
+        let tmp%2#0: uint64 = ((gtxns TypeEnum) i#0)
+        let tmp%3#0: bool = (== tmp%2#0 1u)
+        (assert tmp%3#0) // Txn must be pay
+        let i#0: uint64 = (+ i#0 1u)
+        goto block@1
+    block@3: // after_while_L70
+        return 

--- a/tests/from_awst/itxn_compose/out/VerifierContract.ir/VerifierContract.clear.0.destructured.ir
+++ b/tests/from_awst/itxn_compose/out/VerifierContract.ir/VerifierContract.clear.0.destructured.ir
@@ -1,0 +1,3 @@
+main @algorandfoundation/algorand-typescript/base-contract.d.ts::BaseContract.clearStateProgram:
+    block@0: // L1
+        return 1u

--- a/tests/from_awst/itxn_compose/test_itxn_compose.py
+++ b/tests/from_awst/itxn_compose/test_itxn_compose.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+import algokit_utils
+import algosdk
+import pytest
+from algosdk.atomic_transaction_composer import TransactionWithSigner
+from algosdk.v2client.algod import AlgodClient
+
+from tests import FROM_AWST_DIR
+from tests.from_awst.util import compile_contract
+
+
+@pytest.mark.localnet
+def test_compile_and_run(
+    algod_client: AlgodClient,
+    account: algokit_utils.Account,
+) -> None:
+    test_dir = Path(__file__).parent
+    out_dir = test_dir / "out"
+
+    clients = compile_contract(
+        algod_client=algod_client,
+        account=account,
+        awst_path=FROM_AWST_DIR / "itxn_compose" / "module.awst.json",
+        compilation_set={
+            "tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo": out_dir,
+            "tests/approvals/itxn-compose.algo.ts::VerifierContract": out_dir,
+        },
+    )
+    app_client_verify = clients["tests/approvals/itxn-compose.algo.ts::VerifierContract"]
+    app_client_itxn = clients["tests/approvals/itxn-compose.algo.ts::ItxnComposeAlgo"]
+
+    app_client_verify.create()
+    app_client_itxn.create()
+
+    algokit_utils.ensure_funded(
+        algod_client,
+        algokit_utils.EnsureBalanceParameters(
+            account_to_fund=app_client_itxn.app_address,
+            min_spending_balance_micro_algos=5_000_000,
+        ),
+    )
+    accounts = [
+        algokit_utils.get_account(algod_client, name="A", fund_with_algos=1000),
+        algokit_utils.get_account(algod_client, name="B", fund_with_algos=1000),
+        algokit_utils.get_account(algod_client, name="C", fund_with_algos=1000),
+    ]
+    addresses = [a.address for a in accounts]
+
+    pay = TransactionWithSigner(
+        txn=algosdk.transaction.PaymentTxn(
+            sender=account.address,
+            receiver=app_client_itxn.app_address,
+            amt=9_000,
+            sp=algod_client.suggested_params(),
+        ),
+        signer=account.signer,
+    )
+
+    sp = algod_client.suggested_params()
+    sp.fee = 1000
+
+    app_client_itxn.call(
+        call_abi_method="distribute",
+        addresses=addresses,
+        funds=pay,
+        verifier=app_client_verify.app_id,
+        transaction_parameters=algokit_utils.OnCompleteCallParameters(
+            foreign_apps=[app_client_verify.app_id], accounts=addresses, suggested_params=sp
+        ),
+    )
+
+    app_client_itxn.call(
+        call_abi_method="conditionalBegin",
+        count=4,
+        transaction_parameters=algokit_utils.OnCompleteCallParameters(suggested_params=sp),
+    )

--- a/tests/from_awst/static_bytes/test_static_bytes.py
+++ b/tests/from_awst/static_bytes/test_static_bytes.py
@@ -16,15 +16,14 @@ def test_compile_and_run(
     test_dir = Path(__file__).parent
     out_dir = test_dir / "out"
 
-    compile_contract(
+    clients = compile_contract(
+        algod_client=algod_client,
+        account=account,
         awst_path=FROM_AWST_DIR / "static_bytes" / "module.awst.json",
         compilation_set={"tests/approvals/static-bytes.algo.ts::StaticBytesAlgo": out_dir},
     )
 
-    app_spec_json = (out_dir / "StaticBytesAlgo.arc32.json").read_text("utf8")
-
-    app_spec = algokit_utils.ApplicationSpecification.from_json(app_spec_json)
-    app_client = algokit_utils.ApplicationClient(algod_client, app_spec, signer=account)
+    app_client = clients["tests/approvals/static-bytes.algo.ts::StaticBytesAlgo"]
 
     app_client.create()
 

--- a/tests/output/nodes.ts.txt
+++ b/tests/output/nodes.ts.txt
@@ -478,6 +478,20 @@ export class InnerTransactionField extends Expression {
      return visitor.visitInnerTransactionField(this)
    }
 }
+export class SetInnerTransactionFields extends Expression {
+  constructor(props: Props<SetInnerTransactionFields>) {
+    super(props)
+    this.itxns = props.itxns
+    this.startWithBegin = props.startWithBegin
+    this.wtype = props.wtype
+  }
+  readonly itxns: Array<Expression>
+  readonly startWithBegin: boolean
+  readonly wtype: wtypes.WType
+  accept<T>(visitor: ExpressionVisitor<T>): T {
+     return visitor.visitSetInnerTransactionFields(this)
+   }
+}
 export class SubmitInnerTransaction extends Expression {
   constructor(props: Props<SubmitInnerTransaction>) {
     super(props)
@@ -1467,6 +1481,7 @@ export const concreteNodes = {
   tupleItemExpression: TupleItemExpression,
   varExpression: VarExpression,
   innerTransactionField: InnerTransactionField,
+  setInnerTransactionFields: SetInnerTransactionFields,
   submitInnerTransaction: SubmitInnerTransaction,
   fieldExpression: FieldExpression,
   indexExpression: IndexExpression,
@@ -1577,6 +1592,7 @@ export interface ExpressionVisitor<T> {
   visitTupleItemExpression(expression: TupleItemExpression): T
   visitVarExpression(expression: VarExpression): T
   visitInnerTransactionField(expression: InnerTransactionField): T
+  visitSetInnerTransactionFields(expression: SetInnerTransactionFields): T
   visitSubmitInnerTransaction(expression: SubmitInnerTransaction): T
   visitFieldExpression(expression: FieldExpression): T
   visitIndexExpression(expression: IndexExpression): T


### PR DESCRIPTION
## Proposed Changes

- Add SetInnerTransactionFields node which abstracts em…ission of `itxn_field` ops for a sequence of WinnerTransactionFields expressions delimited with `itxn_begin` or `itxn_next` ops.
