### PR TITLE
Deserialization error handling

### DIFF
--- a/src/puya/__main__.py
+++ b/src/puya/__main__.py
@@ -61,7 +61,9 @@ def serve(*, log_level: LogLevel = LogLevel.info) -> None:
     Parameters:
         log_level: The minimum log level to be used for logging.
     """
-    start_puya_service(log_level=log_level)
+    # log to stderr to prevent interference with jsonrpc
+    configure_logging(min_log_level=log_level, file=sys.stderr)
+    start_puya_service()
 
 
 def _read_text_from_maybe_compressed_file(path: Path) -> str:


### PR DESCRIPTION
1) When running puya in service mode (currently used by both LSP and soon to also be used by puya-ts in CLI compilations also), leave the "feature" request params in their raw serialized format, and only deserialize ("structure" in cattrs) once we're inside the handler.

    By doing so, we can both capture and report any error messages, which means the client has that information and can report it, and also that it's not left waiting for a response that never arrives.

2) Don't raise builtin exceptions in AWST node validation, prefer to either log (if we can continue without introducing spurious errors later on by doing so), or raise an exception derived from PuyaError and thus retain the source location

3) Improve error logging when an exception occurs during deserialization:

    - Disable "detailed validation" when deserializing with cattrs, this improves performance slightly, and also preserves the original exceptions raised during validation, which are more informative than simply showing the JSON path at which an invalid value appeared.
    - Wrap the structure method so that when a non-PuyaError occurs during deserialization the logged error makes that context clear.