### PR TITLE
fix: allow int literals as size arguments for box creation

### DIFF
--- a/changelog.d/20260428_142047_argimirodelpozo_box_create_allow_int_literal.md
+++ b/changelog.d/20260428_142047_argimirodelpozo_box_create_allow_int_literal.md
@@ -32,7 +32,7 @@ For top level release notes, leave all the headers commented out.
 
 ### Fixed
 
-- Allowed supporting integer literals for the `size` argument in `Box.create`
+- Allowed integer literals as `size` arguments in `Box.create`
 
 
 <!--

--- a/changelog.d/20260428_142047_argimirodelpozo_box_create_allow_int_literal.md
+++ b/changelog.d/20260428_142047_argimirodelpozo_box_create_allow_int_literal.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Allowed supporting integer literals for the `size` argument in `Box.create`
+
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/puyapy/awst_build/eb/storage/box.py
+++ b/src/puyapy/awst_build/eb/storage/box.py
@@ -257,11 +257,15 @@ class _Create(FunctionBuilder):
                 size = arg.resolve_literal(converter=UInt64TypeBuilder(location)).resolve()
             case InstanceBuilder(pytype=pytypes.UInt64Type):
                 size = arg.resolve()
-            case _:
+            case None:
                 size = SizeOf(
                     size_wtype=self.content_type.checked_wtype(location),
                     source_location=location,
                 )
+            case _:
+                size = expect.not_this_type(
+                    arg, default=expect.default_dummy_value(pytypes.UInt64Type)
+                ).resolve()
         return BoolExpressionBuilder(
             IntrinsicCall(
                 op_code="box_create",

--- a/src/puyapy/awst_build/eb/storage/box.py
+++ b/src/puyapy/awst_build/eb/storage/box.py
@@ -41,7 +41,7 @@ from puyapy.awst_build.eb.storage._storage import (
 )
 from puyapy.awst_build.eb.storage._util import box_length_checked
 from puyapy.awst_build.eb.storage.box_ref import BoxRefProxyExpressionBuilder, _IntrinsicMethod
-from puyapy.awst_build.eb.uint64 import UInt64ExpressionBuilder
+from puyapy.awst_build.eb.uint64 import UInt64ExpressionBuilder, UInt64TypeBuilder
 from puyapy.awst_build.utils import get_arg_mapping
 
 logger = log.get_logger(__name__)
@@ -249,14 +249,19 @@ class _Create(FunctionBuilder):
         arg_names: list[str | None],
         location: SourceLocation,
     ) -> InstanceBuilder:
-        arg = expect.at_most_one_arg_of_type(args, [pytypes.UInt64Type], location)
-        if arg is not None:
-            size = arg.resolve()
-        else:
-            size = SizeOf(
-                size_wtype=self.content_type.checked_wtype(location),
-                source_location=location,
-            )
+        arg = expect.at_most_one_arg_of_type(
+            args, [pytypes.IntLiteralType, pytypes.UInt64Type], location
+        )
+        match arg:
+            case InstanceBuilder(pytype=pytypes.IntLiteralType):
+                size = arg.resolve_literal(converter=UInt64TypeBuilder(location)).resolve()
+            case InstanceBuilder(pytype=pytypes.UInt64Type):
+                size = arg.resolve()
+            case _:
+                size = SizeOf(
+                    size_wtype=self.content_type.checked_wtype(location),
+                    source_location=location,
+                )
         return BoolExpressionBuilder(
             IntrinsicCall(
                 op_code="box_create",

--- a/tests/test_expected_output/box.test
+++ b/tests/test_expected_output/box.test
@@ -16,6 +16,10 @@ def test_key_types() -> None:
 def wrong_arg() -> None:
     Box("oops", key=b"box")  # type: ignore[arg-type] ## E: first argument must be a type reference
 
+@subroutine
+def create_literal_arg() -> None:
+    box = Box(Bytes, key=b"box")
+    box.create(size=8)  ## W: expression result is ignored
 
 @subroutine
 def wrong_get_arg() -> None:
@@ -97,7 +101,9 @@ class BoxRefContract(ARC4Contract):
     def bad_create_arg(self) -> None:
         self.ok.create(size=32, too_many=42)  # type: ignore[call-arg] ## W: expression result is ignored \
                                                                        ## E: expected 1 argument, got 2
-
+    @arc4.abimethod()
+    def test_literal_create_arg(self) -> None:
+        self.ok.create(size=32)  ## W: expression result is ignored
 
     @arc4.abimethod()
     def bad_resize_arg(self) -> None:

--- a/tests/test_expected_output/box.test
+++ b/tests/test_expected_output/box.test
@@ -20,6 +20,8 @@ def wrong_arg() -> None:
 def create_literal_arg() -> None:
     box = Box(Bytes, key=b"box")
     box.create(size=8)  ## W: expression result is ignored
+    box.create(size=True)  ## W: expression result is ignored \
+                           ## E: unexpected argument type
 
 @subroutine
 def wrong_get_arg() -> None:


### PR DESCRIPTION
Fixes issue #715 by allowing literals in box create size args.

@iglosiggio raised the question as to whether we should even support the size argument for statically typed box creation, which I agree we should disallow in a separate PR (still, no harm in supporting literals wherever the `size` argument would make sense).

Note that create in boxRefs goes through a separate code path where the literal resolution was already in place. Still left a test exercising said resolution.