### PR TITLE
refactor: remove arc4_name from wtypes.ARC4Type

### DIFF
--- a/src/puya/awst/visitors.py
+++ b/src/puya/awst/visitors.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 
 if t.TYPE_CHECKING:
     import puya.awst.nodes
+    import puya.awst.wtypes
 
 
 class StatementVisitor[T](ABC):
@@ -308,3 +309,57 @@ class ExpressionVisitor[T](ABC):
 
     @abstractmethod
     def visit_emit(self, emit: puya.awst.nodes.Emit) -> T: ...
+
+
+class ARC4WTypeVisitor[T](ABC):
+    @abstractmethod
+    def visit_basic_arc4_type(self, wtype: puya.awst.wtypes.ARC4Type) -> T: ...
+
+    @abstractmethod
+    def visit_arc4_uint(self, wtype: puya.awst.wtypes.ARC4UIntN) -> T: ...
+
+    @abstractmethod
+    def visit_arc4_ufixed(self, wtype: puya.awst.wtypes.ARC4UFixedNxM) -> T: ...
+
+    @abstractmethod
+    def visit_arc4_tuple(self, wtype: puya.awst.wtypes.ARC4Tuple) -> T: ...
+
+    @abstractmethod
+    def visit_arc4_dynamic_array(self, wtype: puya.awst.wtypes.ARC4DynamicArray) -> T: ...
+
+    @abstractmethod
+    def visit_arc4_static_array(self, wtype: puya.awst.wtypes.ARC4StaticArray) -> T: ...
+
+    @abstractmethod
+    def visit_arc4_struct(self, wtype: puya.awst.wtypes.ARC4Struct) -> T: ...
+
+
+class WTypeVisitor[T](ARC4WTypeVisitor[T]):
+    @abstractmethod
+    def visit_basic_type(self, wtype: puya.awst.wtypes.WType) -> T: ...
+
+    @abstractmethod
+    def visit_enumeration_type(self, wtype: puya.awst.wtypes.WEnumeration) -> T: ...
+
+    @abstractmethod
+    def visit_group_transaction_type(self, wtype: puya.awst.wtypes.WGroupTransaction) -> T: ...
+
+    @abstractmethod
+    def visit_inner_transaction_type(self, wtype: puya.awst.wtypes.WInnerTransaction) -> T: ...
+
+    @abstractmethod
+    def visit_inner_transaction_fields_type(
+        self, wtype: puya.awst.wtypes.WInnerTransactionFields
+    ) -> T: ...
+
+    @abstractmethod
+    def visit_struct_type(self, wtype: puya.awst.wtypes.WStructType) -> T: ...
+
+    @abstractmethod
+    def visit_stack_array(self, wtype: puya.awst.wtypes.StackArray) -> T: ...
+
+    @abstractmethod
+    def visit_reference_array(self, wtype: puya.awst.wtypes.ReferenceArray) -> T: ...
+
+    @abstractmethod
+    def visit_tuple_type(self, wtype: puya.awst.wtypes.WTuple) -> T: ...

