### PR TITLE
ci: add token bot with write perms

### DIFF
--- a/.github/workflows/check-python.yaml
+++ b/.github/workflows/check-python.yaml
@@ -7,7 +7,6 @@ permissions:
   pull-requests: write # needed for thollander/actions-comment-pull-request
 
 jobs:
-
   check-change-log-fragment:
     runs-on: ubuntu-latest
     steps:
@@ -145,7 +144,7 @@ jobs:
           if-no-files-found: error
 
   coverage:
-    needs: [tests]
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Generate token


### PR DESCRIPTION
Same PR as #494, trying from this repo instead of a fork to see if the secrets are accessible