### PR TITLE
fix: handle MypyError objects with invalid line / column values

### DIFF
--- a/src/puyapy/_mypy_build.py
+++ b/src/puyapy/_mypy_build.py
@@ -86,8 +86,8 @@ class _LogReporter(ErrorFormatter):
             resolved_path = Path(error.file_path).resolve()
             location = SourceLocation(
                 file=resolved_path,
-                line=error.line,
-                column=error.column,
+                line=max(error.line, 1),
+                column=error.column if error.column >= 0 else None,
             )
             message = error.message
             if error.errorcode and (


### PR DESCRIPTION
`MypyError` can be missing line / column info, but these are provided as -1 values, which fail our `SourceLocation` validations.

Problem introduced in #551 which hasn't been released yet, so no changelog required.