### PR TITLE
fix: Replace warning with error when an unsupported opcode is used for the current execution mode

### DIFF
--- a/src/puya/ir/validation/op_run_mode_validator.py
+++ b/src/puya/ir/validation/op_run_mode_validator.py
@@ -16,13 +16,13 @@ class OpRunModeValidator(DestructuredIRValidator):
                 pass
             case RunMode.app:
                 if self.current_run_mode != RunMode.app:
-                    logger.warning(
+                    logger.error(
                         f"The operation {intrinsic} is only allowed in smart contracts",
                         location=intrinsic.source_location,
                     )
             case RunMode.lsig:
                 if self.current_run_mode != RunMode.lsig:
-                    logger.warning(
+                    logger.error(
                         f"The operation {intrinsic} is only allowed in logic signatures",
                         location=intrinsic.source_location,
                     )

--- a/tests/test_expected_output/ops.test
+++ b/tests/test_expected_output/ops.test
@@ -1,0 +1,24 @@
+# ruff: noqa
+# fmt: off
+# type: ignore
+
+## case: test_contract_use_logic_sig_only
+
+from algopy import Contract, UInt64, op
+
+
+class ContractWithUnreachableCode(Contract):
+    def approval_program(self) -> UInt64:
+        return op.btoi(op.arg(0)) ## E: The operation (arg 0) is only allowed in logic signatures
+
+    def clear_state_program(self) -> bool:
+        return True
+
+## case: test_logic_sig_use_contract_only
+
+from algopy import logicsig, log
+
+@logicsig()
+def some_sig() -> bool:
+    log(b"hello") ## E: The operation (log 0x68656c6c6f) is only allowed in smart contracts
+    return True


### PR DESCRIPTION
Fixes #511 

Replace warning with error when an unsupported opcode is used for the current execution mode