### PR TITLE
fix: correct the consume/produce values for bury op

### DIFF
--- a/src/puya/teal/models.py
+++ b/src/puya/teal/models.py
@@ -188,11 +188,11 @@ class Bury(TealOpUInt8):
 
     @consumes.default
     def _consumes(self) -> int:
-        return self.n
+        return self.n + 1
 
     @produces.default
     def _produces(self) -> int:
-        return self.n - 1
+        return self.n
 
 
 def _valid_uint64(node: TealOp, _attribute: object, value: int) -> None:


### PR DESCRIPTION
The net effect is unaffected (difference of one), and the only place these values are consumed independently is in checking for frame overlap in triplet peephole optimisations, in which bury is considered for optimisation. The other location is in checking stack height, this is an extra check on lowering and pre/post optimisation acting to attempt to catch other potential bugs, and in this case *could* have presented a false positive (ie not detected a runtime failure during compilation). Furthermore, we only use bury ops in very limited circumstances (when there are f-stack values in a proto-less function or in the main subroutine), or to optimise `swap; pop` -> `bury 1`. The latter case is correct, and is not optimised futher. The former case is based on static information at initial lowering time and again not subject to further optimisation.