### PR TITLE
fix: detect recursive type aliases instead of crashing with maximum recursion depth

### DIFF
--- a/changelog.d/20260416_105713_bobby.lat.md
+++ b/changelog.d/20260416_105713_bobby.lat.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Recursive type aliases (e.g. `Arr = arc4.DynamicArray["Arr"]`) now produce a clear error instead of crashing with maximum recursion depth.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/puyapy/awst_build/context.py
+++ b/src/puyapy/awst_build/context.py
@@ -206,6 +206,7 @@ def type_to_pytype(
     source_location: SourceLocation,
     in_type_args: bool = False,
     in_func_sig: bool = False,
+    _resolving_aliases: frozenset[str] = frozenset(),
 ) -> pytypes.PyType:
     loc = source_location
     proper_type_or_alias: mypy.types.ProperType | mypy.types.TypeAliasType
@@ -219,6 +220,7 @@ def type_to_pytype(
         source_location=loc,
         in_type_args=in_type_args,
         in_func_sig=in_func_sig,
+        _resolving_aliases=_resolving_aliases,
     )
     match proper_type_or_alias:
         case mypy.types.TypeAliasType(alias=alias, args=args):
@@ -226,8 +228,15 @@ def type_to_pytype(
                 raise InternalError("mypy type alias type missing alias reference", loc)
             result = registry.get(alias.fullname)
             if result is None:
-                return recurse(mypy.types.get_proper_type(proper_type_or_alias))
-            return _maybe_parameterise_pytype(registry, result, args, loc)
+                if alias.fullname in _resolving_aliases:
+                    raise CodeError("recursive type aliases are not supported", loc)
+                return recurse(
+                    mypy.types.get_proper_type(proper_type_or_alias),
+                    _resolving_aliases=_resolving_aliases | {alias.fullname},
+                )
+            return _maybe_parameterise_pytype(
+                registry, result, args, loc, _resolving_aliases=_resolving_aliases
+            )
         # this is how variadic tuples are represented in mypy types...
         case mypy.types.Instance(type=mypy.nodes.TypeInfo(fullname="builtins.tuple"), args=args):
             try:
@@ -248,14 +257,18 @@ def type_to_pytype(
                 else:
                     msg = f"Unknown type: {fullname}"
                 raise CodeError(msg, loc)
-            return _maybe_parameterise_pytype(registry, result, args, loc)
+            return _maybe_parameterise_pytype(
+                registry, result, args, loc, _resolving_aliases=_resolving_aliases
+            )
         case mypy.types.TupleType(items=items, partial_fallback=fallback):
             if not fallback.args:
                 return recurse(fallback)
             generic = registry.get(fallback.type.fullname)
             if generic is None:
                 raise CodeError(f"unknown tuple base type: {fallback.type.fullname}", loc)
-            return _maybe_parameterise_pytype(registry, generic, items, loc)
+            return _maybe_parameterise_pytype(
+                registry, generic, items, loc, _resolving_aliases=_resolving_aliases
+            )
         case mypy.types.LiteralType(fallback=fallback, value=literal_value) as mypy_literal_type:
             if not in_type_args:
                 # this is a bit clumsy, but exists because for some reason, bool types
@@ -312,13 +325,21 @@ def _maybe_parameterise_pytype(
     maybe_generic: pytypes.PyType,
     mypy_type_args: Sequence[mypy.types.Type],
     loc: SourceLocation,
+    *,
+    _resolving_aliases: frozenset[str] = frozenset(),
 ) -> pytypes.PyType:
     if not mypy_type_args:
         return maybe_generic
     if all(isinstance(t, mypy.types.TypeVarType | mypy.types.UnpackType) for t in mypy_type_args):
         return maybe_generic
     type_args_resolved = [
-        type_to_pytype(registry, mta, source_location=loc, in_type_args=True)
+        type_to_pytype(
+            registry,
+            mta,
+            source_location=loc,
+            in_type_args=True,
+            _resolving_aliases=_resolving_aliases,
+        )
         for mta in mypy_type_args
     ]
     result = maybe_generic.parameterise(type_args_resolved, loc)

--- a/src/puyapy/awst_build/context.py
+++ b/src/puyapy/awst_build/context.py
@@ -209,11 +209,21 @@ def type_to_pytype(
     _resolving_aliases: frozenset[str] = frozenset(),
 ) -> pytypes.PyType:
     loc = source_location
-    proper_type_or_alias: mypy.types.ProperType | mypy.types.TypeAliasType
     if isinstance(mypy_type, mypy.types.TypeAliasType):
-        proper_type_or_alias = mypy_type
-    else:
-        proper_type_or_alias = mypy.types.get_proper_type(mypy_type)
+        if mypy_type.alias is None:
+            raise InternalError("mypy type alias type missing alias reference", loc)
+        alias_fullname = mypy_type.alias.fullname
+        if alias_fullname in _resolving_aliases:
+            raise CodeError("recursive type aliases are not supported", loc)
+        result = registry.get(alias_fullname)
+        if result is not None:
+            return _maybe_parameterise_pytype(
+                registry, result, mypy_type.args, loc, _resolving_aliases=_resolving_aliases
+            )
+        # fall through to resolve the proper type, which will do a single expansion of
+        # the type alias, but track that we're now resolving this alias name
+        _resolving_aliases |= {alias_fullname}
+
     recurse = functools.partial(
         type_to_pytype,
         registry,
@@ -222,21 +232,8 @@ def type_to_pytype(
         in_func_sig=in_func_sig,
         _resolving_aliases=_resolving_aliases,
     )
-    match proper_type_or_alias:
-        case mypy.types.TypeAliasType(alias=alias, args=args):
-            if alias is None:
-                raise InternalError("mypy type alias type missing alias reference", loc)
-            result = registry.get(alias.fullname)
-            if result is None:
-                if alias.fullname in _resolving_aliases:
-                    raise CodeError("recursive type aliases are not supported", loc)
-                return recurse(
-                    mypy.types.get_proper_type(proper_type_or_alias),
-                    _resolving_aliases=_resolving_aliases | {alias.fullname},
-                )
-            return _maybe_parameterise_pytype(
-                registry, result, args, loc, _resolving_aliases=_resolving_aliases
-            )
+
+    match mypy.types.get_proper_type(mypy_type):
         # this is how variadic tuples are represented in mypy types...
         case mypy.types.Instance(type=mypy.nodes.TypeInfo(fullname="builtins.tuple"), args=args):
             try:

--- a/tests/test_expected_output/module.test
+++ b/tests/test_expected_output/module.test
@@ -90,6 +90,12 @@ IntAlias: typing.TypeAlias = UInt64
 def one() -> IntAlias:
     return UInt64(1)
 
+## case: recursive_type_alias
+
+from algopy import arc4
+
+Arr = arc4.DynamicArray["Arr"]  ## E: recursive type aliases are not supported
+
 ## case: for_not_supported
 
 for i in [True, False]: ## E: unsupported statement type at module level

--- a/tests/test_expected_output/module.test
+++ b/tests/test_expected_output/module.test
@@ -92,9 +92,55 @@ def one() -> IntAlias:
 
 ## case: recursive_type_alias
 
+import typing
 from algopy import arc4
 
-Arr = arc4.DynamicArray["Arr"]  ## E: recursive type aliases are not supported
+# this is valid. added here to catch any regression.
+Nested_Tuple = arc4.Tuple[arc4.Tuple[arc4.UInt64, arc4.UInt64], arc4.Tuple[arc4.String, arc4.String]]
+
+# auto-recursion through union
+JSON: typing.TypeAlias = int | float | str | bool | None | list["JSON"] | dict[str, "JSON"] ## E: unsupported type-alias format
+
+# auto-recursion through generic param
+Arr = arc4.DynamicArray["Arr"] ## E: recursive type aliases are not supported
+
+# mutually recursive aliases
+Leaf: typing.TypeAlias = int
+Branch: typing.TypeAlias = tuple["Tree", "Tree"] ## E: recursive type aliases are not supported
+Tree: typing.TypeAlias = Leaf | Branch ## E: unsupported type-alias format
+
+# mutual recursion through generic params
+Arr1 = arc4.DynamicArray["Arr2"] ## E: recursive type aliases are not supported
+Arr2 = arc4.DynamicArray["Arr1"] ## E: recursive type aliases are not supported
+
+# recursive generic type
+T = typing.TypeVar("T") ## E: unsupported type-form \
+                        ## E: unsupported statement type at module level
+
+class LinkedList(arc4.ARC4Contract, typing.Generic[T]):
+    head: T
+    tail: "LinkedList[T] | None" ## E: type unions are unsupported at this location
+
+# self-referential classes
+class TreeNode(arc4.Struct):
+    value: arc4.UInt64
+    left: "TreeNode | None" ## E: Unknown type: recursive_type_alias.TreeNode
+    right: "TreeNode | None"
+
+# "phantom" recursion
+Nested: typing.TypeAlias = T | list["Nested[T]"] ## E: unsupported type-alias format
+
+## case: invalid_recursive_type
+from typing import TypeAlias
+
+Bad: TypeAlias = "Bad" ## E: Cannot resolve name "Bad" (possible cyclic definition)  [misc] \
+                       ## E: unsupported type-alias format
+A: TypeAlias = "B" ## E: Cannot resolve name "B" (possible cyclic definition)  [misc] \
+                   ## E: unsupported type-alias format \
+                   ## E: Cannot resolve name "A" (possible cyclic definition)  [misc]
+B: TypeAlias = "A" ## E: Cannot resolve name "B" (possible cyclic definition)  [misc] \
+                   ## E: unsupported type-alias format
+
 
 ## case: for_not_supported
 


### PR DESCRIPTION
- Self-referential type aliases (e.g. `Arr = arc4.DynamicArray["Arr"]`) now emit a clear `CodeError` instead of crashing with `RecursionError`
- Added cycle detection via a `_resolving_aliases` frozenset threaded through `type_to_pytype` and `_maybe_parameterise_pytype`
