### PR TITLE
dependabot: ignore all mypy related packages, and ignore an explicitly versioned package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,5 @@ updates:
       schedule:
           interval: "weekly"
       ignore:
-          - dependency-name: "mypy"
+          - dependency-name: "mypy*"
+          - dependency-name: "python-semantic-release"


### PR DESCRIPTION
@lempira if you can see a way to prevent dependabot from updating explicit version locks like it tried to with #477, that would be neat.