### PR TITLE
chore(ci): replace RELEASE_GITHUB_TOKEN with GitHub App authentication

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -61,12 +61,19 @@ jobs:
       version_number: ${{ steps.get_version_info.outputs.version_number }}
       version_tag: ${{ steps.get_version_info.outputs.version_tag }}
     steps:
+      - name: Generate bot token
+        uses: actions/create-github-app-token@v1
+        id: app_token
+        with:
+          app-id: ${{ secrets.BOT_ID }}
+          private-key: ${{ secrets.BOT_SK }}
+
       - name: Checkout source code
         uses: actions/checkout@v4
         with:
           # Fetch entire repository history so we can determine version number from it
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          token: ${{ steps.app_token.outputs.token }}
 
       - name: Setup Python venv
         uses: ./.github/actions/setup-python-venv
@@ -83,16 +90,16 @@ jobs:
             algokit localnet start
             pytest
 
-      - name: Set git user as GitHub Actions
+      - name: Set Git user as GitHub actions
         run: |
-          git config --global user.email "actions@github.com" 
-          git config --global user.name "github-actions"
+          git config --global user.email "179917785+engineering-ci[bot]@users.noreply.github.com"
+          git config --global user.name "engineering-ci[bot]"
 
       - name: Collect change log
         if: inputs.bump_version
         run: scriv collect --add
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
 
       - name: Update version
         if: inputs.bump_version
@@ -108,7 +115,7 @@ jobs:
           # commit and tag
           semantic-release $SEMANTIC_RELEASE_DRY_RUN -v --strict version --no-changelog
         env:
-            GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
 
       - name: Get version info
         id: get_version_info
@@ -153,6 +160,13 @@ jobs:
     env:
       VERSION_TAG: ${{ needs.prepare-release.outputs.version_tag }}
     steps:
+      - name: Generate bot token
+        uses: actions/create-github-app-token@v1
+        id: app_token
+        with:
+          app-id: ${{ secrets.BOT_ID }}
+          private-key: ${{ secrets.BOT_SK }}
+
       - name: Checkout source code
         uses: actions/checkout@v4
         with:
@@ -179,7 +193,7 @@ jobs:
       - name: Publish to GitHub
         run: semantic-release $SEMANTIC_RELEASE_DRY_RUN publish --tag $VERSION_TAG
         env:
-            GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
 
   publish-to-pypi:
     name: Publish to PyPI

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -29,22 +29,29 @@ jobs:
       version_number: ${{ steps.get_version_info.outputs.version_number }}
       version_tag: ${{ steps.get_version_info.outputs.version_tag }}
     steps:
+      - name: Generate bot token
+        uses: actions/create-github-app-token@v1
+        id: app_token
+        with:
+          app-id: ${{ secrets.BOT_ID }}
+          private-key: ${{ secrets.BOT_SK }}
+
       - name: Checkout source code
         uses: actions/checkout@v4
         with:
           # Fetch entire repository history so we can determine version number from it
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          token: ${{ steps.app_token.outputs.token }}
 
       - name: Setup Python venv
         uses: ./.github/actions/setup-python-venv
         with:
           uv_sync_args: "--group cicd"
 
-      - name: Set git user as GitHub Actions
+      - name: Set Git user as GitHub actions
         run: |
-          git config --global user.email "actions@github.com" 
-          git config --global user.name "github-actions"
+          git config --global user.email "179917785+engineering-ci[bot]@users.noreply.github.com"
+          git config --global user.name "engineering-ci[bot]"
 
       - name: Update version
         if: inputs.bump_version
@@ -60,7 +67,7 @@ jobs:
           # commit and tag
           semantic-release $SEMANTIC_RELEASE_DRY_RUN -v --strict version --no-changelog --as-prerelease
         env:
-            GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
 
       - name: Get version info
         id: get_version_info
@@ -97,6 +104,13 @@ jobs:
     env:
       VERSION_TAG: ${{ needs.prepare-release.outputs.version_tag }}
     steps:
+      - name: Generate bot token
+        uses: actions/create-github-app-token@v1
+        id: app_token
+        with:
+          app-id: ${{ secrets.BOT_ID }}
+          private-key: ${{ secrets.BOT_SK }}
+
       - name: Checkout source code
         uses: actions/checkout@v4
         with:
@@ -122,4 +136,4 @@ jobs:
       - name: Publish to GitHub
         run: semantic-release $SEMANTIC_RELEASE_DRY_RUN publish --tag $VERSION_TAG
         env:
-            GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}


### PR DESCRIPTION
The GITHUB_RELEASE_TOKEN is about to expire, and, instead of using the RELEASE_GITHUB_TOKEN personal access token, this PR replaces it with the engineering-ci GitHub App for authentication in the CD and prerelease workflows. This aligns with the authentication pattern already established in algokit-utils-py and provides better security, auditability, and credential management.