### PR TITLE
Add missing word to reference arrays error message

### DIFF
--- a/src/puya/awst/wtypes.py
+++ b/src/puya/awst/wtypes.py
@@ -320,7 +320,9 @@ class ReferenceArray(_WTypeInstance):
         if element_type == void_wtype:
             logger.error("array element type cannot be void", location=self.source_location)
         elif not element_type.immutable:
-            logger.error("arrays must have immutable elements", location=self.source_location)
+            logger.error(
+                "reference arrays must have immutable elements", location=self.source_location
+            )
 
     @name.default
     def _name(self) -> str:

--- a/tests/test_expected_output/arrays.test
+++ b/tests/test_expected_output/arrays.test
@@ -15,7 +15,7 @@ from algopy import *
 class ArrayContract(arc4.ARC4Contract):
     @arc4.abimethod
     def array_nested(self) -> None:
-        arr = ReferenceArray[ReferenceArray[Bytes]]() ## E: arrays must have immutable elements
+        arr = ReferenceArray[ReferenceArray[Bytes]]() ## E: reference arrays must have immutable elements
 
 ## case: test_array_element_support
 import typing
@@ -47,15 +47,15 @@ class ArrayContract(arc4.ARC4Contract):
         # this test is a duplicate of one above to cover
         # a case where the same invalid types is present multiple times
         # and ensuring both occurrences show an error
-        arr = ReferenceArray[ReferenceArray[Bytes]]() ## E: arrays must have immutable elements
+        arr = ReferenceArray[ReferenceArray[Bytes]]() ## E: reference arrays must have immutable elements
 
     @arc4.abimethod
     def array_mutable_fixed(self) -> None:
-        arr = ReferenceArray[MutableFixed]() ## E: arrays must have immutable elements
+        arr = ReferenceArray[MutableFixed]() ## E: reference arrays must have immutable elements
 
     @arc4.abimethod
     def array_mutable_dynamic(self) -> None:
-        arr = ReferenceArray[MutableDynamic]() ## E: arrays must have immutable elements
+        arr = ReferenceArray[MutableDynamic]() ## E: reference arrays must have immutable elements
 
     @arc4.abimethod
     def array_void(self) -> None:


### PR DESCRIPTION
Arrays can contain "mutable" elements, this error should state explicitly that it is for reference arrays 