### PR TITLE
Fix: bug in getbit intrinsic simplification folding (with uint64 and bytes)

### DIFF
--- a/changelog.d/20260415_205953_argimirodelpozo_getbit_bytes_fold_oob.md
+++ b/changelog.d/20260415_205953_argimirodelpozo_getbit_bytes_fold_oob.md
@@ -1,0 +1,45 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Fixed a miscompilation where `getbit` accessing an out of bounds index in a constant `UInt64` would be folded into a constant 0 integer. The AVM should panic in this scenario.
+
+- Fixed a compiler crash when attempting to constant-fold a `getbit` out of bounds index access into a bytes constant.
+
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/changelog.d/20260415_205953_argimirodelpozo_getbit_bytes_fold_oob.md
+++ b/changelog.d/20260415_205953_argimirodelpozo_getbit_bytes_fold_oob.md
@@ -32,7 +32,7 @@ For top level release notes, leave all the headers commented out.
 
 ### Fixed
 
-- Fixed a miscompilation where `getbit` accessing an out of bounds index in a constant `UInt64` would be folded into a constant 0 integer. The AVM should panic in this scenario.
+- Fixed a miscompilation where `getbit` accessing an out of bounds index in a constant `uint64` would be folded into a constant 0 integer. The AVM should panic in this scenario.
 
 - Fixed a compiler crash when attempting to constant-fold a `getbit` out of bounds index access into a bytes constant.
 

--- a/src/puya/ir/optimize/intrinsic_simplification.py
+++ b/src/puya/ir/optimize/intrinsic_simplification.py
@@ -589,6 +589,8 @@ def _try_fold_intrinsic(
                 models.UInt64Constant(value=source, ir_type=PrimitiveIRType.uint64),
                 models.UInt64Constant(value=index),
             ]:
+                if index >= 64:
+                    return None
                 getbit_result = 1 if (source & (1 << index)) else 0
                 return models.UInt64Constant(value=getbit_result, source_location=op_loc)
             case [
@@ -598,7 +600,10 @@ def _try_fold_intrinsic(
                 binary_array = [
                     x for xs in [bin(bb)[2:].zfill(8) for bb in byte_const.value] for x in xs
                 ]
-                the_bit = binary_array[index]
+                try:
+                    the_bit = binary_array[index]
+                except IndexError:
+                    return None
                 return models.UInt64Constant(source_location=op_loc, value=int(the_bit))
     elif intrinsic.op is AVMOp.setbit:
         match intrinsic.args:

--- a/test_cases/regression_tests/getbit_fold_oob_bytes.py
+++ b/test_cases/regression_tests/getbit_fold_oob_bytes.py
@@ -1,0 +1,11 @@
+from algopy import Bytes, Contract, UInt64, op
+
+
+class GetBitFoldOOBBytes(Contract):
+    def approval_program(self) -> bool:
+        # out of bounds bit index access (8 bits, indices 0...7)
+        assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
+        return True
+
+    def clear_state_program(self) -> bool:
+        return True

--- a/test_cases/regression_tests/getbit_fold_oob_bytes.py
+++ b/test_cases/regression_tests/getbit_fold_oob_bytes.py
@@ -1,10 +1,10 @@
-from algopy import Contract, op
+from algopy import Contract, UInt64, op
 
 
 class GetBitFoldOOBBytes(Contract):
     def approval_program(self) -> bool:
         # out of bounds bit index access (8 bits, indices 0...7)
-        assert op.getbit(b"\xff", 8) == 0
+        assert op.getbit(b"\xff", 8) == UInt64(0)
         return True
 
     def clear_state_program(self) -> bool:

--- a/test_cases/regression_tests/getbit_fold_oob_bytes.py
+++ b/test_cases/regression_tests/getbit_fold_oob_bytes.py
@@ -1,10 +1,10 @@
-from algopy import Bytes, Contract, UInt64, op
+from algopy import Contract, op
 
 
 class GetBitFoldOOBBytes(Contract):
     def approval_program(self) -> bool:
         # out of bounds bit index access (8 bits, indices 0...7)
-        assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
+        assert op.getbit(b"\xff", 8) == 0
         return True
 
     def clear_state_program(self) -> bool:

--- a/test_cases/regression_tests/getbit_fold_oob_uint64.py
+++ b/test_cases/regression_tests/getbit_fold_oob_uint64.py
@@ -1,10 +1,10 @@
-from algopy import Contract, op
+from algopy import Contract, UInt64, op
 
 
 class GetBitFoldOOBUInt64(Contract):
     def approval_program(self) -> bool:
         # out of bounds bit index access (should be indices 0...63)
-        assert op.getbit(0, 64) == 0
+        assert op.getbit(0, 64) == UInt64(0)
         return True
 
     def clear_state_program(self) -> bool:

--- a/test_cases/regression_tests/getbit_fold_oob_uint64.py
+++ b/test_cases/regression_tests/getbit_fold_oob_uint64.py
@@ -1,0 +1,11 @@
+from algopy import Contract, UInt64, op
+
+
+class GetBitFoldOOBUInt64(Contract):
+    def approval_program(self) -> bool:
+        # out of bounds bit index access (should be indices 0...63)
+        assert op.getbit(UInt64(0), 64) == UInt64(0)
+        return True
+
+    def clear_state_program(self) -> bool:
+        return True

--- a/test_cases/regression_tests/getbit_fold_oob_uint64.py
+++ b/test_cases/regression_tests/getbit_fold_oob_uint64.py
@@ -1,10 +1,10 @@
-from algopy import Contract, UInt64, op
+from algopy import Contract, op
 
 
 class GetBitFoldOOBUInt64(Contract):
     def approval_program(self) -> bool:
         # out of bounds bit index access (should be indices 0...63)
-        assert op.getbit(UInt64(0), 64) == UInt64(0)
+        assert op.getbit(0, 64) == 0
         return True
 
     def clear_state_program(self) -> bool:

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.approval.assembly-report
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.approval.assembly-report
@@ -1,13 +1,13 @@
-| PC | TEAL Bytes | TEAL               | Source                                           | Location                                                                                           |
-|--: | :----------| :------------------| :------------------------------------------------| :--------------------------------------------------------------------------------------------------|
-|  0 | 0b         | #pragma version 11 |                                                  |                                                                                                    |
-|    | # main     | main:              |                                                  | test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64: |
-|    |            |                    | assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0) | regression_tests/getbit_fold_oob_bytes.py:7                                                        |
-|  1 | 80 01 ff   |     pushbytes 0xff |                  --------------                  | regression_tests/getbit_fold_oob_bytes.py:7:25-39                                                  |
-|  4 | 81 08      |     pushint 8      |                                  -               | regression_tests/getbit_fold_oob_bytes.py:7:41-42                                                  |
-|  6 | 53         |     getbit         |        ----------------------------              | regression_tests/getbit_fold_oob_bytes.py:7:15-43                                                  |
-|  7 | 14         |     !              |        ----------------------------------------- | regression_tests/getbit_fold_oob_bytes.py:7:15-56                                                  |
-|  8 | 44         |     assert         | ------------------------------------------------ | regression_tests/getbit_fold_oob_bytes.py:7:8-56                                                   |
-|    |            |                    | return True                                      | regression_tests/getbit_fold_oob_bytes.py:8                                                        |
-|  9 | 81 01      |     pushint 1      |        ----                                      | regression_tests/getbit_fold_oob_bytes.py:8:15-19                                                  |
-| 11 | 43         |     return         | -----------                                      | regression_tests/getbit_fold_oob_bytes.py:8:8-19                                                   |
+| PC | TEAL Bytes | TEAL               | Source                                    | Location                                                                                           |
+|--: | :----------| :------------------| :-----------------------------------------| :--------------------------------------------------------------------------------------------------|
+|  0 | 0b         | #pragma version 11 |                                           |                                                                                                    |
+|    | # main     | main:              |                                           | test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64: |
+|    |            |                    | assert op.getbit(b"\xff", 8) == UInt64(0) | regression_tests/getbit_fold_oob_bytes.py:7                                                        |
+|  1 | 80 01 ff   |     pushbytes 0xff |                  -------                  | regression_tests/getbit_fold_oob_bytes.py:7:25-32                                                  |
+|  4 | 81 08      |     pushint 8      |                           -               | regression_tests/getbit_fold_oob_bytes.py:7:34-35                                                  |
+|  6 | 53         |     getbit         |        ---------------------              | regression_tests/getbit_fold_oob_bytes.py:7:15-36                                                  |
+|  7 | 14         |     !              |        ---------------------------------- | regression_tests/getbit_fold_oob_bytes.py:7:15-49                                                  |
+|  8 | 44         |     assert         | ----------------------------------------- | regression_tests/getbit_fold_oob_bytes.py:7:8-49                                                   |
+|    |            |                    | return True                               | regression_tests/getbit_fold_oob_bytes.py:8                                                        |
+|  9 | 81 01      |     pushint 1      |        ----                               | regression_tests/getbit_fold_oob_bytes.py:8:15-19                                                  |
+| 11 | 43         |     return         | -----------                               | regression_tests/getbit_fold_oob_bytes.py:8:8-19                                                   |

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.approval.assembly-report
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.approval.assembly-report
@@ -1,0 +1,13 @@
+| PC | TEAL Bytes | TEAL               | Source                                           | Location                                                                                           |
+|--: | :----------| :------------------| :------------------------------------------------| :--------------------------------------------------------------------------------------------------|
+|  0 | 0b         | #pragma version 11 |                                                  |                                                                                                    |
+|    | # main     | main:              |                                                  | test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64: |
+|    |            |                    | assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0) | regression_tests/getbit_fold_oob_bytes.py:7                                                        |
+|  1 | 80 01 ff   |     pushbytes 0xff |                  --------------                  | regression_tests/getbit_fold_oob_bytes.py:7:25-39                                                  |
+|  4 | 81 08      |     pushint 8      |                                  -               | regression_tests/getbit_fold_oob_bytes.py:7:41-42                                                  |
+|  6 | 53         |     getbit         |        ----------------------------              | regression_tests/getbit_fold_oob_bytes.py:7:15-43                                                  |
+|  7 | 14         |     !              |        ----------------------------------------- | regression_tests/getbit_fold_oob_bytes.py:7:15-56                                                  |
+|  8 | 44         |     assert         | ------------------------------------------------ | regression_tests/getbit_fold_oob_bytes.py:7:8-56                                                   |
+|    |            |                    | return True                                      | regression_tests/getbit_fold_oob_bytes.py:8                                                        |
+|  9 | 81 01      |     pushint 1      |        ----                                      | regression_tests/getbit_fold_oob_bytes.py:8:15-19                                                  |
+| 11 | 43         |     return         | -----------                                      | regression_tests/getbit_fold_oob_bytes.py:8:8-19                                                   |

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.approval.puya.map
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.approval.puya.map
@@ -3,7 +3,7 @@
   "sources": [
     "../getbit_fold_oob_bytes.py"
   ],
