### PR TITLE
refactor: use conventional ARC4Client declaration

### DIFF
--- a/tests/test_expected_output/itxn.test
+++ b/tests/test_expected_output/itxn.test
@@ -178,10 +178,8 @@ from algopy import arc4, subroutine
 
 
 class Client(arc4.ARC4Client, typing.Protocol):
-
     @arc4.abimethod
-    def foo(self, uint: arc4.UInt64) -> None:
-        raise NotImplementedError
+    def foo(self, uint: arc4.UInt64) -> None: ...
 
 
 @subroutine
@@ -214,26 +212,20 @@ import typing
 from algopy import *
 
 class Client(arc4.ARC4Client, typing.Protocol):
+    @arc4.abimethod
+    def foo(self, uint: arc4.UInt64) -> None: ...
 
     @arc4.abimethod
-    def foo(self, uint: arc4.UInt64) -> None:
-        raise NotImplementedError
+    def primitive_types(self, a: UInt64, b: BigUInt, c: Bytes, d: String, e: arc4.UInt64, f: arc4.Bool) -> None: ...
 
     @arc4.abimethod
-    def primitive_types(self, a: UInt64, b: BigUInt, c: Bytes, d: String, e: arc4.UInt64, f: arc4.Bool) -> None:
-        raise NotImplementedError
+    def dynamic_bytes(self, a: Bytes) -> None: ...
 
     @arc4.abimethod
-    def dynamic_bytes(self, a: Bytes) -> None:
-        raise NotImplementedError
+    def static_bytes(self, a: arc4.StaticArray[arc4.Byte, typing.Literal[2]]) -> None: ...
 
     @arc4.abimethod
-    def static_bytes(self, a: arc4.StaticArray[arc4.Byte, typing.Literal[2]]) -> None:
-        raise NotImplementedError
-
-    @arc4.abimethod
-    def acfg_arg(self, acfg: gtxn.AssetConfigTransaction) -> None:
-        raise NotImplementedError
+    def acfg_arg(self, acfg: gtxn.AssetConfigTransaction) -> None: ...
 
 
 @subroutine
@@ -381,8 +373,7 @@ class MyStruct(arc4.Struct):
 
 class Client(arc4.ARC4Client, typing.Protocol):
     @arc4.abimethod
-    def array_check(self, arg: arc4.DynamicArray[MyStruct]) -> None:
-        raise NotImplementedError
+    def array_check(self, arg: arc4.DynamicArray[MyStruct]) -> None: ...
 
 @subroutine
 def correct_array_positional_itxn() -> None:


### PR DESCRIPTION
`raise` is not supported, `raise NotImplementedError` as the sole statement in a method body technically works because MyPy erases it, but we shouldn't rely on this moving forwards.