--- a/src/puya/ir/_arc4_default_args.py
+++ b/src/puya/ir/_arc4_default_args.py
@@ -16,7 +16,7 @@ from puya.awst import (
 from puya.context import CompiledProgramProvider
 from puya.errors import CodeError
 from puya.ir._utils import make_subroutine
-from puya.ir.arc4_types import maybe_wtype_to_arc4_wtype, wtype_to_arc4
+from puya.ir.arc4_types import get_arc4_name, maybe_wtype_to_arc4_wtype, wtype_to_arc4
 from puya.ir.builder.main import FunctionIRBuilder
 from puya.ir.context import IRBuildContext
 from puya.ir.optimize.context import IROptimizationContext
@@ -130,14 +130,16 @@ def _compile_arc4_default_constant(
         return None
 
     if isinstance(expr.wtype, wtypes.ARC4Type):
-        arc4_type_name = expr.wtype.arc4_name
+        arc4_wtype = expr.wtype
     else:
         arc4_type = maybe_wtype_to_arc4_wtype(expr.wtype)
         if arc4_type is None:
             logger.error("unsupported type for argument default", location=location)
             return None
         expr = awst_nodes.ARC4Encode(value=expr, wtype=arc4_type, source_location=location)
-        arc4_type_name = arc4_type.arc4_name
+        arc4_wtype = arc4_type
+
+    arc4_type_name = get_arc4_name(arc4_wtype, use_alias=True)
 
     fake_name = f"#default:{param.name}"
     awst_subroutine = awst_nodes.Subroutine(

--- a/src/puya/ir/_contract_metadata.py
+++ b/src/puya/ir/_contract_metadata.py
@@ -17,7 +17,11 @@ from puya.awst import (
 from puya.awst.function_traverser import FunctionTraverser
 from puya.errors import CodeError, InternalError
 from puya.ir._arc4_default_args import convert_default_args
-from puya.ir.arc4_types import wtype_to_arc4, wtype_to_arc4_wtype
+from puya.ir.arc4_types import (
+    get_arc4_name,
+    wtype_to_arc4,
+    wtype_to_arc4_wtype,
+)
 from puya.ir.builder.storage import get_storage_codec
 from puya.ir.context import IRBuildContext
 from puya.parse import SourceLocation
@@ -371,7 +375,7 @@ def _wtype_to_struct(s: wtypes.ARC4Struct | wtypes.WTuple) -> models.ARC4Struct:
         fields.append(
             models.ARC4StructField(
                 name=field_name,
-                type=field_wtype.arc4_name,
+                type=get_arc4_name(field_wtype, use_alias=True),
                 struct=_get_arc4_struct_name(field_wtype),
             )
         )
@@ -428,7 +432,7 @@ def _get_arc56_type(
     if isinstance(wtype, wtypes.ARC4Struct):
         return wtype.name
     if isinstance(wtype, wtypes.ARC4Type):
-        return wtype.arc4_name
+        return get_arc4_name(wtype, use_alias=True)
     if wtype == wtypes.string_wtype:
         return "AVMString"
     match wtype.scalar_type:

--- a/src/puya/ir/arc4_types.py
+++ b/src/puya/ir/arc4_types.py
@@ -1,8 +1,167 @@
 import typing
 
+import attrs
+
 from puya.awst import wtypes
-from puya.errors import CodeError
+from puya.awst.visitors import ARC4WTypeVisitor, WTypeVisitor
+from puya.errors import CodeError, InternalError
 from puya.parse import SourceLocation
+
+
+class ARC4EncodedWTypeConverterVisitor(WTypeVisitor[wtypes.ARC4Type | None]):
+    @typing.override
+    def visit_basic_type(self, wtype: wtypes.WType) -> wtypes.ARC4Type | None:
+        match wtype:
+            case wtypes.account_wtype:
+                return wtypes.arc4_address_alias
+            case wtypes.bool_wtype:
+                return wtypes.arc4_bool_wtype
+            case wtypes.uint64_wtype | wtypes.asset_wtype | wtypes.application_wtype:
+                return wtypes.ARC4UIntN(n=64, source_location=None)
+            case wtypes.biguint_wtype:
+                return wtypes.ARC4UIntN(n=512, source_location=None)
+            case wtypes.bytes_wtype:
+                return wtypes.ARC4DynamicArray(
+                    element_type=wtypes.arc4_byte_alias,
+                    immutable=True,
+                    source_location=None,
+                )
+            case wtypes.string_wtype:
+                return wtypes.arc4_string_alias
+            case _:
+                return None
+
+    @typing.override
+    def visit_enumeration_type(self, wtype: wtypes.WEnumeration) -> None:
+        return None
+
+    @typing.override
+    def visit_group_transaction_type(self, wtype: wtypes.WGroupTransaction) -> None:
+        return None
+
+    @typing.override
+    def visit_inner_transaction_type(self, wtype: wtypes.WInnerTransaction) -> None:
+        return None
+
+    @typing.override
+    def visit_inner_transaction_fields_type(self, wtype: wtypes.WInnerTransactionFields) -> None:
+        return None
+
+    @typing.override
+    def visit_struct_type(self, wtype: wtypes.WStructType) -> typing.Never:
+        raise NotImplementedError
+
+    @typing.override
+    def visit_stack_array(self, wtype: wtypes.StackArray) -> wtypes.ARC4Type | None:
+        arc4_element_type = wtype.element_type.accept(self)
+        if arc4_element_type is None:
+            return None
+        return wtypes.ARC4DynamicArray(element_type=arc4_element_type, immutable=True)
+
+    @typing.override
+    def visit_reference_array(self, wtype: wtypes.ReferenceArray) -> None:
+        return None
+
+    @typing.override
+    def visit_tuple_type(self, wtuple: wtypes.WTuple) -> wtypes.ARC4Type | None:
+        arc4_item_types = []
+        for t in wtuple.types:
+            arc4_type = maybe_wtype_to_arc4_wtype(t)
+            if arc4_type is None:
+                return None
+            arc4_item_types.append(arc4_type)
+        if wtuple.fields:
+            arc4_fields = dict(zip(wtuple.fields, arc4_item_types, strict=True))
+            return wtypes.ARC4Struct(
+                name=wtuple.name, desc=wtuple.desc, frozen=True, fields=arc4_fields
+            )
+        else:
+            return wtypes.ARC4Tuple(types=arc4_item_types, source_location=None)
+
+    @typing.override
+    def visit_basic_arc4_type(self, wtype: wtypes.ARC4Type) -> wtypes.ARC4Type:
+        return wtype
+
+    @typing.override
+    def visit_arc4_uint(self, wtype: wtypes.ARC4UIntN) -> wtypes.ARC4Type:
+        return wtype
+
+    @typing.override
+    def visit_arc4_ufixed(self, wtype: wtypes.ARC4UFixedNxM) -> wtypes.ARC4Type:
+        return wtype
+
+    @typing.override
+    def visit_arc4_tuple(self, wtype: wtypes.ARC4Tuple) -> wtypes.ARC4Type:
+        return wtype
+
+    @typing.override
+    def visit_arc4_dynamic_array(self, wtype: wtypes.ARC4DynamicArray) -> wtypes.ARC4Type:
+        return wtype
+
+    @typing.override
+    def visit_arc4_static_array(self, wtype: wtypes.ARC4StaticArray) -> wtypes.ARC4Type:
+        return wtype
+
+    @typing.override
+    def visit_arc4_struct(self, wtype: wtypes.ARC4Struct) -> wtypes.ARC4Type:
+        return wtype
+
+
+@attrs.frozen
+class ARC4NameWTypeVisitor(ARC4WTypeVisitor[str]):
+    _use_alias: bool = False
+
+    @typing.override
+    def visit_basic_arc4_type(self, wtype: wtypes.ARC4Type) -> str:
+        if self._use_alias and wtype.arc4_alias is not None:
+            return wtype.arc4_alias
+        match wtype:
+            case wtypes.arc4_bool_wtype:
+                return "bool"
+            case _:
+                raise InternalError(f"unexpected ARC-4 basic type: {wtype!r}")
+
+    @typing.override
+    def visit_arc4_uint(self, wtype: wtypes.ARC4UIntN) -> str:
+        if self._use_alias and wtype.arc4_alias is not None:
+            return wtype.arc4_alias
+        return f"uint{wtype.n}"
+
+    @typing.override
+    def visit_arc4_ufixed(self, wtype: wtypes.ARC4UFixedNxM) -> str:
+        if self._use_alias and wtype.arc4_alias is not None:
+            return wtype.arc4_alias
+        return f"ufixed{wtype.n}x{wtype.m}"
+
+    @typing.override
+    def visit_arc4_tuple(self, wtype: wtypes.ARC4Tuple) -> str:
+        typing.assert_type(wtype.arc4_alias, None)
+        item_arc4_names = [t.accept(self) for t in wtype.types]
+        return f"({','.join(item_arc4_names)})"
+
+    @typing.override
+    def visit_arc4_dynamic_array(self, wtype: wtypes.ARC4DynamicArray) -> str:
+        if self._use_alias and wtype.arc4_alias is not None:
+            return wtype.arc4_alias
+        element_arc4_name = wtype.element_type.accept(self)
+        return f"{element_arc4_name}[]"
+
+    @typing.override
+    def visit_arc4_static_array(self, wtype: wtypes.ARC4StaticArray) -> str:
+        if self._use_alias and wtype.arc4_alias is not None:
+            return wtype.arc4_alias
+        element_arc4_name = wtype.element_type.accept(self)
+        return f"{element_arc4_name}[{wtype.array_size}]"
+
+    @typing.override
+    def visit_arc4_struct(self, wtype: wtypes.ARC4Struct) -> str:
+        typing.assert_type(wtype.arc4_alias, None)
+        item_arc4_names = [t.accept(self) for t in wtype.types]
+        return f"({','.join(item_arc4_names)})"
+
+
+def get_arc4_name(wtype: wtypes.ARC4Type, *, use_alias: bool = False) -> str:
+    return wtype.accept(ARC4NameWTypeVisitor(use_alias=use_alias))
 
 
 def wtype_to_arc4(
@@ -16,8 +175,6 @@ def wtype_to_arc4(
     as an argument
     """
     match wtype:
-        case wtypes.ARC4Type(arc4_name=arc4_name):
-            return arc4_name
         case (
             wtypes.asset_wtype
             | wtypes.account_wtype
@@ -31,7 +188,7 @@ def wtype_to_arc4(
     maybe_arc4_wtype = maybe_wtype_to_arc4_wtype(wtype)
     if maybe_arc4_wtype is None:
         raise CodeError(f"unsupported {kind} type for an ARC-4 method", loc)
-    return maybe_arc4_wtype.arc4_name
+    return get_arc4_name(maybe_arc4_wtype, use_alias=True)
 
 
 def maybe_wtype_to_arc4_wtype(wtype: wtypes.WType) -> wtypes.ARC4Type | None:
@@ -39,46 +196,7 @@ def maybe_wtype_to_arc4_wtype(wtype: wtypes.WType) -> wtypes.ARC4Type | None:
     Returns the ARC-4 equivalent type, note account, asset and application types are returned
     as their ARC-4 equivalent stack encoded values and not their ARC-4 reference alias types
     """
-    match wtype:
-        case wtypes.ARC4Type() as arc4_wtype:
-            return arc4_wtype
-        case wtypes.account_wtype:
-            return wtypes.arc4_address_alias
-        case wtypes.bool_wtype:
-            return wtypes.arc4_bool_wtype
-        case wtypes.uint64_wtype | wtypes.asset_wtype | wtypes.application_wtype:
-            return wtypes.ARC4UIntN(n=64, source_location=None)
-        case wtypes.biguint_wtype:
-            return wtypes.ARC4UIntN(n=512, source_location=None)
-        case wtypes.bytes_wtype:
-            return wtypes.ARC4DynamicArray(
-                element_type=wtypes.arc4_byte_alias,
-                immutable=True,
-                source_location=None,
-            )
-        case wtypes.string_wtype:
-            return wtypes.arc4_string_alias
-        case wtypes.StackArray(element_type=element_type):
-            arc4_element_type = maybe_wtype_to_arc4_wtype(element_type)
-            if arc4_element_type is None:
-                return None
-            return wtypes.ARC4DynamicArray(element_type=arc4_element_type, immutable=True)
-        case wtypes.WTuple() as wtuple:
-            arc4_item_types = []
-            for t in wtuple.types:
-                arc4_type = maybe_wtype_to_arc4_wtype(t)
-                if arc4_type is None:
-                    return None
-                arc4_item_types.append(arc4_type)
-            if wtuple.fields:
-                arc4_fields = dict(zip(wtuple.fields, arc4_item_types, strict=True))
-                return wtypes.ARC4Struct(
-                    name=wtuple.name, desc=wtuple.desc, frozen=True, fields=arc4_fields
-                )
-            else:
-                return wtypes.ARC4Tuple(types=arc4_item_types, source_location=None)
-        case _:
-            return None
+    return wtype.accept(ARC4EncodedWTypeConverterVisitor())
 
 
 def wtype_to_arc4_wtype(wtype: wtypes.WType, loc: SourceLocation | None) -> wtypes.ARC4Type:
@@ -110,7 +228,6 @@ def is_equivalent_effective_array_encoding(
 ) -> bool:
     effective_type = effective_array_encoding(array_type, loc)
     typing.assert_type(effective_type, wtypes.ARC4DynamicArray)  # could be expanded to ARC4Type
-    return (
-        isinstance(encoding_type, wtypes.ARC4Type)
-        and effective_type.arc4_name == encoding_type.arc4_name
+    return isinstance(encoding_type, wtypes.ARC4Type) and (
+        get_arc4_name(effective_type) == get_arc4_name(encoding_type)
     )

--- a/tests/test_arc4_codec.py
+++ b/tests/test_arc4_codec.py
@@ -4,6 +4,7 @@ import pytest
 from puya.awst import nodes, wtypes
 from puya.context import CompileContext
 from puya.errors import log_exceptions
+from puya.ir.arc4_types import get_arc4_name
 from puya.ir.main import awst_to_ir
 from puya.log import LogLevel, logging_context
 from puya.options import PuyaOptions
@@ -12,7 +13,7 @@ from puya.parse import SourceLocation
 
 def _arc4_name_or_str(wtype: wtypes.WType) -> str:
     if isinstance(wtype, wtypes.ARC4Type):
-        return wtype.arc4_name
+        return get_arc4_name(wtype, use_alias=True)
     else:
         return str(wtype)
 
@@ -61,7 +62,9 @@ def test_supported_decodes(arc4_type: wtypes.ARC4Type, target_type: wtypes.WType
 def test_unsupported_decodes(arc4_type: wtypes.ARC4Type, target_type: wtypes.WType) -> None:
     func = _build_decode_function(arc4_type, target_type)
     errors = _get_ir_build_errors(func)
-    assert errors == [f"unsupported ARC-4 decode operation from type {arc4_type.arc4_name}"]
+    assert errors == [
+        f"unsupported ARC-4 decode operation from type {_arc4_name_or_str(arc4_type)}"
+    ]
 
 
 def _get_ir_build_errors(func: nodes.Subroutine) -> list[str]:

--- a/tests/test_expected_output/arc4.test
+++ b/tests/test_expected_output/arc4.test
@@ -802,3 +802,15 @@ class ReferenceReturn(arc4.ARC4Contract):
     @arc4.abimethod ## E: unsupported return type for an ARC-4 method
     def txn(self) -> gtxn.Transaction:
         return gtxn.Transaction(1)
+
+
+## case: invalid_arc4_type_in_abi_call
+from algopy import *
+
+@subroutine
+def caller() -> None:
+    arc4.abi_call( ## E: algopy.itxn.PaymentInnerTransaction is not an ARC-4 type and no implicit ARC-4 conversion possible
+        "foo",
+        itxn.Payment(receiver=Txn.sender).submit(),
+        app_id=1234,
+    )


### PR DESCRIPTION
This change removes the required field `arc4_name` from `wtypes.ARC4Type`. For ARC-4 aggregate types (e.g. `arc4.DynamicArray`, `arc4.Struct`), this allows deferring the conversion from native to ARC-4 types until the IR layer. This is a step towards allowing native types inside ARC-4 aggregates to be handled transparently.