-  "mappings": ";AAMyB;;;AAAgB;;AAA1B;AAAA;AAAP;AACO;;AAAP",
+  "mappings": ";AAMyB;;;AAAS;;AAAnB;AAAA;AAAP;AACO;;AAAP",
   "op_pc_offset": 0,
   "pc_events": {
     "1": {

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.approval.puya.map
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.approval.puya.map
@@ -1,0 +1,69 @@
+{
+  "version": 3,
+  "sources": [
+    "../getbit_fold_oob_bytes.py"
+  ],
+  "mappings": ";AAMyB;;;AAAgB;;AAA1B;AAAA;AAAP;AACO;;AAAP",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program",
+      "params": {},
+      "block": "main",
+      "stack_in": [],
+      "op": "pushbytes 0xff",
+      "defined_out": [
+        "0xff"
+      ],
+      "stack_out": [
+        "0xff"
+      ]
+    },
+    "4": {
+      "op": "pushint 8",
+      "defined_out": [
+        "0xff",
+        "8"
+      ],
+      "stack_out": [
+        "0xff",
+        "8"
+      ]
+    },
+    "6": {
+      "op": "getbit",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "7": {
+      "op": "!",
+      "defined_out": [
+        "tmp%1#0"
+      ],
+      "stack_out": [
+        "tmp%1#0"
+      ]
+    },
+    "8": {
+      "op": "assert",
+      "stack_out": []
+    },
+    "9": {
+      "op": "pushint 1",
+      "defined_out": [
+        "1"
+      ],
+      "stack_out": [
+        "1"
+      ]
+    },
+    "11": {
+      "op": "return",
+      "stack_out": []
+    }
+  }
+}

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.approval.stats.txt
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.approval.stats.txt
@@ -1,0 +1,10 @@
+total_bytes = 12
+total_ops = 7
+constant_bytes = 7
+constant_ops = 3
+control_flow_bytes = 0
+control_flow_ops = 0
+stack_bytes = 0
+stack_ops = 0
+other_bytes = 4
+other_ops = 4

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.approval.teal
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.approval.teal
@@ -1,0 +1,17 @@
+#pragma version 11
+#pragma typetrack false
+
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+main:
+    // regression_tests/getbit_fold_oob_bytes.py:6-7
+    // # out of bounds bit index access (8 bits, indices 0...7)
+    // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
+    pushbytes 0xff
+    pushint 8
+    getbit
+    !
+    assert
+    // regression_tests/getbit_fold_oob_bytes.py:8
+    // return True
+    pushint 1
+    return

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.approval.teal
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.approval.teal
@@ -5,7 +5,7 @@
 main:
     // regression_tests/getbit_fold_oob_bytes.py:6-7
     // # out of bounds bit index access (8 bits, indices 0...7)
-    // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
+    // assert op.getbit(b"\xff", 8) == UInt64(0)
     pushbytes 0xff
     pushint 8
     getbit

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.clear.assembly-report
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.clear.assembly-report
@@ -1,0 +1,7 @@
+| PC | TEAL Bytes | TEAL               | Source      | Location                                                                                              |
+|--: | :----------| :------------------| :-----------| :-----------------------------------------------------------------------------------------------------|
+|  0 | 0b         | #pragma version 11 |             |                                                                                                       |
+|    | # main     | main:              |             | test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64: |
+|    |            |                    | return True | regression_tests/getbit_fold_oob_bytes.py:11                                                          |
+|  1 | 81 01      |     pushint 1      |        ---- | regression_tests/getbit_fold_oob_bytes.py:11:15-19                                                    |
+|  3 | 43         |     return         | ----------- | regression_tests/getbit_fold_oob_bytes.py:11:8-19                                                     |

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.clear.puya.map
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.clear.puya.map
@@ -1,0 +1,27 @@
+{
+  "version": 3,
+  "sources": [
+    "../getbit_fold_oob_bytes.py"
+  ],
+  "mappings": ";AAUe;;AAAP",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program",
+      "params": {},
+      "block": "main",
+      "stack_in": [],
+      "op": "pushint 1",
+      "defined_out": [
+        "1"
+      ],
+      "stack_out": [
+        "1"
+      ]
+    },
+    "3": {
+      "op": "return",
+      "stack_out": []
+    }
+  }
+}

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.clear.stats.txt
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.clear.stats.txt
@@ -1,0 +1,10 @@
+total_bytes = 4
+total_ops = 2
+constant_bytes = 2
+constant_ops = 1
+control_flow_bytes = 0
+control_flow_ops = 0
+stack_bytes = 0
+stack_ops = 0
+other_bytes = 1
+other_ops = 1

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.clear.teal
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.clear.teal
@@ -1,0 +1,9 @@
+#pragma version 11
+#pragma typetrack false
+
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
+main:
+    // regression_tests/getbit_fold_oob_bytes.py:11
+    // return True
+    pushint 1
+    return

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.000.ssa.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.000.ssa.ir
@@ -1,0 +1,6 @@
+main test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program:
+    block@0: // L5
+        let tmp%0#0: bool = (getbit 0xff 8u)
+        let tmp%1#0: bool = (== 0u tmp%0#0)
+        (assert tmp%1#0)
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.001.ssa.opt.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.001.ssa.opt.ir
@@ -1,0 +1,6 @@
+main test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program:
+    block@0: // L5
+        let tmp%0#0: bool = (getbit 0xff 8u)
+        let tmp%1#0: bool = (! tmp%0#0)
+        (assert tmp%1#0)
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.100.ssa.array.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.100.ssa.array.ir
@@ -1,0 +1,6 @@
+main test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program:
+    block@0: // L5
+        let tmp%0#0: bool = (getbit 0xff 8u)
+        let tmp%1#0: bool = (! tmp%0#0)
+        (assert tmp%1#0)
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.300.ssa.slot.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.300.ssa.slot.ir
@@ -1,0 +1,6 @@
+main test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program:
+    block@0: // L5
+        let tmp%0#0: bool = (getbit 0xff 8u)
+        let tmp%1#0: bool = (! tmp%0#0)
+        (assert tmp%1#0)
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.400.destructured.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.400.destructured.ir
@@ -1,0 +1,6 @@
+main test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program:
+    block@0: // L5
+        let tmp%0#0: bool = (getbit 0xff 8u)
+        let tmp%1#0: bool = (! tmp%0#0)
+        (assert tmp%1#0)
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.500.build.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.500.build.mir
@@ -1,21 +1,21 @@
-// Op                                                       Stack (out)
+// Op                                                  Stack (out)
 // test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_bytes.py:7
-        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
-        byte 0xff                                           0xff
-        int 8                                               0xff,8
-        getbit                                              tmp%0#0
+        // assert op.getbit(b"\xff", 8) == UInt64(0)
+        byte 0xff                                      0xff
+        int 8                                          0xff,8
+        getbit                                         tmp%0#0
         v-store tmp%0#0
-        v-load tmp%0#0                                      tmp%0#0
-        !                                                   tmp%1#0
+        v-load tmp%0#0                                 tmp%0#0
+        !                                              tmp%1#0
         v-store tmp%1#0
-        v-load tmp%1#0                                      tmp%1#0
+        v-load tmp%1#0                                 tmp%1#0
         assert
         // regression_tests/getbit_fold_oob_bytes.py:8
         // return True
-        int 1                                               1
+        int 1                                          1
         return
 
 

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.500.build.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.500.build.mir
@@ -1,0 +1,21 @@
+// Op                                                       Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:7
+        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
+        byte 0xff                                           0xff
+        int 8                                               0xff,8
+        getbit                                              tmp%0#0
+        v-store tmp%0#0
+        v-load tmp%0#0                                      tmp%0#0
+        !                                                   tmp%1#0
+        v-store tmp%1#0
+        v-load tmp%1#0                                      tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_bytes.py:8
+        // return True
+        int 1                                               1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.501.lstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.501.lstack.mir
@@ -1,0 +1,19 @@
+// Op                                                       Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:7
+        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
+        byte 0xff                                           0xff
+        int 8                                               0xff,8
+        getbit                                              tmp%0#0
+        l-load tmp%0#0 0                                    tmp%0#0
+        !                                                   tmp%1#0
+        l-load tmp%1#0 0                                    tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_bytes.py:8
+        // return True
+        int 1                                               1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.501.lstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.501.lstack.mir
@@ -1,19 +1,19 @@
-// Op                                                       Stack (out)
+// Op                                                  Stack (out)
 // test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_bytes.py:7
-        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
-        byte 0xff                                           0xff
-        int 8                                               0xff,8
-        getbit                                              tmp%0#0
-        l-load tmp%0#0 0                                    tmp%0#0
-        !                                                   tmp%1#0
-        l-load tmp%1#0 0                                    tmp%1#0
+        // assert op.getbit(b"\xff", 8) == UInt64(0)
+        byte 0xff                                      0xff
+        int 8                                          0xff,8
+        getbit                                         tmp%0#0
+        l-load tmp%0#0 0                               tmp%0#0
+        !                                              tmp%1#0
+        l-load tmp%1#0 0                               tmp%1#0
         assert
         // regression_tests/getbit_fold_oob_bytes.py:8
         // return True
-        int 1                                               1
+        int 1                                          1
         return
 
 

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.502.lstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.502.lstack.opt.mir
@@ -1,17 +1,17 @@
-// Op                                                       Stack (out)
+// Op                                                  Stack (out)
 // test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_bytes.py:7
-        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
-        byte 0xff                                           0xff
-        int 8                                               0xff,8
-        getbit                                              tmp%0#0
-        !                                                   tmp%1#0
+        // assert op.getbit(b"\xff", 8) == UInt64(0)
+        byte 0xff                                      0xff
+        int 8                                          0xff,8
+        getbit                                         tmp%0#0
+        !                                              tmp%1#0
         assert
         // regression_tests/getbit_fold_oob_bytes.py:8
         // return True
-        int 1                                               1
+        int 1                                          1
         return
 
 

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.502.lstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.502.lstack.opt.mir
@@ -1,0 +1,17 @@
+// Op                                                       Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:7
+        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
+        byte 0xff                                           0xff
+        int 8                                               0xff,8
+        getbit                                              tmp%0#0
+        !                                                   tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_bytes.py:8
+        // return True
+        int 1                                               1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.503.xstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.503.xstack.mir
@@ -1,17 +1,17 @@
-// Op                                                       Stack (out)
+// Op                                                  Stack (out)
 // test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_bytes.py:7
-        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
-        byte 0xff                                           0xff
-        int 8                                               0xff,8
-        getbit                                              tmp%0#0
-        !                                                   tmp%1#0
+        // assert op.getbit(b"\xff", 8) == UInt64(0)
+        byte 0xff                                      0xff
+        int 8                                          0xff,8
+        getbit                                         tmp%0#0
+        !                                              tmp%1#0
         assert
         // regression_tests/getbit_fold_oob_bytes.py:8
         // return True
-        int 1                                               1
+        int 1                                          1
         return
 
 

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.503.xstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.503.xstack.mir
@@ -1,0 +1,17 @@
+// Op                                                       Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:7
+        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
+        byte 0xff                                           0xff
+        int 8                                               0xff,8
+        getbit                                              tmp%0#0
+        !                                                   tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_bytes.py:8
+        // return True
+        int 1                                               1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.504.xstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.504.xstack.opt.mir
@@ -1,17 +1,17 @@
-// Op                                                       Stack (out)
+// Op                                                  Stack (out)
 // test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_bytes.py:7
-        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
-        byte 0xff                                           0xff
-        int 8                                               0xff,8
-        getbit                                              tmp%0#0
-        !                                                   tmp%1#0
+        // assert op.getbit(b"\xff", 8) == UInt64(0)
+        byte 0xff                                      0xff
+        int 8                                          0xff,8
+        getbit                                         tmp%0#0
+        !                                              tmp%1#0
         assert
         // regression_tests/getbit_fold_oob_bytes.py:8
         // return True
-        int 1                                               1
+        int 1                                          1
         return
 
 

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.504.xstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.504.xstack.opt.mir
@@ -1,0 +1,17 @@
+// Op                                                       Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:7
+        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
+        byte 0xff                                           0xff
+        int 8                                               0xff,8
+        getbit                                              tmp%0#0
+        !                                                   tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_bytes.py:8
+        // return True
+        int 1                                               1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.505.fstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.505.fstack.mir
@@ -1,17 +1,17 @@
-// Op                                                       Stack (out)
+// Op                                                  Stack (out)
 // test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_bytes.py:7
-        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
-        byte 0xff                                           0xff
-        int 8                                               0xff,8
-        getbit                                              tmp%0#0
-        !                                                   tmp%1#0
+        // assert op.getbit(b"\xff", 8) == UInt64(0)
+        byte 0xff                                      0xff
+        int 8                                          0xff,8
+        getbit                                         tmp%0#0
+        !                                              tmp%1#0
         assert
         // regression_tests/getbit_fold_oob_bytes.py:8
         // return True
-        int 1                                               1
+        int 1                                          1
         return
 
 

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.505.fstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.505.fstack.mir
@@ -1,0 +1,17 @@
+// Op                                                       Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:7
+        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
+        byte 0xff                                           0xff
+        int 8                                               0xff,8
+        getbit                                              tmp%0#0
+        !                                                   tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_bytes.py:8
+        // return True
+        int 1                                               1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.506.fstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.506.fstack.opt.mir
@@ -1,17 +1,17 @@
-// Op                                                       Stack (out)
+// Op                                                  Stack (out)
 // test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_bytes.py:7
-        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
-        byte 0xff                                           0xff
-        int 8                                               0xff,8
-        getbit                                              tmp%0#0
-        !                                                   tmp%1#0
+        // assert op.getbit(b"\xff", 8) == UInt64(0)
+        byte 0xff                                      0xff
+        int 8                                          0xff,8
+        getbit                                         tmp%0#0
+        !                                              tmp%1#0
         assert
         // regression_tests/getbit_fold_oob_bytes.py:8
         // return True
-        int 1                                               1
+        int 1                                          1
         return
 
 

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.506.fstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.506.fstack.opt.mir
@@ -1,0 +1,17 @@
+// Op                                                       Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:7
+        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
+        byte 0xff                                           0xff
+        int 8                                               0xff,8
+        getbit                                              tmp%0#0
+        !                                                   tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_bytes.py:8
+        // return True
+        int 1                                               1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.507.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.507.mir
@@ -1,17 +1,17 @@
-// Op                                                       Stack (out)
+// Op                                                  Stack (out)
 // test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_bytes.py:7
-        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
-        byte 0xff                                           0xff
-        int 8                                               0xff,8
-        getbit                                              tmp%0#0
-        !                                                   tmp%1#0
+        // assert op.getbit(b"\xff", 8) == UInt64(0)
+        byte 0xff                                      0xff
+        int 8                                          0xff,8
+        getbit                                         tmp%0#0
+        !                                              tmp%1#0
         assert
         // regression_tests/getbit_fold_oob_bytes.py:8
         // return True
-        int 1                                               1
+        int 1                                          1
         return
 
 

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.507.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.507.mir
@@ -1,0 +1,17 @@
+// Op                                                       Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:7
+        // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
+        byte 0xff                                           0xff
+        int 8                                               0xff,8
+        getbit                                              tmp%0#0
+        !                                                   tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_bytes.py:8
+        // return True
+        int 1                                               1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.000.ssa.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.000.ssa.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program:
+    block@0: // L10
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.100.ssa.array.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.100.ssa.array.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program:
+    block@0: // L10
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.300.ssa.slot.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.300.ssa.slot.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program:
+    block@0: // L10
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.400.destructured.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.400.destructured.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program:
+    block@0: // L10
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.500.build.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.500.build.mir
@@ -1,0 +1,10 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:11
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.501.lstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.501.lstack.mir
@@ -1,0 +1,10 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:11
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.502.lstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.502.lstack.opt.mir
@@ -1,0 +1,10 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:11
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.503.xstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.503.xstack.mir
@@ -1,0 +1,10 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:11
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.504.xstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.504.xstack.opt.mir
@@ -1,0 +1,10 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:11
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.505.fstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.505.fstack.mir
@@ -1,0 +1,10 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:11
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.506.fstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.506.fstack.opt.mir
@@ -1,0 +1,10 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:11
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.507.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.507.mir
@@ -1,0 +1,10 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_bytes.py:11
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.approval.assembly-report
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.approval.assembly-report
@@ -1,12 +1,12 @@
-| PC | TEAL Bytes  | TEAL               | Source                                       | Location                                                                                             |
-|--: | :-----------| :------------------| :--------------------------------------------| :----------------------------------------------------------------------------------------------------|
-|  0 | 0b          | #pragma version 11 |                                              |                                                                                                      |
-|    | # main      | main:              |                                              | test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64: |
-|    |             |                    | assert op.getbit(UInt64(0), 64) == UInt64(0) | regression_tests/getbit_fold_oob_uint64.py:7                                                         |
-|  1 | 83 02 00 40 |     pushints 0 64  |                  -------------               | regression_tests/getbit_fold_oob_uint64.py:7:25-38                                                   |
-|  5 | 53          |     getbit         |        ------------------------              | regression_tests/getbit_fold_oob_uint64.py:7:15-39                                                   |
-|  6 | 14          |     !              |        ------------------------------------- | regression_tests/getbit_fold_oob_uint64.py:7:15-52                                                   |
-|  7 | 44          |     assert         | -------------------------------------------- | regression_tests/getbit_fold_oob_uint64.py:7:8-52                                                    |
-|    |             |                    | return True                                  | regression_tests/getbit_fold_oob_uint64.py:8                                                         |
-|  8 | 81 01       |     pushint 1      |        ----                                  | regression_tests/getbit_fold_oob_uint64.py:8:15-19                                                   |
-| 10 | 43          |     return         | -----------                                  | regression_tests/getbit_fold_oob_uint64.py:8:8-19                                                    |
+| PC | TEAL Bytes  | TEAL               | Source                               | Location                                                                                             |
+|--: | :-----------| :------------------| :------------------------------------| :----------------------------------------------------------------------------------------------------|
+|  0 | 0b          | #pragma version 11 |                                      |                                                                                                      |
+|    | # main      | main:              |                                      | test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64: |
+|    |             |                    | assert op.getbit(0, 64) == UInt64(0) | regression_tests/getbit_fold_oob_uint64.py:7                                                         |
+|  1 | 83 02 00 40 |     pushints 0 64  |                  -----               | regression_tests/getbit_fold_oob_uint64.py:7:25-30                                                   |
+|  5 | 53          |     getbit         |        ----------------              | regression_tests/getbit_fold_oob_uint64.py:7:15-31                                                   |
+|  6 | 14          |     !              |        ----------------------------- | regression_tests/getbit_fold_oob_uint64.py:7:15-44                                                   |
+|  7 | 44          |     assert         | ------------------------------------ | regression_tests/getbit_fold_oob_uint64.py:7:8-44                                                    |
+|    |             |                    | return True                          | regression_tests/getbit_fold_oob_uint64.py:8                                                         |
+|  8 | 81 01       |     pushint 1      |        ----                          | regression_tests/getbit_fold_oob_uint64.py:8:15-19                                                   |
+| 10 | 43          |     return         | -----------                          | regression_tests/getbit_fold_oob_uint64.py:8:8-19                                                    |

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.approval.assembly-report
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.approval.assembly-report
@@ -1,0 +1,12 @@
+| PC | TEAL Bytes  | TEAL               | Source                                       | Location                                                                                             |
+|--: | :-----------| :------------------| :--------------------------------------------| :----------------------------------------------------------------------------------------------------|
+|  0 | 0b          | #pragma version 11 |                                              |                                                                                                      |
+|    | # main      | main:              |                                              | test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64: |
+|    |             |                    | assert op.getbit(UInt64(0), 64) == UInt64(0) | regression_tests/getbit_fold_oob_uint64.py:7                                                         |
+|  1 | 83 02 00 40 |     pushints 0 64  |                  -------------               | regression_tests/getbit_fold_oob_uint64.py:7:25-38                                                   |
+|  5 | 53          |     getbit         |        ------------------------              | regression_tests/getbit_fold_oob_uint64.py:7:15-39                                                   |
+|  6 | 14          |     !              |        ------------------------------------- | regression_tests/getbit_fold_oob_uint64.py:7:15-52                                                   |
+|  7 | 44          |     assert         | -------------------------------------------- | regression_tests/getbit_fold_oob_uint64.py:7:8-52                                                    |
+|    |             |                    | return True                                  | regression_tests/getbit_fold_oob_uint64.py:8                                                         |
+|  8 | 81 01       |     pushint 1      |        ----                                  | regression_tests/getbit_fold_oob_uint64.py:8:15-19                                                   |
+| 10 | 43          |     return         | -----------                                  | regression_tests/getbit_fold_oob_uint64.py:8:8-19                                                    |

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.approval.puya.map
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.approval.puya.map
@@ -1,0 +1,60 @@
+{
+  "version": 3,
+  "sources": [
+    "../getbit_fold_oob_uint64.py"
+  ],
+  "mappings": ";AAMyB;;;;AAAV;AAAA;AAAP;AACO;;AAAP",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program",
+      "params": {},
+      "block": "main",
+      "stack_in": [],
+      "op": "pushints 0 64",
+      "defined_out": [
+        "0",
+        "64"
+      ],
+      "stack_out": [
+        "0",
+        "64"
+      ]
+    },
+    "5": {
+      "op": "getbit",
+      "defined_out": [
+        "tmp%0#0"
+      ],
+      "stack_out": [
+        "tmp%0#0"
+      ]
+    },
+    "6": {
+      "op": "!",
+      "defined_out": [
+        "tmp%1#0"
+      ],
+      "stack_out": [
+        "tmp%1#0"
+      ]
+    },
+    "7": {
+      "op": "assert",
+      "stack_out": []
+    },
+    "8": {
+      "op": "pushint 1",
+      "defined_out": [
+        "1"
+      ],
+      "stack_out": [
+        "1"
+      ]
+    },
+    "10": {
+      "op": "return",
+      "stack_out": []
+    }
+  }
+}

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.approval.stats.txt
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.approval.stats.txt
@@ -1,0 +1,10 @@
+total_bytes = 11
+total_ops = 6
+constant_bytes = 6
+constant_ops = 2
+control_flow_bytes = 0
+control_flow_ops = 0
+stack_bytes = 0
+stack_ops = 0
+other_bytes = 4
+other_ops = 4

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.approval.teal
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.approval.teal
@@ -1,0 +1,16 @@
+#pragma version 11
+#pragma typetrack false
+
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+main:
+    // regression_tests/getbit_fold_oob_uint64.py:6-7
+    // # out of bounds bit index access (should be indices 0...63)
+    // assert op.getbit(UInt64(0), 64) == UInt64(0)
+    pushints 0 64
+    getbit
+    !
+    assert
+    // regression_tests/getbit_fold_oob_uint64.py:8
+    // return True
+    pushint 1
+    return

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.approval.teal
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.approval.teal
@@ -5,7 +5,7 @@
 main:
     // regression_tests/getbit_fold_oob_uint64.py:6-7
     // # out of bounds bit index access (should be indices 0...63)
-    // assert op.getbit(UInt64(0), 64) == UInt64(0)
+    // assert op.getbit(0, 64) == UInt64(0)
     pushints 0 64
     getbit
     !

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.clear.assembly-report
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.clear.assembly-report
@@ -1,0 +1,7 @@
+| PC | TEAL Bytes | TEAL               | Source      | Location                                                                                                |
+|--: | :----------| :------------------| :-----------| :-------------------------------------------------------------------------------------------------------|
+|  0 | 0b         | #pragma version 11 |             |                                                                                                         |
+|    | # main     | main:              |             | test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64: |
+|    |            |                    | return True | regression_tests/getbit_fold_oob_uint64.py:11                                                           |
+|  1 | 81 01      |     pushint 1      |        ---- | regression_tests/getbit_fold_oob_uint64.py:11:15-19                                                     |
+|  3 | 43         |     return         | ----------- | regression_tests/getbit_fold_oob_uint64.py:11:8-19                                                      |

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.clear.puya.map
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.clear.puya.map
@@ -1,0 +1,27 @@
+{
+  "version": 3,
+  "sources": [
+    "../getbit_fold_oob_uint64.py"
+  ],
+  "mappings": ";AAUe;;AAAP",
+  "op_pc_offset": 0,
+  "pc_events": {
+    "1": {
+      "subroutine": "test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program",
+      "params": {},
+      "block": "main",
+      "stack_in": [],
+      "op": "pushint 1",
+      "defined_out": [
+        "1"
+      ],
+      "stack_out": [
+        "1"
+      ]
+    },
+    "3": {
+      "op": "return",
+      "stack_out": []
+    }
+  }
+}

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.clear.stats.txt
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.clear.stats.txt
@@ -1,0 +1,10 @@
+total_bytes = 4
+total_ops = 2
+constant_bytes = 2
+constant_ops = 1
+control_flow_bytes = 0
+control_flow_ops = 0
+stack_bytes = 0
+stack_ops = 0
+other_bytes = 1
+other_ops = 1

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.clear.teal
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.clear.teal
@@ -1,0 +1,9 @@
+#pragma version 11
+#pragma typetrack false
+
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+main:
+    // regression_tests/getbit_fold_oob_uint64.py:11
+    // return True
+    pushint 1
+    return

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.000.ssa.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.000.ssa.ir
@@ -1,0 +1,6 @@
+main test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program:
+    block@0: // L5
+        let tmp%0#0: bool = (getbit 0u 64u)
+        let tmp%1#0: bool = (== 0u tmp%0#0)
+        (assert tmp%1#0)
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.001.ssa.opt.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.001.ssa.opt.ir
@@ -1,0 +1,6 @@
+main test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program:
+    block@0: // L5
+        let tmp%0#0: bool = (getbit 0u 64u)
+        let tmp%1#0: bool = (! tmp%0#0)
+        (assert tmp%1#0)
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.100.ssa.array.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.100.ssa.array.ir
@@ -1,0 +1,6 @@
+main test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program:
+    block@0: // L5
+        let tmp%0#0: bool = (getbit 0u 64u)
+        let tmp%1#0: bool = (! tmp%0#0)
+        (assert tmp%1#0)
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.300.ssa.slot.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.300.ssa.slot.ir
@@ -1,0 +1,6 @@
+main test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program:
+    block@0: // L5
+        let tmp%0#0: bool = (getbit 0u 64u)
+        let tmp%1#0: bool = (! tmp%0#0)
+        (assert tmp%1#0)
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.400.destructured.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.400.destructured.ir
@@ -1,0 +1,6 @@
+main test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program:
+    block@0: // L5
+        let tmp%0#0: bool = (getbit 0u 64u)
+        let tmp%1#0: bool = (! tmp%0#0)
+        (assert tmp%1#0)
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.500.build.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.500.build.mir
@@ -3,7 +3,7 @@
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_uint64.py:7
-        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        // assert op.getbit(0, 64) == UInt64(0)
         int 0                                           0
         int 64                                          0,64
         getbit                                          tmp%0#0

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.500.build.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.500.build.mir
@@ -1,0 +1,21 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:7
+        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        int 0                                           0
+        int 64                                          0,64
+        getbit                                          tmp%0#0
+        v-store tmp%0#0
+        v-load tmp%0#0                                  tmp%0#0
+        !                                               tmp%1#0
+        v-store tmp%1#0
+        v-load tmp%1#0                                  tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_uint64.py:8
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.501.lstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.501.lstack.mir
@@ -3,7 +3,7 @@
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_uint64.py:7
-        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        // assert op.getbit(0, 64) == UInt64(0)
         int 0                                           0
         int 64                                          0,64
         getbit                                          tmp%0#0

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.501.lstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.501.lstack.mir
@@ -1,0 +1,19 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:7
+        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        int 0                                           0
+        int 64                                          0,64
+        getbit                                          tmp%0#0
+        l-load tmp%0#0 0                                tmp%0#0
+        !                                               tmp%1#0
+        l-load tmp%1#0 0                                tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_uint64.py:8
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.502.lstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.502.lstack.opt.mir
@@ -3,7 +3,7 @@
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_uint64.py:7
-        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        // assert op.getbit(0, 64) == UInt64(0)
         int 0                                           0
         int 64                                          0,64
         getbit                                          tmp%0#0

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.502.lstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.502.lstack.opt.mir
@@ -1,0 +1,17 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:7
+        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        int 0                                           0
+        int 64                                          0,64
+        getbit                                          tmp%0#0
+        !                                               tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_uint64.py:8
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.503.xstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.503.xstack.mir
@@ -3,7 +3,7 @@
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_uint64.py:7
-        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        // assert op.getbit(0, 64) == UInt64(0)
         int 0                                           0
         int 64                                          0,64
         getbit                                          tmp%0#0

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.503.xstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.503.xstack.mir
@@ -1,0 +1,17 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:7
+        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        int 0                                           0
+        int 64                                          0,64
+        getbit                                          tmp%0#0
+        !                                               tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_uint64.py:8
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.504.xstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.504.xstack.opt.mir
@@ -3,7 +3,7 @@
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_uint64.py:7
-        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        // assert op.getbit(0, 64) == UInt64(0)
         int 0                                           0
         int 64                                          0,64
         getbit                                          tmp%0#0

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.504.xstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.504.xstack.opt.mir
@@ -1,0 +1,17 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:7
+        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        int 0                                           0
+        int 64                                          0,64
+        getbit                                          tmp%0#0
+        !                                               tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_uint64.py:8
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.505.fstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.505.fstack.mir
@@ -3,7 +3,7 @@
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_uint64.py:7
-        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        // assert op.getbit(0, 64) == UInt64(0)
         int 0                                           0
         int 64                                          0,64
         getbit                                          tmp%0#0

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.505.fstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.505.fstack.mir
@@ -1,0 +1,17 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:7
+        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        int 0                                           0
+        int 64                                          0,64
+        getbit                                          tmp%0#0
+        !                                               tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_uint64.py:8
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.506.fstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.506.fstack.opt.mir
@@ -3,7 +3,7 @@
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_uint64.py:7
-        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        // assert op.getbit(0, 64) == UInt64(0)
         int 0                                           0
         int 64                                          0,64
         getbit                                          tmp%0#0

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.506.fstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.506.fstack.opt.mir
@@ -1,0 +1,17 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:7
+        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        int 0                                           0
+        int 64                                          0,64
+        getbit                                          tmp%0#0
+        !                                               tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_uint64.py:8
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.507.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.507.mir
@@ -3,7 +3,7 @@
 subroutine main:
     main_block@0:
         // regression_tests/getbit_fold_oob_uint64.py:7
-        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        // assert op.getbit(0, 64) == UInt64(0)
         int 0                                           0
         int 64                                          0,64
         getbit                                          tmp%0#0

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.507.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.507.mir
@@ -1,0 +1,17 @@
+// Op                                                   Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:7
+        // assert op.getbit(UInt64(0), 64) == UInt64(0)
+        int 0                                           0
+        int 64                                          0,64
+        getbit                                          tmp%0#0
+        !                                               tmp%1#0
+        assert
+        // regression_tests/getbit_fold_oob_uint64.py:8
+        // return True
+        int 1                                           1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.000.ssa.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.000.ssa.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program:
+    block@0: // L10
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.100.ssa.array.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.100.ssa.array.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program:
+    block@0: // L10
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.300.ssa.slot.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.300.ssa.slot.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program:
+    block@0: // L10
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.400.destructured.ir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.400.destructured.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program:
+    block@0: // L10
+        return 1u

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.500.build.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.500.build.mir
@@ -1,0 +1,10 @@
+// Op                                                    Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:11
+        // return True
+        int 1                                            1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.501.lstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.501.lstack.mir
@@ -1,0 +1,10 @@
+// Op                                                    Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:11
+        // return True
+        int 1                                            1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.502.lstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.502.lstack.opt.mir
@@ -1,0 +1,10 @@
+// Op                                                    Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:11
+        // return True
+        int 1                                            1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.503.xstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.503.xstack.mir
@@ -1,0 +1,10 @@
+// Op                                                    Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:11
+        // return True
+        int 1                                            1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.504.xstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.504.xstack.opt.mir
@@ -1,0 +1,10 @@
+// Op                                                    Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:11
+        // return True
+        int 1                                            1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.505.fstack.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.505.fstack.mir
@@ -1,0 +1,10 @@
+// Op                                                    Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:11
+        // return True
+        int 1                                            1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.506.fstack.opt.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.506.fstack.opt.mir
@@ -1,0 +1,10 @@
+// Op                                                    Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:11
+        // return True
+        int 1                                            1
+        return
+
+

--- a/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.507.mir
+++ b/test_cases/regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.507.mir
@@ -1,0 +1,10 @@
+// Op                                                    Stack (out)
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+subroutine main:
+    main_block@0:
+        // regression_tests/getbit_fold_oob_uint64.py:11
+        // return True
+        int 1                                            1
+        return
+
+

--- a/test_cases/regression_tests/out/module.awst
+++ b/test_cases/regression_tests/out/module.awst
@@ -730,6 +730,50 @@ contract Issue118
   }
 }
 
+contract GetBitFoldOOBUInt64
+{
+  method_resolution_order: (
+    algopy._contract.Contract,
+  )
+  
+  subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program(): bool
+  {
+    assert(0u == reinterpret_cast<uint64>(getbit(0u, 64u)))
+    return true
+  }
+  
+  subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program(): bool
+  {
+    return true
+  }
+  
+  subroutine algopy._contract.Contract.__init__(): void
+  {
+  }
+}
+
+contract GetBitFoldOOBBytes
+{
+  method_resolution_order: (
+    algopy._contract.Contract,
+  )
+  
+  subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program(): bool
+  {
+    assert(0u == reinterpret_cast<uint64>(getbit(hex<"FF">, 8u)))
+    return true
+  }
+  
+  subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program(): bool
+  {
+    return true
+  }
+  
+  subroutine algopy._contract.Contract.__init__(): void
+  {
+  }
+}
+
 contract DivIdentityFoldUInt64
 {
   method_resolution_order: (

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.approval.assembly-report
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.approval.assembly-report
@@ -1,13 +1,13 @@
-| PC | TEAL Bytes | TEAL               | Source                                           | Location                                                                                           |
-|--: | :----------| :------------------| :------------------------------------------------| :--------------------------------------------------------------------------------------------------|
-|  0 | 0b         | #pragma version 11 |                                                  |                                                                                                    |
-|    | # main     | main:              |                                                  | test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64: |
-|    |            |                    | assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0) | regression_tests/getbit_fold_oob_bytes.py:7                                                        |
-|  1 | 80 01 ff   |     pushbytes 0xff |                  --------------                  | regression_tests/getbit_fold_oob_bytes.py:7:25-39                                                  |
-|  4 | 81 08      |     pushint 8      |                                  -               | regression_tests/getbit_fold_oob_bytes.py:7:41-42                                                  |
-|  6 | 53         |     getbit         |        ----------------------------              | regression_tests/getbit_fold_oob_bytes.py:7:15-43                                                  |
-|  7 | 14         |     !              |        ----------------------------------------- | regression_tests/getbit_fold_oob_bytes.py:7:15-56                                                  |
-|  8 | 44         |     assert         | ------------------------------------------------ | regression_tests/getbit_fold_oob_bytes.py:7:8-56                                                   |
-|    |            |                    | return True                                      | regression_tests/getbit_fold_oob_bytes.py:8                                                        |
-|  9 | 81 01      |     pushint 1      |        ----                                      | regression_tests/getbit_fold_oob_bytes.py:8:15-19                                                  |
-| 11 | 43         |     return         | -----------                                      | regression_tests/getbit_fold_oob_bytes.py:8:8-19                                                   |
+| PC | TEAL Bytes | TEAL               | Source                                    | Location                                                                                           |
+|--: | :----------| :------------------| :-----------------------------------------| :--------------------------------------------------------------------------------------------------|
+|  0 | 0b         | #pragma version 11 |                                           |                                                                                                    |
+|    | # main     | main:              |                                           | test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64: |
+|    |            |                    | assert op.getbit(b"\xff", 8) == UInt64(0) | regression_tests/getbit_fold_oob_bytes.py:7                                                        |
+|  1 | 80 01 ff   |     pushbytes 0xff |                  -------                  | regression_tests/getbit_fold_oob_bytes.py:7:25-32                                                  |
+|  4 | 81 08      |     pushint 8      |                           -               | regression_tests/getbit_fold_oob_bytes.py:7:34-35                                                  |
+|  6 | 53         |     getbit         |        ---------------------              | regression_tests/getbit_fold_oob_bytes.py:7:15-36                                                  |
+|  7 | 14         |     !              |        ---------------------------------- | regression_tests/getbit_fold_oob_bytes.py:7:15-49                                                  |
+|  8 | 44         |     assert         | ----------------------------------------- | regression_tests/getbit_fold_oob_bytes.py:7:8-49                                                   |
+|    |            |                    | return True                               | regression_tests/getbit_fold_oob_bytes.py:8                                                        |
+|  9 | 81 01      |     pushint 1      |        ----                               | regression_tests/getbit_fold_oob_bytes.py:8:15-19                                                  |
+| 11 | 43         |     return         | -----------                               | regression_tests/getbit_fold_oob_bytes.py:8:8-19                                                   |

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.approval.assembly-report
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.approval.assembly-report
@@ -1,0 +1,13 @@
+| PC | TEAL Bytes | TEAL               | Source                                           | Location                                                                                           |
+|--: | :----------| :------------------| :------------------------------------------------| :--------------------------------------------------------------------------------------------------|
+|  0 | 0b         | #pragma version 11 |                                                  |                                                                                                    |
+|    | # main     | main:              |                                                  | test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64: |
+|    |            |                    | assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0) | regression_tests/getbit_fold_oob_bytes.py:7                                                        |
+|  1 | 80 01 ff   |     pushbytes 0xff |                  --------------                  | regression_tests/getbit_fold_oob_bytes.py:7:25-39                                                  |
+|  4 | 81 08      |     pushint 8      |                                  -               | regression_tests/getbit_fold_oob_bytes.py:7:41-42                                                  |
+|  6 | 53         |     getbit         |        ----------------------------              | regression_tests/getbit_fold_oob_bytes.py:7:15-43                                                  |
+|  7 | 14         |     !              |        ----------------------------------------- | regression_tests/getbit_fold_oob_bytes.py:7:15-56                                                  |
+|  8 | 44         |     assert         | ------------------------------------------------ | regression_tests/getbit_fold_oob_bytes.py:7:8-56                                                   |
+|    |            |                    | return True                                      | regression_tests/getbit_fold_oob_bytes.py:8                                                        |
+|  9 | 81 01      |     pushint 1      |        ----                                      | regression_tests/getbit_fold_oob_bytes.py:8:15-19                                                  |
+| 11 | 43         |     return         | -----------                                      | regression_tests/getbit_fold_oob_bytes.py:8:8-19                                                   |

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.approval.stats.txt
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.approval.stats.txt
@@ -1,0 +1,10 @@
+total_bytes = 12
+total_ops = 7
+constant_bytes = 7
+constant_ops = 3
+control_flow_bytes = 0
+control_flow_ops = 0
+stack_bytes = 0
+stack_ops = 0
+other_bytes = 4
+other_ops = 4

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.approval.teal
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.approval.teal
@@ -1,0 +1,12 @@
+#pragma version 11
+#pragma typetrack false
+
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+main:
+    pushbytes 0xff
+    pushint 8
+    getbit
+    !
+    assert
+    pushint 1
+    return

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.clear.assembly-report
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.clear.assembly-report
@@ -1,0 +1,7 @@
+| PC | TEAL Bytes | TEAL               | Source      | Location                                                                                              |
+|--: | :----------| :------------------| :-----------| :-----------------------------------------------------------------------------------------------------|
+|  0 | 0b         | #pragma version 11 |             |                                                                                                       |
+|    | # main     | main:              |             | test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64: |
+|    |            |                    | return True | regression_tests/getbit_fold_oob_bytes.py:11                                                          |
+|  1 | 81 01      |     pushint 1      |        ---- | regression_tests/getbit_fold_oob_bytes.py:11:15-19                                                    |
+|  3 | 43         |     return         | ----------- | regression_tests/getbit_fold_oob_bytes.py:11:8-19                                                     |

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.clear.stats.txt
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.clear.stats.txt
@@ -1,0 +1,10 @@
+total_bytes = 4
+total_ops = 2
+constant_bytes = 2
+constant_ops = 1
+control_flow_bytes = 0
+control_flow_ops = 0
+stack_bytes = 0
+stack_ops = 0
+other_bytes = 1
+other_ops = 1

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.clear.teal
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.clear.teal
@@ -1,0 +1,7 @@
+#pragma version 11
+#pragma typetrack false
+
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
+main:
+    pushint 1
+    return

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.400.destructured.ir
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.400.destructured.ir
@@ -1,0 +1,6 @@
+main test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program:
+    block@0: // L5
+        let tmp%0#0: bool = (getbit 0xff 8u)
+        let tmp%1#0: bool = (! tmp%0#0)
+        (assert tmp%1#0)
+        return 1u

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.400.destructured.ir
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.400.destructured.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program:
+    block@0: // L10
+        return 1u

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.approval.assembly-report
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.approval.assembly-report
@@ -1,12 +1,12 @@
-| PC | TEAL Bytes  | TEAL               | Source                                       | Location                                                                                             |
-|--: | :-----------| :------------------| :--------------------------------------------| :----------------------------------------------------------------------------------------------------|
-|  0 | 0b          | #pragma version 11 |                                              |                                                                                                      |
-|    | # main      | main:              |                                              | test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64: |
-|    |             |                    | assert op.getbit(UInt64(0), 64) == UInt64(0) | regression_tests/getbit_fold_oob_uint64.py:7                                                         |
-|  1 | 83 02 00 40 |     pushints 0 64  |                  -------------               | regression_tests/getbit_fold_oob_uint64.py:7:25-38                                                   |
-|  5 | 53          |     getbit         |        ------------------------              | regression_tests/getbit_fold_oob_uint64.py:7:15-39                                                   |
-|  6 | 14          |     !              |        ------------------------------------- | regression_tests/getbit_fold_oob_uint64.py:7:15-52                                                   |
-|  7 | 44          |     assert         | -------------------------------------------- | regression_tests/getbit_fold_oob_uint64.py:7:8-52                                                    |
-|    |             |                    | return True                                  | regression_tests/getbit_fold_oob_uint64.py:8                                                         |
-|  8 | 81 01       |     pushint 1      |        ----                                  | regression_tests/getbit_fold_oob_uint64.py:8:15-19                                                   |
-| 10 | 43          |     return         | -----------                                  | regression_tests/getbit_fold_oob_uint64.py:8:8-19                                                    |
+| PC | TEAL Bytes  | TEAL               | Source                               | Location                                                                                             |
+|--: | :-----------| :------------------| :------------------------------------| :----------------------------------------------------------------------------------------------------|
+|  0 | 0b          | #pragma version 11 |                                      |                                                                                                      |
+|    | # main      | main:              |                                      | test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64: |
+|    |             |                    | assert op.getbit(0, 64) == UInt64(0) | regression_tests/getbit_fold_oob_uint64.py:7                                                         |
+|  1 | 83 02 00 40 |     pushints 0 64  |                  -----               | regression_tests/getbit_fold_oob_uint64.py:7:25-30                                                   |
+|  5 | 53          |     getbit         |        ----------------              | regression_tests/getbit_fold_oob_uint64.py:7:15-31                                                   |
+|  6 | 14          |     !              |        ----------------------------- | regression_tests/getbit_fold_oob_uint64.py:7:15-44                                                   |
+|  7 | 44          |     assert         | ------------------------------------ | regression_tests/getbit_fold_oob_uint64.py:7:8-44                                                    |
+|    |             |                    | return True                          | regression_tests/getbit_fold_oob_uint64.py:8                                                         |
+|  8 | 81 01       |     pushint 1      |        ----                          | regression_tests/getbit_fold_oob_uint64.py:8:15-19                                                   |
+| 10 | 43          |     return         | -----------                          | regression_tests/getbit_fold_oob_uint64.py:8:8-19                                                    |

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.approval.assembly-report
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.approval.assembly-report
@@ -1,0 +1,12 @@
+| PC | TEAL Bytes  | TEAL               | Source                                       | Location                                                                                             |
+|--: | :-----------| :------------------| :--------------------------------------------| :----------------------------------------------------------------------------------------------------|
+|  0 | 0b          | #pragma version 11 |                                              |                                                                                                      |
+|    | # main      | main:              |                                              | test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64: |
+|    |             |                    | assert op.getbit(UInt64(0), 64) == UInt64(0) | regression_tests/getbit_fold_oob_uint64.py:7                                                         |
+|  1 | 83 02 00 40 |     pushints 0 64  |                  -------------               | regression_tests/getbit_fold_oob_uint64.py:7:25-38                                                   |
+|  5 | 53          |     getbit         |        ------------------------              | regression_tests/getbit_fold_oob_uint64.py:7:15-39                                                   |
+|  6 | 14          |     !              |        ------------------------------------- | regression_tests/getbit_fold_oob_uint64.py:7:15-52                                                   |
+|  7 | 44          |     assert         | -------------------------------------------- | regression_tests/getbit_fold_oob_uint64.py:7:8-52                                                    |
+|    |             |                    | return True                                  | regression_tests/getbit_fold_oob_uint64.py:8                                                         |
+|  8 | 81 01       |     pushint 1      |        ----                                  | regression_tests/getbit_fold_oob_uint64.py:8:15-19                                                   |
+| 10 | 43          |     return         | -----------                                  | regression_tests/getbit_fold_oob_uint64.py:8:8-19                                                    |

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.approval.stats.txt
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.approval.stats.txt
@@ -1,0 +1,10 @@
+total_bytes = 11
+total_ops = 6
+constant_bytes = 6
+constant_ops = 2
+control_flow_bytes = 0
+control_flow_ops = 0
+stack_bytes = 0
+stack_ops = 0
+other_bytes = 4
+other_ops = 4

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.approval.teal
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.approval.teal
@@ -1,0 +1,11 @@
+#pragma version 11
+#pragma typetrack false
+
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+main:
+    pushints 0 64
+    getbit
+    !
+    assert
+    pushint 1
+    return

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.clear.assembly-report
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.clear.assembly-report
@@ -1,0 +1,7 @@
+| PC | TEAL Bytes | TEAL               | Source      | Location                                                                                                |
+|--: | :----------| :------------------| :-----------| :-------------------------------------------------------------------------------------------------------|
+|  0 | 0b         | #pragma version 11 |             |                                                                                                         |
+|    | # main     | main:              |             | test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64: |
+|    |            |                    | return True | regression_tests/getbit_fold_oob_uint64.py:11                                                           |
+|  1 | 81 01      |     pushint 1      |        ---- | regression_tests/getbit_fold_oob_uint64.py:11:15-19                                                     |
+|  3 | 43         |     return         | ----------- | regression_tests/getbit_fold_oob_uint64.py:11:8-19                                                      |

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.clear.stats.txt
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.clear.stats.txt
@@ -1,0 +1,10 @@
+total_bytes = 4
+total_ops = 2
+constant_bytes = 2
+constant_ops = 1
+control_flow_bytes = 0
+control_flow_ops = 0
+stack_bytes = 0
+stack_ops = 0
+other_bytes = 1
+other_ops = 1

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.clear.teal
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.clear.teal
@@ -1,0 +1,7 @@
+#pragma version 11
+#pragma typetrack false
+
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+main:
+    pushint 1
+    return

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.400.destructured.ir
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.400.destructured.ir
@@ -1,0 +1,6 @@
+main test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program:
+    block@0: // L5
+        let tmp%0#0: bool = (getbit 0u 64u)
+        let tmp%1#0: bool = (! tmp%0#0)
+        (assert tmp%1#0)
+        return 1u

--- a/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.400.destructured.ir
+++ b/test_cases/regression_tests/out_O2/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.400.destructured.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program:
+    block@0: // L10
+        return 1u

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.approval.assembly-report
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.approval.assembly-report
@@ -1,16 +1,16 @@
-| PC | TEAL Bytes     | TEAL               | Source                                           | Location                                                                                           |
-|--: | :--------------| :------------------| :------------------------------------------------| :--------------------------------------------------------------------------------------------------|
-|  0 | 0b             | #pragma version 11 |                                                  |                                                                                                    |
-|    | # main         | main:              |                                                  | test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64: |
-|  1 | 42 00 00       |     b main_block@0 |                                                  |                                                                                                    |
-|    | # main_block@0 | main_block@0:      |                                                  |                                                                                                    |
-|    |                |                    | assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0) | regression_tests/getbit_fold_oob_bytes.py:7                                                        |
-|  4 | 80 01 ff       |     pushbytes 0xff |                  --------------                  | regression_tests/getbit_fold_oob_bytes.py:7:25-39                                                  |
-|  7 | 81 08          |     pushint 8      |                                  -               | regression_tests/getbit_fold_oob_bytes.py:7:41-42                                                  |
-|  9 | 53             |     getbit         |        ----------------------------              | regression_tests/getbit_fold_oob_bytes.py:7:15-43                                                  |
-| 10 | 81 00          |     pushint 0      |                                        --------- | regression_tests/getbit_fold_oob_bytes.py:7:47-56                                                  |
-| 12 | 12             |     ==             |        ----------------------------------------- | regression_tests/getbit_fold_oob_bytes.py:7:15-56                                                  |
-| 13 | 44             |     assert         | ------------------------------------------------ | regression_tests/getbit_fold_oob_bytes.py:7:8-56                                                   |
-|    |                |                    | return True                                      | regression_tests/getbit_fold_oob_bytes.py:8                                                        |
-| 14 | 81 01          |     pushint 1      |        ----                                      | regression_tests/getbit_fold_oob_bytes.py:8:15-19                                                  |
-| 16 | 43             |     return         | -----------                                      | regression_tests/getbit_fold_oob_bytes.py:8:8-19                                                   |
+| PC | TEAL Bytes     | TEAL               | Source                                    | Location                                                                                           |
+|--: | :--------------| :------------------| :-----------------------------------------| :--------------------------------------------------------------------------------------------------|
+|  0 | 0b             | #pragma version 11 |                                           |                                                                                                    |
+|    | # main         | main:              |                                           | test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64: |
+|  1 | 42 00 00       |     b main_block@0 |                                           |                                                                                                    |
+|    | # main_block@0 | main_block@0:      |                                           |                                                                                                    |
+|    |                |                    | assert op.getbit(b"\xff", 8) == UInt64(0) | regression_tests/getbit_fold_oob_bytes.py:7                                                        |
+|  4 | 80 01 ff       |     pushbytes 0xff |                  -------                  | regression_tests/getbit_fold_oob_bytes.py:7:25-32                                                  |
+|  7 | 81 08          |     pushint 8      |                           -               | regression_tests/getbit_fold_oob_bytes.py:7:34-35                                                  |
+|  9 | 53             |     getbit         |        ---------------------              | regression_tests/getbit_fold_oob_bytes.py:7:15-36                                                  |
+| 10 | 81 00          |     pushint 0      |                                 --------- | regression_tests/getbit_fold_oob_bytes.py:7:40-49                                                  |
+| 12 | 12             |     ==             |        ---------------------------------- | regression_tests/getbit_fold_oob_bytes.py:7:15-49                                                  |
+| 13 | 44             |     assert         | ----------------------------------------- | regression_tests/getbit_fold_oob_bytes.py:7:8-49                                                   |
+|    |                |                    | return True                               | regression_tests/getbit_fold_oob_bytes.py:8                                                        |
+| 14 | 81 01          |     pushint 1      |        ----                               | regression_tests/getbit_fold_oob_bytes.py:8:15-19                                                  |
+| 16 | 43             |     return         | -----------                               | regression_tests/getbit_fold_oob_bytes.py:8:8-19                                                   |

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.approval.assembly-report
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.approval.assembly-report
@@ -1,0 +1,16 @@
+| PC | TEAL Bytes     | TEAL               | Source                                           | Location                                                                                           |
+|--: | :--------------| :------------------| :------------------------------------------------| :--------------------------------------------------------------------------------------------------|
+|  0 | 0b             | #pragma version 11 |                                                  |                                                                                                    |
+|    | # main         | main:              |                                                  | test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64: |
+|  1 | 42 00 00       |     b main_block@0 |                                                  |                                                                                                    |
+|    | # main_block@0 | main_block@0:      |                                                  |                                                                                                    |
+|    |                |                    | assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0) | regression_tests/getbit_fold_oob_bytes.py:7                                                        |
+|  4 | 80 01 ff       |     pushbytes 0xff |                  --------------                  | regression_tests/getbit_fold_oob_bytes.py:7:25-39                                                  |
+|  7 | 81 08          |     pushint 8      |                                  -               | regression_tests/getbit_fold_oob_bytes.py:7:41-42                                                  |
+|  9 | 53             |     getbit         |        ----------------------------              | regression_tests/getbit_fold_oob_bytes.py:7:15-43                                                  |
+| 10 | 81 00          |     pushint 0      |                                        --------- | regression_tests/getbit_fold_oob_bytes.py:7:47-56                                                  |
+| 12 | 12             |     ==             |        ----------------------------------------- | regression_tests/getbit_fold_oob_bytes.py:7:15-56                                                  |
+| 13 | 44             |     assert         | ------------------------------------------------ | regression_tests/getbit_fold_oob_bytes.py:7:8-56                                                   |
+|    |                |                    | return True                                      | regression_tests/getbit_fold_oob_bytes.py:8                                                        |
+| 14 | 81 01          |     pushint 1      |        ----                                      | regression_tests/getbit_fold_oob_bytes.py:8:15-19                                                  |
+| 16 | 43             |     return         | -----------                                      | regression_tests/getbit_fold_oob_bytes.py:8:8-19                                                   |

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.approval.stats.txt
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.approval.stats.txt
@@ -1,0 +1,10 @@
+total_bytes = 17
+total_ops = 9
+constant_bytes = 9
+constant_ops = 4
+control_flow_bytes = 3
+control_flow_ops = 1
+stack_bytes = 0
+stack_ops = 0
+other_bytes = 4
+other_ops = 4

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.approval.teal
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.approval.teal
@@ -1,0 +1,21 @@
+#pragma version 11
+#pragma typetrack false
+
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+main:
+    b main_block@0
+
+main_block@0:
+    // regression_tests/getbit_fold_oob_bytes.py:6-7
+    // # out of bounds bit index access (8 bits, indices 0...7)
+    // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
+    pushbytes 0xff
+    pushint 8
+    getbit
+    pushint 0
+    ==
+    assert
+    // regression_tests/getbit_fold_oob_bytes.py:8
+    // return True
+    pushint 1
+    return

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.approval.teal
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.approval.teal
@@ -8,7 +8,7 @@ main:
 main_block@0:
     // regression_tests/getbit_fold_oob_bytes.py:6-7
     // # out of bounds bit index access (8 bits, indices 0...7)
-    // assert op.getbit(Bytes(b"\xff"), 8) == UInt64(0)
+    // assert op.getbit(b"\xff", 8) == UInt64(0)
     pushbytes 0xff
     pushint 8
     getbit

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.clear.assembly-report
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.clear.assembly-report
@@ -1,0 +1,9 @@
+| PC | TEAL Bytes     | TEAL               | Source      | Location                                                                                              |
+|--: | :--------------| :------------------| :-----------| :-----------------------------------------------------------------------------------------------------|
+|  0 | 0b             | #pragma version 11 |             |                                                                                                       |
+|    | # main         | main:              |             | test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64: |
+|  1 | 42 00 00       |     b main_block@0 |             |                                                                                                       |
+|    | # main_block@0 | main_block@0:      |             |                                                                                                       |
+|    |                |                    | return True | regression_tests/getbit_fold_oob_bytes.py:11                                                          |
+|  4 | 81 01          |     pushint 1      |        ---- | regression_tests/getbit_fold_oob_bytes.py:11:15-19                                                    |
+|  6 | 43             |     return         | ----------- | regression_tests/getbit_fold_oob_bytes.py:11:8-19                                                     |

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.clear.stats.txt
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.clear.stats.txt
@@ -1,0 +1,10 @@
+total_bytes = 7
+total_ops = 3
+constant_bytes = 2
+constant_ops = 1
+control_flow_bytes = 3
+control_flow_ops = 1
+stack_bytes = 0
+stack_ops = 0
+other_bytes = 1
+other_ops = 1

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.clear.teal
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.clear.teal
@@ -1,0 +1,12 @@
+#pragma version 11
+#pragma typetrack false
+
+// test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
+main:
+    b main_block@0
+
+main_block@0:
+    // regression_tests/getbit_fold_oob_bytes.py:11
+    // return True
+    pushint 1
+    return

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.400.destructured.ir
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.400.destructured.ir
@@ -1,0 +1,6 @@
+main test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program:
+    block@0: // L5
+        let tmp%0#0: bool = (getbit 0xff 8u)
+        let tmp%1#0: bool = (== 0u tmp%0#0)
+        (assert tmp%1#0)
+        return 1u

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.400.destructured.ir
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.400.destructured.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program:
+    block@0: // L10
+        return 1u

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.approval.assembly-report
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.approval.assembly-report
@@ -1,16 +1,16 @@
-| PC | TEAL Bytes     | TEAL               | Source                                       | Location                                                                                             |
-|--: | :--------------| :------------------| :--------------------------------------------| :----------------------------------------------------------------------------------------------------|
-|  0 | 0b             | #pragma version 11 |                                              |                                                                                                      |
-|    | # main         | main:              |                                              | test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64: |
-|  1 | 42 00 00       |     b main_block@0 |                                              |                                                                                                      |
-|    | # main_block@0 | main_block@0:      |                                              |                                                                                                      |
-|    |                |                    | assert op.getbit(UInt64(0), 64) == UInt64(0) | regression_tests/getbit_fold_oob_uint64.py:7                                                         |
-|  4 | 81 00          |     pushint 0      |                  ---------                   | regression_tests/getbit_fold_oob_uint64.py:7:25-34                                                   |
-|  6 | 81 40          |     pushint 64     |                             --               | regression_tests/getbit_fold_oob_uint64.py:7:36-38                                                   |
-|  8 | 53             |     getbit         |        ------------------------              | regression_tests/getbit_fold_oob_uint64.py:7:15-39                                                   |
-|  9 | 81 00          |     pushint 0      |                                    --------- | regression_tests/getbit_fold_oob_uint64.py:7:43-52                                                   |
-| 11 | 12             |     ==             |        ------------------------------------- | regression_tests/getbit_fold_oob_uint64.py:7:15-52                                                   |
-| 12 | 44             |     assert         | -------------------------------------------- | regression_tests/getbit_fold_oob_uint64.py:7:8-52                                                    |
-|    |                |                    | return True                                  | regression_tests/getbit_fold_oob_uint64.py:8                                                         |
-| 13 | 81 01          |     pushint 1      |        ----                                  | regression_tests/getbit_fold_oob_uint64.py:8:15-19                                                   |
-| 15 | 43             |     return         | -----------                                  | regression_tests/getbit_fold_oob_uint64.py:8:8-19                                                    |
+| PC | TEAL Bytes     | TEAL               | Source                               | Location                                                                                             |
+|--: | :--------------| :------------------| :------------------------------------| :----------------------------------------------------------------------------------------------------|
+|  0 | 0b             | #pragma version 11 |                                      |                                                                                                      |
+|    | # main         | main:              |                                      | test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64: |
+|  1 | 42 00 00       |     b main_block@0 |                                      |                                                                                                      |
+|    | # main_block@0 | main_block@0:      |                                      |                                                                                                      |
+|    |                |                    | assert op.getbit(0, 64) == UInt64(0) | regression_tests/getbit_fold_oob_uint64.py:7                                                         |
+|  4 | 81 00          |     pushint 0      |                  -                   | regression_tests/getbit_fold_oob_uint64.py:7:25-26                                                   |
+|  6 | 81 40          |     pushint 64     |                     --               | regression_tests/getbit_fold_oob_uint64.py:7:28-30                                                   |
+|  8 | 53             |     getbit         |        ----------------              | regression_tests/getbit_fold_oob_uint64.py:7:15-31                                                   |
+|  9 | 81 00          |     pushint 0      |                            --------- | regression_tests/getbit_fold_oob_uint64.py:7:35-44                                                   |
+| 11 | 12             |     ==             |        ----------------------------- | regression_tests/getbit_fold_oob_uint64.py:7:15-44                                                   |
+| 12 | 44             |     assert         | ------------------------------------ | regression_tests/getbit_fold_oob_uint64.py:7:8-44                                                    |
+|    |                |                    | return True                          | regression_tests/getbit_fold_oob_uint64.py:8                                                         |
+| 13 | 81 01          |     pushint 1      |        ----                          | regression_tests/getbit_fold_oob_uint64.py:8:15-19                                                   |
+| 15 | 43             |     return         | -----------                          | regression_tests/getbit_fold_oob_uint64.py:8:8-19                                                    |

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.approval.assembly-report
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.approval.assembly-report
@@ -1,0 +1,16 @@
+| PC | TEAL Bytes     | TEAL               | Source                                       | Location                                                                                             |
+|--: | :--------------| :------------------| :--------------------------------------------| :----------------------------------------------------------------------------------------------------|
+|  0 | 0b             | #pragma version 11 |                                              |                                                                                                      |
+|    | # main         | main:              |                                              | test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64: |
+|  1 | 42 00 00       |     b main_block@0 |                                              |                                                                                                      |
+|    | # main_block@0 | main_block@0:      |                                              |                                                                                                      |
+|    |                |                    | assert op.getbit(UInt64(0), 64) == UInt64(0) | regression_tests/getbit_fold_oob_uint64.py:7                                                         |
+|  4 | 81 00          |     pushint 0      |                  ---------                   | regression_tests/getbit_fold_oob_uint64.py:7:25-34                                                   |
+|  6 | 81 40          |     pushint 64     |                             --               | regression_tests/getbit_fold_oob_uint64.py:7:36-38                                                   |
+|  8 | 53             |     getbit         |        ------------------------              | regression_tests/getbit_fold_oob_uint64.py:7:15-39                                                   |
+|  9 | 81 00          |     pushint 0      |                                    --------- | regression_tests/getbit_fold_oob_uint64.py:7:43-52                                                   |
+| 11 | 12             |     ==             |        ------------------------------------- | regression_tests/getbit_fold_oob_uint64.py:7:15-52                                                   |
+| 12 | 44             |     assert         | -------------------------------------------- | regression_tests/getbit_fold_oob_uint64.py:7:8-52                                                    |
+|    |                |                    | return True                                  | regression_tests/getbit_fold_oob_uint64.py:8                                                         |
+| 13 | 81 01          |     pushint 1      |        ----                                  | regression_tests/getbit_fold_oob_uint64.py:8:15-19                                                   |
+| 15 | 43             |     return         | -----------                                  | regression_tests/getbit_fold_oob_uint64.py:8:8-19                                                    |

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.approval.stats.txt
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.approval.stats.txt
@@ -1,0 +1,10 @@
+total_bytes = 16
+total_ops = 9
+constant_bytes = 8
+constant_ops = 4
+control_flow_bytes = 3
+control_flow_ops = 1
+stack_bytes = 0
+stack_ops = 0
+other_bytes = 4
+other_ops = 4

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.approval.teal
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.approval.teal
@@ -8,7 +8,7 @@ main:
 main_block@0:
     // regression_tests/getbit_fold_oob_uint64.py:6-7
     // # out of bounds bit index access (should be indices 0...63)
-    // assert op.getbit(UInt64(0), 64) == UInt64(0)
+    // assert op.getbit(0, 64) == UInt64(0)
     pushint 0
     pushint 64
     getbit

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.approval.teal
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.approval.teal
@@ -1,0 +1,21 @@
+#pragma version 11
+#pragma typetrack false
+
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+main:
+    b main_block@0
+
+main_block@0:
+    // regression_tests/getbit_fold_oob_uint64.py:6-7
+    // # out of bounds bit index access (should be indices 0...63)
+    // assert op.getbit(UInt64(0), 64) == UInt64(0)
+    pushint 0
+    pushint 64
+    getbit
+    pushint 0
+    ==
+    assert
+    // regression_tests/getbit_fold_oob_uint64.py:8
+    // return True
+    pushint 1
+    return

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.clear.assembly-report
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.clear.assembly-report
@@ -1,0 +1,9 @@
+| PC | TEAL Bytes     | TEAL               | Source      | Location                                                                                                |
+|--: | :--------------| :------------------| :-----------| :-------------------------------------------------------------------------------------------------------|
+|  0 | 0b             | #pragma version 11 |             |                                                                                                         |
+|    | # main         | main:              |             | test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64: |
+|  1 | 42 00 00       |     b main_block@0 |             |                                                                                                         |
+|    | # main_block@0 | main_block@0:      |             |                                                                                                         |
+|    |                |                    | return True | regression_tests/getbit_fold_oob_uint64.py:11                                                           |
+|  4 | 81 01          |     pushint 1      |        ---- | regression_tests/getbit_fold_oob_uint64.py:11:15-19                                                     |
+|  6 | 43             |     return         | ----------- | regression_tests/getbit_fold_oob_uint64.py:11:8-19                                                      |

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.clear.stats.txt
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.clear.stats.txt
@@ -1,0 +1,10 @@
+total_bytes = 7
+total_ops = 3
+constant_bytes = 2
+constant_ops = 1
+control_flow_bytes = 3
+control_flow_ops = 1
+stack_bytes = 0
+stack_ops = 0
+other_bytes = 1
+other_ops = 1

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.clear.teal
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.clear.teal
@@ -1,0 +1,12 @@
+#pragma version 11
+#pragma typetrack false
+
+// test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+main:
+    b main_block@0
+
+main_block@0:
+    // regression_tests/getbit_fold_oob_uint64.py:11
+    // return True
+    pushint 1
+    return

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.400.destructured.ir
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.400.destructured.ir
@@ -1,0 +1,6 @@
+main test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program:
+    block@0: // L5
+        let tmp%0#0: bool = (getbit 0u 64u)
+        let tmp%1#0: bool = (== 0u tmp%0#0)
+        (assert tmp%1#0)
+        return 1u

--- a/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.400.destructured.ir
+++ b/test_cases/regression_tests/out_unoptimized/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.400.destructured.ir
@@ -1,0 +1,3 @@
+main test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program:
+    block@0: // L10
+        return 1u

--- a/test_cases/regression_tests/puya.log
+++ b/test_cases/regression_tests/puya.log
@@ -3162,6 +3162,200 @@ debug: removing unused subroutine test_cases.regression_tests.issue_118.Issue118
 debug: removing unused subroutine algopy.arc4.ARC4Contract.approval_program
 debug: removing unused subroutine algopy.arc4.ARC4Contract.clear_state_program
 debug: removing unused subroutine algopy._contract.Contract.__init__
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function algopy._contract.Contract.__init__
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_dec
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_inc
+debug: removing unused subroutine _puya_lib.box_arc4._box_extract_u16
+debug: removing unused subroutine _puya_lib.box_arc4._as_uint16
+debug: removing unused subroutine _puya_lib.arc4._itob16
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.r_trim
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4._recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_assert_index
+debug: removing unused subroutine test_cases.regression_tests.xor_identity_fold_biguint.self_xor
+debug: removing unused subroutine test_cases.regression_tests.wrong_import_location__sub.get_return_value
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.do_something_with_array
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.append_to_array
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke_with_fstack
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm_uint64
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_uint64.self_div
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_biguint.self_div
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: removing unused subroutine algopy._contract.Contract.__init__
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_dec
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_inc
+debug: removing unused subroutine _puya_lib.box_arc4._box_extract_u16
+debug: removing unused subroutine _puya_lib.box_arc4._as_uint16
+debug: removing unused subroutine _puya_lib.arc4._itob16
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.r_trim
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4._recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_assert_index
+debug: removing unused subroutine test_cases.regression_tests.xor_identity_fold_biguint.self_xor
+debug: removing unused subroutine test_cases.regression_tests.wrong_import_location__sub.get_return_value
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.do_something_with_array
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.append_to_array
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke_with_fstack
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm_uint64
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_uint64.self_div
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_biguint.self_div
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: removing unused subroutine algopy._contract.Contract.__init__
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function algopy._contract.Contract.__init__
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_dec
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_inc
+debug: removing unused subroutine _puya_lib.box_arc4._box_extract_u16
+debug: removing unused subroutine _puya_lib.box_arc4._as_uint16
+debug: removing unused subroutine _puya_lib.arc4._itob16
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.r_trim
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4._recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_assert_index
+debug: removing unused subroutine test_cases.regression_tests.xor_identity_fold_biguint.self_xor
+debug: removing unused subroutine test_cases.regression_tests.wrong_import_location__sub.get_return_value
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.do_something_with_array
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.append_to_array
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke_with_fstack
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm_uint64
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_uint64.self_div
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_biguint.self_div
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: removing unused subroutine algopy._contract.Contract.__init__
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_dec
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_inc
+debug: removing unused subroutine _puya_lib.box_arc4._box_extract_u16
+debug: removing unused subroutine _puya_lib.box_arc4._as_uint16
+debug: removing unused subroutine _puya_lib.arc4._itob16
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.r_trim
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4._recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_assert_index
+debug: removing unused subroutine test_cases.regression_tests.xor_identity_fold_biguint.self_xor
+debug: removing unused subroutine test_cases.regression_tests.wrong_import_location__sub.get_return_value
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.do_something_with_array
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.append_to_array
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke_with_fstack
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm_uint64
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_uint64.self_div
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_biguint.self_div
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: removing unused subroutine algopy._contract.Contract.__init__
 debug: Building IR for function test_cases.regression_tests.div_identity_fold_uint64.DivIdentityFoldUInt64.approval_program
 debug: Sealing block@0
 debug: Terminated block@0
@@ -17058,6 +17252,316 @@ debug: removing explicit jump to fall-through block verify_after_inlined_test_ca
 debug: optimizing TEAL subroutine ops algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
 debug: optimizing TEAL subroutine blocks algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
 debug: inlining single reference block main_block@0 into main
+debug: Output IR to regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.000.ssa.ir
+debug: Output IR to regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.000.ssa.ir
+debug: optimizing approval program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64 at level 1
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Simplified (== 0u tmp%0#0) to (! tmp%0#0)
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: Output IR to regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.001.ssa.opt.ir
+debug: Begin optimization pass 2/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 2, ending loop
+debug: optimizing clear program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64 at level 1
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: lowering array IR nodes in approval program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64
+debug: Output IR to regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.100.ssa.array.ir
+debug: lowering array IR nodes in clear program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64
+debug: Output IR to regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.100.ssa.array.ir
+debug: optimizing approval program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64 at level 1
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: optimizing clear program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64 at level 1
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: removing local static slots in approval program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64
+regression_tests/getbit_fold_oob_uint64.py:5:5 debug: auto reserving slots in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program, []
+debug: Slot allocation not required
+debug: Output IR to regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.300.ssa.slot.ir
+debug: removing local static slots in clear program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64
+regression_tests/getbit_fold_oob_uint64.py:10:5 debug: auto reserving slots in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program, []
+debug: Slot allocation not required
+debug: Output IR to regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.300.ssa.slot.ir
+debug: Performing SSA IR destructuring for test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program using strategy 'root_operand'
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Performing post-SSA optimizations at level 1
+debug: Output IR to regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.400.destructured.ir
+debug: Performing SSA IR destructuring for test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program using strategy 'root_operand'
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Performing post-SSA optimizations at level 1
+debug: Output IR to regression_tests/out/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.400.destructured.ir
+debug: Inserted main_block@0.ops[3]: 'l-store-copy tmp%0#0 0'
+debug: Replaced main_block@0.ops[5]: 'v-load tmp%0#0' with 'l-load tmp%0#0'
+debug: Inserted main_block@0.ops[7]: 'l-store-copy tmp%1#0 0'
+debug: Replaced main_block@0.ops[9]: 'v-load tmp%1#0' with 'l-load tmp%1#0'
+regression_tests/getbit_fold_oob_uint64.py:5:5 debug: optimizing TEAL subroutine ops test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+regression_tests/getbit_fold_oob_uint64.py:5:5 debug: optimizing TEAL subroutine blocks test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+debug: inlining single reference block main_block@0 into main
+regression_tests/getbit_fold_oob_uint64.py:10:5 debug: optimizing TEAL subroutine ops test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+regression_tests/getbit_fold_oob_uint64.py:10:5 debug: optimizing TEAL subroutine blocks test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+debug: inlining single reference block main_block@0 into main
+debug: Output IR to regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.000.ssa.ir
+debug: Output IR to regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.000.ssa.ir
+debug: optimizing approval program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes at level 1
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Simplified (== 0u tmp%0#0) to (! tmp%0#0)
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: Output IR to regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.001.ssa.opt.ir
+debug: Begin optimization pass 2/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 2, ending loop
+debug: optimizing clear program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes at level 1
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: lowering array IR nodes in approval program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes
+debug: Output IR to regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.100.ssa.array.ir
+debug: lowering array IR nodes in clear program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes
+debug: Output IR to regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.100.ssa.array.ir
+debug: optimizing approval program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes at level 1
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: optimizing clear program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes at level 1
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: removing local static slots in approval program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes
+regression_tests/getbit_fold_oob_bytes.py:5:5 debug: auto reserving slots in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program, []
+debug: Slot allocation not required
+debug: Output IR to regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.300.ssa.slot.ir
+debug: removing local static slots in clear program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes
+regression_tests/getbit_fold_oob_bytes.py:10:5 debug: auto reserving slots in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program, []
+debug: Slot allocation not required
+debug: Output IR to regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.300.ssa.slot.ir
+debug: Performing SSA IR destructuring for test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program using strategy 'root_operand'
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Performing post-SSA optimizations at level 1
+debug: Output IR to regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.400.destructured.ir
+debug: Performing SSA IR destructuring for test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program using strategy 'root_operand'
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Performing post-SSA optimizations at level 1
+debug: Output IR to regression_tests/out/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.400.destructured.ir
+debug: Inserted main_block@0.ops[3]: 'l-store-copy tmp%0#0 0'
+debug: Replaced main_block@0.ops[5]: 'v-load tmp%0#0' with 'l-load tmp%0#0'
+debug: Inserted main_block@0.ops[7]: 'l-store-copy tmp%1#0 0'
+debug: Replaced main_block@0.ops[9]: 'v-load tmp%1#0' with 'l-load tmp%1#0'
+regression_tests/getbit_fold_oob_bytes.py:5:5 debug: optimizing TEAL subroutine ops test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+regression_tests/getbit_fold_oob_bytes.py:5:5 debug: optimizing TEAL subroutine blocks test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+debug: inlining single reference block main_block@0 into main
+regression_tests/getbit_fold_oob_bytes.py:10:5 debug: optimizing TEAL subroutine ops test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
+regression_tests/getbit_fold_oob_bytes.py:10:5 debug: optimizing TEAL subroutine blocks test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
+debug: inlining single reference block main_block@0 into main
 debug: Output IR to regression_tests/out/DivIdentityFoldUInt64.ir/DivIdentityFoldUInt64.approval.000.ssa.ir
 debug: Output IR to regression_tests/out/DivIdentityFoldUInt64.ir/DivIdentityFoldUInt64.clear.000.ssa.ir
 debug: optimizing approval program of test_cases.regression_tests.div_identity_fold_uint64.DivIdentityFoldUInt64 at level 1
@@ -20701,6 +21205,26 @@ info: Writing regression_tests/out/Issue118.approval.assembly-report
 info: Writing regression_tests/out/Issue118.clear.assembly-report
 info: Writing regression_tests/out/Issue118.approval.puya.map
 info: Writing regression_tests/out/Issue118.clear.puya.map
+info: Writing regression_tests/out/GetBitFoldOOBUInt64.approval.teal
+info: Writing regression_tests/out/GetBitFoldOOBUInt64.clear.teal
+info: Writing regression_tests/out/GetBitFoldOOBUInt64.approval.bin
+info: Writing regression_tests/out/GetBitFoldOOBUInt64.clear.bin
+info: Writing regression_tests/out/GetBitFoldOOBUInt64.approval.stats.txt
+info: Writing regression_tests/out/GetBitFoldOOBUInt64.clear.stats.txt
+info: Writing regression_tests/out/GetBitFoldOOBUInt64.approval.assembly-report
+info: Writing regression_tests/out/GetBitFoldOOBUInt64.clear.assembly-report
+info: Writing regression_tests/out/GetBitFoldOOBUInt64.approval.puya.map
+info: Writing regression_tests/out/GetBitFoldOOBUInt64.clear.puya.map
+info: Writing regression_tests/out/GetBitFoldOOBBytes.approval.teal
+info: Writing regression_tests/out/GetBitFoldOOBBytes.clear.teal
+info: Writing regression_tests/out/GetBitFoldOOBBytes.approval.bin
+info: Writing regression_tests/out/GetBitFoldOOBBytes.clear.bin
+info: Writing regression_tests/out/GetBitFoldOOBBytes.approval.stats.txt
+info: Writing regression_tests/out/GetBitFoldOOBBytes.clear.stats.txt
+info: Writing regression_tests/out/GetBitFoldOOBBytes.approval.assembly-report
+info: Writing regression_tests/out/GetBitFoldOOBBytes.clear.assembly-report
+info: Writing regression_tests/out/GetBitFoldOOBBytes.approval.puya.map
+info: Writing regression_tests/out/GetBitFoldOOBBytes.clear.puya.map
 info: Writing regression_tests/out/DivIdentityFoldUInt64.approval.teal
 info: Writing regression_tests/out/DivIdentityFoldUInt64.clear.teal
 info: Writing regression_tests/out/DivIdentityFoldUInt64.approval.bin

--- a/test_cases/regression_tests/puya_O2.log
+++ b/test_cases/regression_tests/puya_O2.log
@@ -3161,6 +3161,200 @@ debug: removing unused subroutine test_cases.regression_tests.issue_118.Issue118
 debug: removing unused subroutine algopy.arc4.ARC4Contract.approval_program
 debug: removing unused subroutine algopy.arc4.ARC4Contract.clear_state_program
 debug: removing unused subroutine algopy._contract.Contract.__init__
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function algopy._contract.Contract.__init__
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_dec
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_inc
+debug: removing unused subroutine _puya_lib.box_arc4._box_extract_u16
+debug: removing unused subroutine _puya_lib.box_arc4._as_uint16
+debug: removing unused subroutine _puya_lib.arc4._itob16
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.r_trim
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4._recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_assert_index
+debug: removing unused subroutine test_cases.regression_tests.xor_identity_fold_biguint.self_xor
+debug: removing unused subroutine test_cases.regression_tests.wrong_import_location__sub.get_return_value
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.do_something_with_array
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.append_to_array
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke_with_fstack
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm_uint64
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_uint64.self_div
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_biguint.self_div
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: removing unused subroutine algopy._contract.Contract.__init__
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_dec
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_inc
+debug: removing unused subroutine _puya_lib.box_arc4._box_extract_u16
+debug: removing unused subroutine _puya_lib.box_arc4._as_uint16
+debug: removing unused subroutine _puya_lib.arc4._itob16
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.r_trim
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4._recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_assert_index
+debug: removing unused subroutine test_cases.regression_tests.xor_identity_fold_biguint.self_xor
+debug: removing unused subroutine test_cases.regression_tests.wrong_import_location__sub.get_return_value
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.do_something_with_array
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.append_to_array
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke_with_fstack
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm_uint64
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_uint64.self_div
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_biguint.self_div
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: removing unused subroutine algopy._contract.Contract.__init__
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function algopy._contract.Contract.__init__
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_dec
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_inc
+debug: removing unused subroutine _puya_lib.box_arc4._box_extract_u16
+debug: removing unused subroutine _puya_lib.box_arc4._as_uint16
+debug: removing unused subroutine _puya_lib.arc4._itob16
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.r_trim
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4._recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_assert_index
+debug: removing unused subroutine test_cases.regression_tests.xor_identity_fold_biguint.self_xor
+debug: removing unused subroutine test_cases.regression_tests.wrong_import_location__sub.get_return_value
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.do_something_with_array
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.append_to_array
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke_with_fstack
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm_uint64
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_uint64.self_div
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_biguint.self_div
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: removing unused subroutine algopy._contract.Contract.__init__
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_dec
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_inc
+debug: removing unused subroutine _puya_lib.box_arc4._box_extract_u16
+debug: removing unused subroutine _puya_lib.box_arc4._as_uint16
+debug: removing unused subroutine _puya_lib.arc4._itob16
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.r_trim
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4._recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_assert_index
+debug: removing unused subroutine test_cases.regression_tests.xor_identity_fold_biguint.self_xor
+debug: removing unused subroutine test_cases.regression_tests.wrong_import_location__sub.get_return_value
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.do_something_with_array
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.append_to_array
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke_with_fstack
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm_uint64
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_uint64.self_div
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_biguint.self_div
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: removing unused subroutine algopy._contract.Contract.__init__
 debug: Building IR for function test_cases.regression_tests.div_identity_fold_uint64.DivIdentityFoldUInt64.approval_program
 debug: Sealing block@0
 debug: Terminated block@0
@@ -15226,6 +15420,302 @@ debug: removing explicit jump to fall-through block main_after_inlined_test_case
 debug: optimizing TEAL subroutine ops algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
 debug: optimizing TEAL subroutine blocks algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
 debug: inlining single reference block main_block@0 into main
+debug: optimizing approval program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64 at level 2
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Simplified (== 0u tmp%0#0) to (! tmp%0#0)
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: Begin optimization pass 2/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 2, ending loop
+debug: optimizing clear program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64 at level 2
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: lowering array IR nodes in approval program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64
+debug: lowering array IR nodes in clear program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64
+debug: optimizing approval program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64 at level 2
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: optimizing clear program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64 at level 2
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: removing local static slots in approval program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64
+regression_tests/getbit_fold_oob_uint64.py:5:5 debug: auto reserving slots in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program, []
+debug: Slot allocation not required
+debug: removing local static slots in clear program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64
+regression_tests/getbit_fold_oob_uint64.py:10:5 debug: auto reserving slots in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program, []
+debug: Slot allocation not required
+debug: Performing SSA IR destructuring for test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program using strategy 'root_operand'
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Performing post-SSA optimizations at level 2
+debug: Output IR to regression_tests/out_O2/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.400.destructured.ir
+debug: Performing SSA IR destructuring for test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program using strategy 'root_operand'
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Performing post-SSA optimizations at level 2
+debug: Output IR to regression_tests/out_O2/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.400.destructured.ir
+debug: Inserted main_block@0.ops[3]: 'l-store-copy tmp%0#0 0'
+debug: Replaced main_block@0.ops[5]: 'v-load tmp%0#0' with 'l-load tmp%0#0'
+debug: Inserted main_block@0.ops[7]: 'l-store-copy tmp%1#0 0'
+debug: Replaced main_block@0.ops[9]: 'v-load tmp%1#0' with 'l-load tmp%1#0'
+regression_tests/getbit_fold_oob_uint64.py:5:5 debug: optimizing TEAL subroutine ops test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+regression_tests/getbit_fold_oob_uint64.py:5:5 debug: optimizing TEAL subroutine blocks test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+debug: inlining single reference block main_block@0 into main
+regression_tests/getbit_fold_oob_uint64.py:10:5 debug: optimizing TEAL subroutine ops test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+regression_tests/getbit_fold_oob_uint64.py:10:5 debug: optimizing TEAL subroutine blocks test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+debug: inlining single reference block main_block@0 into main
+debug: optimizing approval program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes at level 2
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Simplified (== 0u tmp%0#0) to (! tmp%0#0)
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: Begin optimization pass 2/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 2, ending loop
+debug: optimizing clear program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes at level 2
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: lowering array IR nodes in approval program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes
+debug: lowering array IR nodes in clear program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes
+debug: optimizing approval program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes at level 2
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: optimizing clear program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes at level 2
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Copy Propagation
+debug: Optimizer: Elide Itxn Field Calls
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Intrinsic Simplifier
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Simplify Control Ops
+debug: Optimizer: Merge Blocks
+debug: Optimizer: Remove Linear Jumps
+debug: Optimizer: Remove Unreachable Blocks
+debug: Optimizer: Repeated Expression Elimination
+debug: Optimizer: Encode Decode Pair Elimination
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: Optimizer: Minimize Box Exist Asserts
+debug: Optimizer: Constant Reads And Unobserved Writes Elimination
+debug: No optimizations performed in pass 1, ending loop
+debug: removing local static slots in approval program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes
+regression_tests/getbit_fold_oob_bytes.py:5:5 debug: auto reserving slots in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program, []
+debug: Slot allocation not required
+debug: removing local static slots in clear program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes
+regression_tests/getbit_fold_oob_bytes.py:10:5 debug: auto reserving slots in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program, []
+debug: Slot allocation not required
+debug: Performing SSA IR destructuring for test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program using strategy 'root_operand'
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Performing post-SSA optimizations at level 2
+debug: Output IR to regression_tests/out_O2/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.400.destructured.ir
+debug: Performing SSA IR destructuring for test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program using strategy 'root_operand'
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Performing post-SSA optimizations at level 2
+debug: Output IR to regression_tests/out_O2/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.400.destructured.ir
+debug: Inserted main_block@0.ops[3]: 'l-store-copy tmp%0#0 0'
+debug: Replaced main_block@0.ops[5]: 'v-load tmp%0#0' with 'l-load tmp%0#0'
+debug: Inserted main_block@0.ops[7]: 'l-store-copy tmp%1#0 0'
+debug: Replaced main_block@0.ops[9]: 'v-load tmp%1#0' with 'l-load tmp%1#0'
+regression_tests/getbit_fold_oob_bytes.py:5:5 debug: optimizing TEAL subroutine ops test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+regression_tests/getbit_fold_oob_bytes.py:5:5 debug: optimizing TEAL subroutine blocks test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+debug: inlining single reference block main_block@0 into main
+regression_tests/getbit_fold_oob_bytes.py:10:5 debug: optimizing TEAL subroutine ops test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
+regression_tests/getbit_fold_oob_bytes.py:10:5 debug: optimizing TEAL subroutine blocks test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
+debug: inlining single reference block main_block@0 into main
 debug: optimizing approval program of test_cases.regression_tests.div_identity_fold_uint64.DivIdentityFoldUInt64 at level 2
 debug: Begin optimization pass 1/100
 debug: Optimizing subroutine test_cases.regression_tests.div_identity_fold_uint64.DivIdentityFoldUInt64.approval_program
@@ -18388,6 +18878,22 @@ info: Writing regression_tests/out_O2/Issue118.approval.stats.txt
 info: Writing regression_tests/out_O2/Issue118.clear.stats.txt
 info: Writing regression_tests/out_O2/Issue118.approval.assembly-report
 info: Writing regression_tests/out_O2/Issue118.clear.assembly-report
+info: Writing regression_tests/out_O2/GetBitFoldOOBUInt64.approval.teal
+info: Writing regression_tests/out_O2/GetBitFoldOOBUInt64.clear.teal
+info: Writing regression_tests/out_O2/GetBitFoldOOBUInt64.approval.bin
+info: Writing regression_tests/out_O2/GetBitFoldOOBUInt64.clear.bin
+info: Writing regression_tests/out_O2/GetBitFoldOOBUInt64.approval.stats.txt
+info: Writing regression_tests/out_O2/GetBitFoldOOBUInt64.clear.stats.txt
+info: Writing regression_tests/out_O2/GetBitFoldOOBUInt64.approval.assembly-report
+info: Writing regression_tests/out_O2/GetBitFoldOOBUInt64.clear.assembly-report
+info: Writing regression_tests/out_O2/GetBitFoldOOBBytes.approval.teal
+info: Writing regression_tests/out_O2/GetBitFoldOOBBytes.clear.teal
+info: Writing regression_tests/out_O2/GetBitFoldOOBBytes.approval.bin
+info: Writing regression_tests/out_O2/GetBitFoldOOBBytes.clear.bin
+info: Writing regression_tests/out_O2/GetBitFoldOOBBytes.approval.stats.txt
+info: Writing regression_tests/out_O2/GetBitFoldOOBBytes.clear.stats.txt
+info: Writing regression_tests/out_O2/GetBitFoldOOBBytes.approval.assembly-report
+info: Writing regression_tests/out_O2/GetBitFoldOOBBytes.clear.assembly-report
 info: Writing regression_tests/out_O2/DivIdentityFoldUInt64.approval.teal
 info: Writing regression_tests/out_O2/DivIdentityFoldUInt64.clear.teal
 info: Writing regression_tests/out_O2/DivIdentityFoldUInt64.approval.bin

--- a/test_cases/regression_tests/puya_unoptimized.log
+++ b/test_cases/regression_tests/puya_unoptimized.log
@@ -3161,6 +3161,200 @@ debug: removing unused subroutine test_cases.regression_tests.issue_118.Issue118
 debug: removing unused subroutine algopy.arc4.ARC4Contract.approval_program
 debug: removing unused subroutine algopy.arc4.ARC4Contract.clear_state_program
 debug: removing unused subroutine algopy._contract.Contract.__init__
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function algopy._contract.Contract.__init__
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_dec
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_inc
+debug: removing unused subroutine _puya_lib.box_arc4._box_extract_u16
+debug: removing unused subroutine _puya_lib.box_arc4._as_uint16
+debug: removing unused subroutine _puya_lib.arc4._itob16
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.r_trim
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4._recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_assert_index
+debug: removing unused subroutine test_cases.regression_tests.xor_identity_fold_biguint.self_xor
+debug: removing unused subroutine test_cases.regression_tests.wrong_import_location__sub.get_return_value
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.do_something_with_array
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.append_to_array
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke_with_fstack
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm_uint64
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_uint64.self_div
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_biguint.self_div
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: removing unused subroutine algopy._contract.Contract.__init__
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_dec
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_inc
+debug: removing unused subroutine _puya_lib.box_arc4._box_extract_u16
+debug: removing unused subroutine _puya_lib.box_arc4._as_uint16
+debug: removing unused subroutine _puya_lib.arc4._itob16
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.r_trim
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4._recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_assert_index
+debug: removing unused subroutine test_cases.regression_tests.xor_identity_fold_biguint.self_xor
+debug: removing unused subroutine test_cases.regression_tests.wrong_import_location__sub.get_return_value
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.do_something_with_array
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.append_to_array
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke_with_fstack
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm_uint64
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_uint64.self_div
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_biguint.self_div
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: removing unused subroutine algopy._contract.Contract.__init__
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function algopy._contract.Contract.__init__
+debug: Sealing block@0
+debug: Terminated block@0
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_dec
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_inc
+debug: removing unused subroutine _puya_lib.box_arc4._box_extract_u16
+debug: removing unused subroutine _puya_lib.box_arc4._as_uint16
+debug: removing unused subroutine _puya_lib.arc4._itob16
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.r_trim
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4._recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_assert_index
+debug: removing unused subroutine test_cases.regression_tests.xor_identity_fold_biguint.self_xor
+debug: removing unused subroutine test_cases.regression_tests.wrong_import_location__sub.get_return_value
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.do_something_with_array
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.append_to_array
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke_with_fstack
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm_uint64
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_uint64.self_div
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_biguint.self_div
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: removing unused subroutine algopy._contract.Contract.__init__
+debug: Building IR for function test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Sealing block@0
+debug: Terminated block@0
+debug: removing unused subroutine _puya_lib.util.ensure_budget
+debug: removing unused subroutine _puya_lib.bytes_.is_substring
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.box_arc4.box_dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_dec
+debug: removing unused subroutine _puya_lib.box_arc4.box_update_offset_inc
+debug: removing unused subroutine _puya_lib.box_arc4._box_extract_u16
+debug: removing unused subroutine _puya_lib.box_arc4._as_uint16
+debug: removing unused subroutine _puya_lib.arc4._itob16
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_bit
+debug: removing unused subroutine _puya_lib.arc4.r_trim
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_fixed_size
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_pop_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_read_byte_length_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_fixed
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_bits
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_concat_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_dynamic_element
+debug: removing unused subroutine _puya_lib.arc4.static_array_replace_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4._recalculate_head_for_elements_with_byte_length_head
+debug: removing unused subroutine _puya_lib.arc4.dynamic_assert_index
+debug: removing unused subroutine test_cases.regression_tests.xor_identity_fold_biguint.self_xor
+debug: removing unused subroutine test_cases.regression_tests.wrong_import_location__sub.get_return_value
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.do_something_with_array
+debug: removing unused subroutine test_cases.regression_tests.slot_allocation_inlining.append_to_array
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke
+debug: removing unused subroutine test_cases.regression_tests.never_returns.invoke_with_fstack
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm
+debug: removing unused subroutine test_cases.regression_tests.leftover_branch.hmm_uint64
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_uint64.self_div
+debug: removing unused subroutine test_cases.regression_tests.div_identity_fold_biguint.self_div
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: removing unused subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: removing unused subroutine algopy._contract.Contract.__init__
 debug: Building IR for function test_cases.regression_tests.div_identity_fold_uint64.DivIdentityFoldUInt64.approval_program
 debug: Sealing block@0
 debug: Terminated block@0
@@ -11172,6 +11366,162 @@ debug: optimizing TEAL subroutine ops algopy.arc4.ARC4Contract.approval_program(
 regression_tests/issue_118.py:7:6 debug: optimizing TEAL subroutine ops test_cases.regression_tests.issue_118.Issue118.verify[routing]() -> void:
 regression_tests/issue_118.py:7:6 debug: optimizing TEAL subroutine ops test_cases.regression_tests.issue_118.Issue118.verify(values: bytes) -> bytes:
 debug: optimizing TEAL subroutine ops algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+debug: optimizing approval program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64 at level 0
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: No optimizations performed in pass 1, ending loop
+debug: optimizing clear program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64 at level 0
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: No optimizations performed in pass 1, ending loop
+debug: lowering array IR nodes in approval program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64
+debug: lowering array IR nodes in clear program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64
+debug: optimizing approval program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64 at level 0
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: No optimizations performed in pass 1, ending loop
+debug: optimizing clear program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64 at level 0
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: No optimizations performed in pass 1, ending loop
+debug: removing local static slots in approval program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64
+regression_tests/getbit_fold_oob_uint64.py:5:5 debug: auto reserving slots in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program, []
+debug: Slot allocation not required
+debug: removing local static slots in clear program of test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64
+regression_tests/getbit_fold_oob_uint64.py:10:5 debug: auto reserving slots in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program, []
+debug: Slot allocation not required
+debug: Performing SSA IR destructuring for test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program using strategy 'root_operand'
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program
+debug: Performing post-SSA optimizations at level 0
+debug: Output IR to regression_tests/out_unoptimized/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.approval.400.destructured.ir
+debug: Performing SSA IR destructuring for test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program using strategy 'root_operand'
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program
+debug: Performing post-SSA optimizations at level 0
+debug: Output IR to regression_tests/out_unoptimized/GetBitFoldOOBUInt64.ir/GetBitFoldOOBUInt64.clear.400.destructured.ir
+debug: Inserted main_block@0.ops[7]: 'l-store-copy tmp%1#0 0'
+debug: Replaced main_block@0.ops[9]: 'v-load tmp%1#0' with 'l-load tmp%1#0'
+debug: Inserted main_block@0.ops[3]: 'l-store-copy tmp%0#0 0'
+debug: Replaced main_block@0.ops[6]: 'v-load tmp%0#0' with 'l-load tmp%0#0'
+regression_tests/getbit_fold_oob_uint64.py:5:5 debug: optimizing TEAL subroutine ops test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.approval_program() -> uint64:
+regression_tests/getbit_fold_oob_uint64.py:10:5 debug: optimizing TEAL subroutine ops test_cases.regression_tests.getbit_fold_oob_uint64.GetBitFoldOOBUInt64.clear_state_program() -> uint64:
+debug: optimizing approval program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes at level 0
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: No optimizations performed in pass 1, ending loop
+debug: optimizing clear program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes at level 0
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: No optimizations performed in pass 1, ending loop
+debug: lowering array IR nodes in approval program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes
+debug: lowering array IR nodes in clear program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes
+debug: optimizing approval program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes at level 0
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: No optimizations performed in pass 1, ending loop
+debug: optimizing clear program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes at level 0
+debug: Begin optimization pass 1/100
+debug: Optimizing subroutine test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Optimizer: Perform Subroutine Inlining
+debug: Optimizer: Split Parallel Copies
+debug: Optimizer: Constant Replacer
+debug: Optimizer: Remove Unused Variables
+debug: Optimizer: Inner Txn Field Replacer
+debug: Optimizer: Replace Compiled References
+debug: Optimizer: Merge Chained Aggregate Reads
+debug: Optimizer: Replace Aggregate Box Ops
+debug: No optimizations performed in pass 1, ending loop
+debug: removing local static slots in approval program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes
+regression_tests/getbit_fold_oob_bytes.py:5:5 debug: auto reserving slots in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program, []
+debug: Slot allocation not required
+debug: removing local static slots in clear program of test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes
+regression_tests/getbit_fold_oob_bytes.py:10:5 debug: auto reserving slots in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program, []
+debug: Slot allocation not required
+debug: Performing SSA IR destructuring for test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program using strategy 'root_operand'
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program
+debug: Performing post-SSA optimizations at level 0
+debug: Output IR to regression_tests/out_unoptimized/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.approval.400.destructured.ir
+debug: Performing SSA IR destructuring for test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Converting to CSSA
+debug: Removing Phi nodes
+debug: Coalescing local variables in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program using strategy 'root_operand'
+debug: Coalescing resulted in 0 replacement/s
+debug: Sequentializing parallel copies in test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program
+debug: Performing post-SSA optimizations at level 0
+debug: Output IR to regression_tests/out_unoptimized/GetBitFoldOOBBytes.ir/GetBitFoldOOBBytes.clear.400.destructured.ir
+debug: Inserted main_block@0.ops[7]: 'l-store-copy tmp%1#0 0'
+debug: Replaced main_block@0.ops[9]: 'v-load tmp%1#0' with 'l-load tmp%1#0'
+debug: Inserted main_block@0.ops[3]: 'l-store-copy tmp%0#0 0'
+debug: Replaced main_block@0.ops[6]: 'v-load tmp%0#0' with 'l-load tmp%0#0'
+regression_tests/getbit_fold_oob_bytes.py:5:5 debug: optimizing TEAL subroutine ops test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.approval_program() -> uint64:
+regression_tests/getbit_fold_oob_bytes.py:10:5 debug: optimizing TEAL subroutine ops test_cases.regression_tests.getbit_fold_oob_bytes.GetBitFoldOOBBytes.clear_state_program() -> uint64:
 debug: optimizing approval program of test_cases.regression_tests.div_identity_fold_uint64.DivIdentityFoldUInt64 at level 0
 debug: Begin optimization pass 1/100
 debug: Optimizing subroutine test_cases.regression_tests.div_identity_fold_uint64.DivIdentityFoldUInt64.approval_program
@@ -13315,6 +13665,22 @@ info: Writing regression_tests/out_unoptimized/Issue118.approval.stats.txt
 info: Writing regression_tests/out_unoptimized/Issue118.clear.stats.txt
 info: Writing regression_tests/out_unoptimized/Issue118.approval.assembly-report
 info: Writing regression_tests/out_unoptimized/Issue118.clear.assembly-report
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBUInt64.approval.teal
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBUInt64.clear.teal
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBUInt64.approval.bin
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBUInt64.clear.bin
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBUInt64.approval.stats.txt
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBUInt64.clear.stats.txt
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBUInt64.approval.assembly-report
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBUInt64.clear.assembly-report
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBBytes.approval.teal
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBBytes.clear.teal
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBBytes.approval.bin
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBBytes.clear.bin
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBBytes.approval.stats.txt
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBBytes.clear.stats.txt
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBBytes.approval.assembly-report
+info: Writing regression_tests/out_unoptimized/GetBitFoldOOBBytes.clear.assembly-report
 info: Writing regression_tests/out_unoptimized/DivIdentityFoldUInt64.approval.teal
 info: Writing regression_tests/out_unoptimized/DivIdentityFoldUInt64.clear.teal
 info: Writing regression_tests/out_unoptimized/DivIdentityFoldUInt64.approval.bin

--- a/tests/onchain/test_regression_tests.py
+++ b/tests/onchain/test_regression_tests.py
@@ -32,15 +32,11 @@ def test_xor_identity_fold_biguint(deployer_o: Deployer) -> None:
 def test_gebit_bytes_fold_oob(deployer_o: Deployer) -> None:
     # solves compiler crash when trying to fold OOB getbit acces into Bytes constant.
     with pytest.raises(au.LogicError, match="had error 'getbit index beyond byteslice'"):
-        deployer_o.create_bare(
-            TEST_CASES_DIR / "regression_tests" / "getbit_fold_oob_bytes.py"
-        )
+        deployer_o.create_bare(TEST_CASES_DIR / "regression_tests" / "getbit_fold_oob_bytes.py")
 
 
 def test_getbit_uint64_fold_oob(deployer_o: Deployer) -> None:
     # OOB getbit access in uint64 should panic on the AVM.
     # Without the fix, the optimizer folds this to UInt64(0) and the panic is lost.
     with pytest.raises(au.LogicError, match="had error 'getbit index > 63 with Uint'"):
-        deployer_o.create_bare(
-            TEST_CASES_DIR / "regression_tests" / "getbit_fold_oob_uint64.py"
-        )
+        deployer_o.create_bare(TEST_CASES_DIR / "regression_tests" / "getbit_fold_oob_uint64.py")

--- a/tests/onchain/test_regression_tests.py
+++ b/tests/onchain/test_regression_tests.py
@@ -29,7 +29,7 @@ def test_xor_identity_fold_biguint(deployer_o: Deployer) -> None:
     deployer_o.create_bare(TEST_CASES_DIR / "regression_tests" / "xor_identity_fold_biguint.py")
 
 
-def test_gebit_bytes_fold_oob(deployer_o: Deployer) -> None:
+def test_getbit_bytes_fold_oob(deployer_o: Deployer) -> None:
     # solves compiler crash when trying to fold OOB getbit acces into Bytes constant.
     with pytest.raises(au.LogicError, match="had error 'getbit index beyond byteslice'"):
         deployer_o.create_bare(TEST_CASES_DIR / "regression_tests" / "getbit_fold_oob_bytes.py")

--- a/tests/onchain/test_regression_tests.py
+++ b/tests/onchain/test_regression_tests.py
@@ -27,3 +27,20 @@ def test_div_identity_fold_biguint(deployer_o: Deployer) -> None:
 
 def test_xor_identity_fold_biguint(deployer_o: Deployer) -> None:
     deployer_o.create_bare(TEST_CASES_DIR / "regression_tests" / "xor_identity_fold_biguint.py")
+
+
+def test_gebit_bytes_fold_oob(deployer_o: Deployer) -> None:
+    # solves compiler crash when trying to fold OOB getbit acces into Bytes constant.
+    with pytest.raises(au.LogicError, match="had error 'getbit index beyond byteslice'"):
+        deployer_o.create_bare(
+            TEST_CASES_DIR / "regression_tests" / "getbit_fold_oob_bytes.py"
+        )
+
+
+def test_getbit_uint64_fold_oob(deployer_o: Deployer) -> None:
+    # OOB getbit access in uint64 should panic on the AVM.
+    # Without the fix, the optimizer folds this to UInt64(0) and the panic is lost.
+    with pytest.raises(au.LogicError, match="had error 'getbit index > 63 with Uint'"):
+        deployer_o.create_bare(
+            TEST_CASES_DIR / "regression_tests" / "getbit_fold_oob_uint64.py"
+        )


### PR DESCRIPTION
This PR fixes two small bugs in intrinsic simplification:

- When attempting to fold a `getbit` out of bounds index access on a uint64, the compiler would silently fold it to a constant uint64 0.

- In the same scenario but on a bytes constant, it'd cause a compiler crash.

Now both scenarios compile, however they produce a piece of code that will panic on runtime.
It might be sensible to introduce warnings for these scenarios, however this is out of scope for this fix.