### PR TITLE
[refactor] Puya: reduce double-eval IR logs

### DIFF
--- a/examples/box_storage/puya.log
+++ b/examples/box_storage/puya.log
@@ -723,8 +723,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.set_boxes
 debug: Sealing block@0
-box_storage/contract.py:88:9 debug: encountered already materialized expression ('box_large'), reusing result: "box_large"
-box_storage/contract.py:94:9 debug: encountered already materialized expression ('box_a'), reusing result: "box_a"
 box_storage/contract.py:104:16 debug: encountered already materialized expression (reinterpret_cast<bytes>(Box[hex<"424F585F43">])), reusing result: storage_value%5#0
 box_storage/contract.py:104:46 debug: encountered already materialized expression (reinterpret_cast<bytes>(c)), reusing result: c#0
 box_storage/contract.py:110:16 debug: encountered already materialized expression (Box['box_d']), reusing result: storage_value%9#0
@@ -738,7 +736,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.set_many_ints
 debug: Sealing block@0
-box_storage/contract.py:130:9 debug: encountered already materialized expression ('many_ints'), reusing result: "many_ints"
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.create_big_fixed_bytes
 debug: Sealing block@0
@@ -788,7 +785,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.indirect_extract_and_replace
 debug: Sealing block@0
-box_storage/contract.py:188:9 debug: encountered already materialized expression (large), reusing result: large#0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.read_boxes
 debug: Sealing block@0
@@ -810,7 +806,6 @@ debug: Created Phi assignment: let value_internal%0#1: uint64 = undefined while 
 debug: Terminated block@1
 debug: Sealing block@2
 box_storage/contract.py:220:13 debug: encountered already materialized expression (Box['dynamic_arr_struct']), reusing result: storage_value%0#0
-box_storage/contract.py:220:13 debug: encountered already materialized expression ('dynamic_arr_struct'), reusing result: "dynamic_arr_struct"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -827,7 +822,6 @@ debug: Created Phi assignment: let value_internal%0#1: uint64 = undefined while 
 debug: Terminated block@1
 debug: Sealing block@2
 box_storage/contract.py:226:13 debug: encountered already materialized expression (Box['dynamic_arr_struct']), reusing result: storage_value%0#0
-box_storage/contract.py:226:13 debug: encountered already materialized expression ('dynamic_arr_struct'), reusing result: "dynamic_arr_struct"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -841,12 +835,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.nested_write
 debug: Sealing block@0
-box_storage/contract.py:247:9 debug: encountered already materialized expression (box), reusing result: box#0
-box_storage/contract.py:248:9 debug: encountered already materialized expression (box), reusing result: box#0
-box_storage/contract.py:249:9 debug: encountered already materialized expression (box), reusing result: box#0
-box_storage/contract.py:250:9 debug: encountered already materialized expression (box), reusing result: box#0
-box_storage/contract.py:251:9 debug: encountered already materialized expression (box), reusing result: box#0
-box_storage/contract.py:252:9 debug: encountered already materialized expression (box), reusing result: box#0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.nested_read
 debug: Sealing block@0
@@ -891,7 +879,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.set_bool
 debug: Sealing block@0
-box_storage/contract.py:283:9 debug: encountered already materialized expression ('too_many_bools'), reusing result: "too_many_bools"
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.sum_bools
 debug: Sealing block@0
@@ -952,7 +939,6 @@ debug: Looking for 'value_internal%0' in an unsealed block creating an incomplet
 debug: Created Phi assignment: let value_internal%0#1: uint64 = undefined while trying to resolve 'value_internal%0' in block@1
 debug: Terminated block@1
 debug: Sealing block@2
-box_storage/contract.py:306:13 debug: encountered already materialized expression ('dynamic_box'), reusing result: "dynamic_box"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -968,7 +954,6 @@ debug: Looking for 'value_internal%0' in an unsealed block creating an incomplet
 debug: Created Phi assignment: let value_internal%0#1: uint64 = undefined while trying to resolve 'value_internal%0' in block@1
 debug: Terminated block@1
 debug: Sealing block@2
-box_storage/contract.py:312:13 debug: encountered already materialized expression ('dynamic_box'), reusing result: "dynamic_box"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -998,11 +983,9 @@ debug: Sealing block@4
 debug: Terminated block@4
 debug: Building IR for function examples.box_storage.contract.BoxContract.write_dynamic_box
 debug: Sealing block@0
-box_storage/contract.py:325:9 debug: encountered already materialized expression ('dynamic_box'), reusing result: "dynamic_box"
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.write_dynamic_arr_struct
 debug: Sealing block@0
-box_storage/contract.py:329:9 debug: encountered already materialized expression ('dynamic_arr_struct'), reusing result: "dynamic_arr_struct"
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.slice_box
 debug: Sealing block@0

--- a/examples/box_storage/puya_O2.log
+++ b/examples/box_storage/puya_O2.log
@@ -722,8 +722,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.set_boxes
 debug: Sealing block@0
-box_storage/contract.py:88:9 debug: encountered already materialized expression ('box_large'), reusing result: "box_large"
-box_storage/contract.py:94:9 debug: encountered already materialized expression ('box_a'), reusing result: "box_a"
 box_storage/contract.py:104:16 debug: encountered already materialized expression (reinterpret_cast<bytes>(Box[hex<"424F585F43">])), reusing result: storage_value%5#0
 box_storage/contract.py:104:46 debug: encountered already materialized expression (reinterpret_cast<bytes>(c)), reusing result: c#0
 box_storage/contract.py:110:16 debug: encountered already materialized expression (Box['box_d']), reusing result: storage_value%9#0
@@ -737,7 +735,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.set_many_ints
 debug: Sealing block@0
-box_storage/contract.py:130:9 debug: encountered already materialized expression ('many_ints'), reusing result: "many_ints"
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.create_big_fixed_bytes
 debug: Sealing block@0
@@ -787,7 +784,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.indirect_extract_and_replace
 debug: Sealing block@0
-box_storage/contract.py:188:9 debug: encountered already materialized expression (large), reusing result: large#0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.read_boxes
 debug: Sealing block@0
@@ -809,7 +805,6 @@ debug: Created Phi assignment: let value_internal%0#1: uint64 = undefined while 
 debug: Terminated block@1
 debug: Sealing block@2
 box_storage/contract.py:220:13 debug: encountered already materialized expression (Box['dynamic_arr_struct']), reusing result: storage_value%0#0
-box_storage/contract.py:220:13 debug: encountered already materialized expression ('dynamic_arr_struct'), reusing result: "dynamic_arr_struct"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -826,7 +821,6 @@ debug: Created Phi assignment: let value_internal%0#1: uint64 = undefined while 
 debug: Terminated block@1
 debug: Sealing block@2
 box_storage/contract.py:226:13 debug: encountered already materialized expression (Box['dynamic_arr_struct']), reusing result: storage_value%0#0
-box_storage/contract.py:226:13 debug: encountered already materialized expression ('dynamic_arr_struct'), reusing result: "dynamic_arr_struct"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -840,12 +834,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.nested_write
 debug: Sealing block@0
-box_storage/contract.py:247:9 debug: encountered already materialized expression (box), reusing result: box#0
-box_storage/contract.py:248:9 debug: encountered already materialized expression (box), reusing result: box#0
-box_storage/contract.py:249:9 debug: encountered already materialized expression (box), reusing result: box#0
-box_storage/contract.py:250:9 debug: encountered already materialized expression (box), reusing result: box#0
-box_storage/contract.py:251:9 debug: encountered already materialized expression (box), reusing result: box#0
-box_storage/contract.py:252:9 debug: encountered already materialized expression (box), reusing result: box#0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.nested_read
 debug: Sealing block@0
@@ -890,7 +878,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.set_bool
 debug: Sealing block@0
-box_storage/contract.py:283:9 debug: encountered already materialized expression ('too_many_bools'), reusing result: "too_many_bools"
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.sum_bools
 debug: Sealing block@0
@@ -951,7 +938,6 @@ debug: Looking for 'value_internal%0' in an unsealed block creating an incomplet
 debug: Created Phi assignment: let value_internal%0#1: uint64 = undefined while trying to resolve 'value_internal%0' in block@1
 debug: Terminated block@1
 debug: Sealing block@2
-box_storage/contract.py:306:13 debug: encountered already materialized expression ('dynamic_box'), reusing result: "dynamic_box"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -967,7 +953,6 @@ debug: Looking for 'value_internal%0' in an unsealed block creating an incomplet
 debug: Created Phi assignment: let value_internal%0#1: uint64 = undefined while trying to resolve 'value_internal%0' in block@1
 debug: Terminated block@1
 debug: Sealing block@2
-box_storage/contract.py:312:13 debug: encountered already materialized expression ('dynamic_box'), reusing result: "dynamic_box"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -997,11 +982,9 @@ debug: Sealing block@4
 debug: Terminated block@4
 debug: Building IR for function examples.box_storage.contract.BoxContract.write_dynamic_box
 debug: Sealing block@0
-box_storage/contract.py:325:9 debug: encountered already materialized expression ('dynamic_box'), reusing result: "dynamic_box"
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.write_dynamic_arr_struct
 debug: Sealing block@0
-box_storage/contract.py:329:9 debug: encountered already materialized expression ('dynamic_arr_struct'), reusing result: "dynamic_arr_struct"
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.slice_box
 debug: Sealing block@0

--- a/examples/box_storage/puya_unoptimized.log
+++ b/examples/box_storage/puya_unoptimized.log
@@ -722,8 +722,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.set_boxes
 debug: Sealing block@0
-box_storage/contract.py:88:9 debug: encountered already materialized expression ('box_large'), reusing result: "box_large"
-box_storage/contract.py:94:9 debug: encountered already materialized expression ('box_a'), reusing result: "box_a"
 box_storage/contract.py:104:16 debug: encountered already materialized expression (reinterpret_cast<bytes>(Box[hex<"424F585F43">])), reusing result: storage_value%5#0
 box_storage/contract.py:104:46 debug: encountered already materialized expression (reinterpret_cast<bytes>(c)), reusing result: c#0
 box_storage/contract.py:110:16 debug: encountered already materialized expression (Box['box_d']), reusing result: storage_value%9#0
@@ -737,7 +735,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.set_many_ints
 debug: Sealing block@0
-box_storage/contract.py:130:9 debug: encountered already materialized expression ('many_ints'), reusing result: "many_ints"
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.create_big_fixed_bytes
 debug: Sealing block@0
@@ -787,7 +784,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.indirect_extract_and_replace
 debug: Sealing block@0
-box_storage/contract.py:188:9 debug: encountered already materialized expression (large), reusing result: large#0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.read_boxes
 debug: Sealing block@0
@@ -809,7 +805,6 @@ debug: Created Phi assignment: let value_internal%0#1: uint64 = undefined while 
 debug: Terminated block@1
 debug: Sealing block@2
 box_storage/contract.py:220:13 debug: encountered already materialized expression (Box['dynamic_arr_struct']), reusing result: storage_value%0#0
-box_storage/contract.py:220:13 debug: encountered already materialized expression ('dynamic_arr_struct'), reusing result: "dynamic_arr_struct"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -826,7 +821,6 @@ debug: Created Phi assignment: let value_internal%0#1: uint64 = undefined while 
 debug: Terminated block@1
 debug: Sealing block@2
 box_storage/contract.py:226:13 debug: encountered already materialized expression (Box['dynamic_arr_struct']), reusing result: storage_value%0#0
-box_storage/contract.py:226:13 debug: encountered already materialized expression ('dynamic_arr_struct'), reusing result: "dynamic_arr_struct"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -840,12 +834,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.nested_write
 debug: Sealing block@0
-box_storage/contract.py:247:9 debug: encountered already materialized expression (box), reusing result: box#0
-box_storage/contract.py:248:9 debug: encountered already materialized expression (box), reusing result: box#0
-box_storage/contract.py:249:9 debug: encountered already materialized expression (box), reusing result: box#0
-box_storage/contract.py:250:9 debug: encountered already materialized expression (box), reusing result: box#0
-box_storage/contract.py:251:9 debug: encountered already materialized expression (box), reusing result: box#0
-box_storage/contract.py:252:9 debug: encountered already materialized expression (box), reusing result: box#0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.nested_read
 debug: Sealing block@0
@@ -890,7 +878,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.set_bool
 debug: Sealing block@0
-box_storage/contract.py:283:9 debug: encountered already materialized expression ('too_many_bools'), reusing result: "too_many_bools"
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.sum_bools
 debug: Sealing block@0
@@ -951,7 +938,6 @@ debug: Looking for 'value_internal%0' in an unsealed block creating an incomplet
 debug: Created Phi assignment: let value_internal%0#1: uint64 = undefined while trying to resolve 'value_internal%0' in block@1
 debug: Terminated block@1
 debug: Sealing block@2
-box_storage/contract.py:306:13 debug: encountered already materialized expression ('dynamic_box'), reusing result: "dynamic_box"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -967,7 +953,6 @@ debug: Looking for 'value_internal%0' in an unsealed block creating an incomplet
 debug: Created Phi assignment: let value_internal%0#1: uint64 = undefined while trying to resolve 'value_internal%0' in block@1
 debug: Terminated block@1
 debug: Sealing block@2
-box_storage/contract.py:312:13 debug: encountered already materialized expression ('dynamic_box'), reusing result: "dynamic_box"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -997,11 +982,9 @@ debug: Sealing block@4
 debug: Terminated block@4
 debug: Building IR for function examples.box_storage.contract.BoxContract.write_dynamic_box
 debug: Sealing block@0
-box_storage/contract.py:325:9 debug: encountered already materialized expression ('dynamic_box'), reusing result: "dynamic_box"
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.write_dynamic_arr_struct
 debug: Sealing block@0
-box_storage/contract.py:329:9 debug: encountered already materialized expression ('dynamic_arr_struct'), reusing result: "dynamic_arr_struct"
 debug: Terminated block@0
 debug: Building IR for function examples.box_storage.contract.BoxContract.slice_box
 debug: Sealing block@0

--- a/examples/tictactoe/puya.log
+++ b/examples/tictactoe/puya.log
@@ -519,7 +519,6 @@ debug: Added column#0 to Phi node: let column#1: uint64 = φ(column#0 <- block@6
 debug: Replacing trivial Phi node: let column#1: uint64 = φ(column#0 <- block@6, column#0 <- block@7) (column#1) with column#0
 debug: Deleting Phi assignment: let column#1: uint64 = φ(column#0 <- block@6, column#0 <- block@7)
 debug: Replaced trivial Phi node: let column#1: uint64 = φ(column#0 <- block@6, column#0 <- block@7) (column#1) with column#0 in current definition for 1 blocks
-tictactoe/tictactoe.py:34:9 debug: encountered already materialized expression ('game'), reusing result: "game"
 debug: Terminated block@8
 debug: Building IR for function examples.tictactoe.tictactoe.TicTacToeContract.join_game
 debug: Sealing block@0
@@ -600,8 +599,6 @@ debug: Added player#0 to Phi node: let player#1: Encoded(uint8) = φ(player#0 <-
 debug: Replacing trivial Phi node: let player#1: Encoded(uint8) = φ(player#0 <- block@2, player#0 <- block@3) (player#1) with player#0
 debug: Deleting Phi assignment: let player#1: Encoded(uint8) = φ(player#0 <- block@2, player#0 <- block@3)
 debug: Replaced trivial Phi node: let player#1: Encoded(uint8) = φ(player#0 <- block@2, player#0 <- block@3) (player#1) with player#0 in current definition for 1 blocks
-tictactoe/tictactoe.py:65:9 debug: encountered already materialized expression ('game'), reusing result: "game"
-tictactoe/tictactoe.py:66:9 debug: encountered already materialized expression ('turns'), reusing result: "turns"
 debug: Terminated block@4
 debug: Sealing block@5
 debug: Terminated block@5
@@ -661,7 +658,6 @@ debug: Terminated block@6
 debug: Sealing block@7
 debug: Terminated block@7
 debug: Sealing block@8
-tictactoe/tictactoe.py:84:27 debug: encountered already materialized expression (player), reusing result: player#0
 debug: Terminated block@8
 debug: Sealing block@9
 debug: Terminated block@9
@@ -680,7 +676,6 @@ debug: Deleting Phi assignment: let player#3: Encoded(uint8) = φ(player#0 <- bl
 debug: Replaced trivial Phi node: let player#3: Encoded(uint8) = φ(player#0 <- block@7, player#0 <- block@8) (player#3) with player#0 in current definition for 1 blocks
 debug: Terminated block@10
 debug: Sealing block@11
-tictactoe/tictactoe.py:86:27 debug: encountered already materialized expression (player), reusing result: player#0
 debug: Terminated block@11
 debug: Sealing block@12
 debug: Terminated block@12

--- a/examples/tictactoe/puya_O2.log
+++ b/examples/tictactoe/puya_O2.log
@@ -518,7 +518,6 @@ debug: Added column#0 to Phi node: let column#1: uint64 = φ(column#0 <- block@6
 debug: Replacing trivial Phi node: let column#1: uint64 = φ(column#0 <- block@6, column#0 <- block@7) (column#1) with column#0
 debug: Deleting Phi assignment: let column#1: uint64 = φ(column#0 <- block@6, column#0 <- block@7)
 debug: Replaced trivial Phi node: let column#1: uint64 = φ(column#0 <- block@6, column#0 <- block@7) (column#1) with column#0 in current definition for 1 blocks
-tictactoe/tictactoe.py:34:9 debug: encountered already materialized expression ('game'), reusing result: "game"
 debug: Terminated block@8
 debug: Building IR for function examples.tictactoe.tictactoe.TicTacToeContract.join_game
 debug: Sealing block@0
@@ -599,8 +598,6 @@ debug: Added player#0 to Phi node: let player#1: Encoded(uint8) = φ(player#0 <-
 debug: Replacing trivial Phi node: let player#1: Encoded(uint8) = φ(player#0 <- block@2, player#0 <- block@3) (player#1) with player#0
 debug: Deleting Phi assignment: let player#1: Encoded(uint8) = φ(player#0 <- block@2, player#0 <- block@3)
 debug: Replaced trivial Phi node: let player#1: Encoded(uint8) = φ(player#0 <- block@2, player#0 <- block@3) (player#1) with player#0 in current definition for 1 blocks
-tictactoe/tictactoe.py:65:9 debug: encountered already materialized expression ('game'), reusing result: "game"
-tictactoe/tictactoe.py:66:9 debug: encountered already materialized expression ('turns'), reusing result: "turns"
 debug: Terminated block@4
 debug: Sealing block@5
 debug: Terminated block@5
@@ -660,7 +657,6 @@ debug: Terminated block@6
 debug: Sealing block@7
 debug: Terminated block@7
 debug: Sealing block@8
-tictactoe/tictactoe.py:84:27 debug: encountered already materialized expression (player), reusing result: player#0
 debug: Terminated block@8
 debug: Sealing block@9
 debug: Terminated block@9
@@ -679,7 +675,6 @@ debug: Deleting Phi assignment: let player#3: Encoded(uint8) = φ(player#0 <- bl
 debug: Replaced trivial Phi node: let player#3: Encoded(uint8) = φ(player#0 <- block@7, player#0 <- block@8) (player#3) with player#0 in current definition for 1 blocks
 debug: Terminated block@10
 debug: Sealing block@11
-tictactoe/tictactoe.py:86:27 debug: encountered already materialized expression (player), reusing result: player#0
 debug: Terminated block@11
 debug: Sealing block@12
 debug: Terminated block@12

--- a/examples/tictactoe/puya_unoptimized.log
+++ b/examples/tictactoe/puya_unoptimized.log
@@ -518,7 +518,6 @@ debug: Added column#0 to Phi node: let column#1: uint64 = φ(column#0 <- block@6
 debug: Replacing trivial Phi node: let column#1: uint64 = φ(column#0 <- block@6, column#0 <- block@7) (column#1) with column#0
 debug: Deleting Phi assignment: let column#1: uint64 = φ(column#0 <- block@6, column#0 <- block@7)
 debug: Replaced trivial Phi node: let column#1: uint64 = φ(column#0 <- block@6, column#0 <- block@7) (column#1) with column#0 in current definition for 1 blocks
-tictactoe/tictactoe.py:34:9 debug: encountered already materialized expression ('game'), reusing result: "game"
 debug: Terminated block@8
 debug: Building IR for function examples.tictactoe.tictactoe.TicTacToeContract.join_game
 debug: Sealing block@0
@@ -599,8 +598,6 @@ debug: Added player#0 to Phi node: let player#1: Encoded(uint8) = φ(player#0 <-
 debug: Replacing trivial Phi node: let player#1: Encoded(uint8) = φ(player#0 <- block@2, player#0 <- block@3) (player#1) with player#0
 debug: Deleting Phi assignment: let player#1: Encoded(uint8) = φ(player#0 <- block@2, player#0 <- block@3)
 debug: Replaced trivial Phi node: let player#1: Encoded(uint8) = φ(player#0 <- block@2, player#0 <- block@3) (player#1) with player#0 in current definition for 1 blocks
-tictactoe/tictactoe.py:65:9 debug: encountered already materialized expression ('game'), reusing result: "game"
-tictactoe/tictactoe.py:66:9 debug: encountered already materialized expression ('turns'), reusing result: "turns"
 debug: Terminated block@4
 debug: Sealing block@5
 debug: Terminated block@5
@@ -660,7 +657,6 @@ debug: Terminated block@6
 debug: Sealing block@7
 debug: Terminated block@7
 debug: Sealing block@8
-tictactoe/tictactoe.py:84:27 debug: encountered already materialized expression (player), reusing result: player#0
 debug: Terminated block@8
 debug: Sealing block@9
 debug: Terminated block@9
@@ -679,7 +675,6 @@ debug: Deleting Phi assignment: let player#3: Encoded(uint8) = φ(player#0 <- bl
 debug: Replaced trivial Phi node: let player#3: Encoded(uint8) = φ(player#0 <- block@7, player#0 <- block@8) (player#3) with player#0 in current definition for 1 blocks
 debug: Terminated block@10
 debug: Sealing block@11
-tictactoe/tictactoe.py:86:27 debug: encountered already materialized expression (player), reusing result: player#0
 debug: Terminated block@11
 debug: Sealing block@12
 debug: Terminated block@12

--- a/examples/voting/puya.log
+++ b/examples/voting/puya.log
@@ -569,7 +569,6 @@ debug: Looking for 'answer_ids' in an unsealed block creating an incomplete Phi:
 debug: Created Phi assignment: let answer_ids#1: Encoded(len+uint8[]) = undefined while trying to resolve 'answer_ids' in block@1
 debug: Looking for 'cumulative_offset' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let cumulative_offset#1: uint64 = undefined while trying to resolve 'cumulative_offset' in block@1
-voting/voting.py:203:13 debug: encountered already materialized expression ('voter_count'), reusing result: "voter_count"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3

--- a/examples/voting/puya_O2.log
+++ b/examples/voting/puya_O2.log
@@ -568,7 +568,6 @@ debug: Looking for 'answer_ids' in an unsealed block creating an incomplete Phi:
 debug: Created Phi assignment: let answer_ids#1: Encoded(len+uint8[]) = undefined while trying to resolve 'answer_ids' in block@1
 debug: Looking for 'cumulative_offset' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let cumulative_offset#1: uint64 = undefined while trying to resolve 'cumulative_offset' in block@1
-voting/voting.py:203:13 debug: encountered already materialized expression ('voter_count'), reusing result: "voter_count"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3

--- a/examples/voting/puya_unoptimized.log
+++ b/examples/voting/puya_unoptimized.log
@@ -568,7 +568,6 @@ debug: Looking for 'answer_ids' in an unsealed block creating an incomplete Phi:
 debug: Created Phi assignment: let answer_ids#1: Encoded(len+uint8[]) = undefined while trying to resolve 'answer_ids' in block@1
 debug: Looking for 'cumulative_offset' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let cumulative_offset#1: uint64 = undefined while trying to resolve 'cumulative_offset' in block@1
-voting/voting.py:203:13 debug: encountered already materialized expression ('voter_count'), reusing result: "voter_count"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3

--- a/src/puya/ir/builder/main.py
+++ b/src/puya/ir/builder/main.py
@@ -1579,8 +1579,14 @@ class FunctionIRBuilder(
     def _visit_and_check_for_double_eval(
         self, expr: awst_nodes.Expression, *, materialise_as: str | Sequence[str] | None = None
     ) -> ir.ValueProvider | None:
-        # explicit SingleEvaluation nodes already handle this
-        if isinstance(expr, awst_nodes.SingleEvaluation):
+        # - explicit SingleEvaluation nodes already handle multi-eval (as the name implies)
+        # -constants and var expresions have no side effects and cannot contain nested expressions
+        if isinstance(
+            expr,
+            awst_nodes.SingleEvaluation
+            | awst_nodes.CompileTimeConstantExpression
+            | awst_nodes.VarExpression,
+        ):
             return expr.accept(self)
         # include the expression in the key to ensure the lifetime of the
         # expression is as long as the cache.

--- a/test_cases/arc4_dynamic_arrays/puya.log
+++ b/test_cases/arc4_dynamic_arrays/puya.log
@@ -503,8 +503,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_dynamic_arrays.contract.DynamicArrayContract.test_mixed_single_dynamic_elements
 debug: Sealing block@0
-arc4_dynamic_arrays/contract.py:94:16 debug: encountered already materialized expression (array2), reusing result: array2#1
-arc4_dynamic_arrays/contract.py:95:16 debug: encountered already materialized expression (array2), reusing result: array2#1
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_dynamic_arrays.contract.DynamicArrayContract.test_mixed_multiple_dynamic_elements
 debug: Sealing block@0
@@ -514,7 +512,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_dynamic_arrays.contract.DynamicArrayContract.test_nested_tuple_modification
 debug: Sealing block@0
-arc4_dynamic_arrays/contract.py:176:9 debug: encountered already materialized expression (tup2), reusing result: tup2#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_dynamic_arrays.contract.DynamicArrayContract.__algopy_default_create
 debug: Sealing block@0

--- a/test_cases/arc4_dynamic_arrays/puya_O2.log
+++ b/test_cases/arc4_dynamic_arrays/puya_O2.log
@@ -502,8 +502,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_dynamic_arrays.contract.DynamicArrayContract.test_mixed_single_dynamic_elements
 debug: Sealing block@0
-arc4_dynamic_arrays/contract.py:94:16 debug: encountered already materialized expression (array2), reusing result: array2#1
-arc4_dynamic_arrays/contract.py:95:16 debug: encountered already materialized expression (array2), reusing result: array2#1
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_dynamic_arrays.contract.DynamicArrayContract.test_mixed_multiple_dynamic_elements
 debug: Sealing block@0
@@ -513,7 +511,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_dynamic_arrays.contract.DynamicArrayContract.test_nested_tuple_modification
 debug: Sealing block@0
-arc4_dynamic_arrays/contract.py:176:9 debug: encountered already materialized expression (tup2), reusing result: tup2#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_dynamic_arrays.contract.DynamicArrayContract.__algopy_default_create
 debug: Sealing block@0

--- a/test_cases/arc4_dynamic_arrays/puya_unoptimized.log
+++ b/test_cases/arc4_dynamic_arrays/puya_unoptimized.log
@@ -502,8 +502,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_dynamic_arrays.contract.DynamicArrayContract.test_mixed_single_dynamic_elements
 debug: Sealing block@0
-arc4_dynamic_arrays/contract.py:94:16 debug: encountered already materialized expression (array2), reusing result: array2#1
-arc4_dynamic_arrays/contract.py:95:16 debug: encountered already materialized expression (array2), reusing result: array2#1
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_dynamic_arrays.contract.DynamicArrayContract.test_mixed_multiple_dynamic_elements
 debug: Sealing block@0
@@ -513,7 +511,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_dynamic_arrays.contract.DynamicArrayContract.test_nested_tuple_modification
 debug: Sealing block@0
-arc4_dynamic_arrays/contract.py:176:9 debug: encountered already materialized expression (tup2), reusing result: tup2#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_dynamic_arrays.contract.DynamicArrayContract.__algopy_default_create
 debug: Sealing block@0

--- a/test_cases/arc4_encode_decode/puya.log
+++ b/test_cases/arc4_encode_decode/puya.log
@@ -452,13 +452,9 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_encode_decode.contract.test_tuple
 debug: Sealing block@0
-arc4_encode_decode/contract.py:175:12 debug: encountered already materialized expression (decoded), reusing result: (decoded.0#0, decoded.1#0)
-arc4_encode_decode/contract.py:175:23 debug: encountered already materialized expression (value), reusing result: (value.0#0, value.1#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_encode_decode.contract.test_named_tuple
 debug: Sealing block@0
-arc4_encode_decode/contract.py:183:12 debug: encountered already materialized expression (decoded), reusing result: (decoded.x#0, decoded.y#0)
-arc4_encode_decode/contract.py:183:23 debug: encountered already materialized expression (value), reusing result: (value.x#0, value.y#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_encode_decode.contract.test_arc4_dynamic_array
 debug: Sealing block@0

--- a/test_cases/arc4_encode_decode/puya_O2.log
+++ b/test_cases/arc4_encode_decode/puya_O2.log
@@ -451,13 +451,9 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_encode_decode.contract.test_tuple
 debug: Sealing block@0
-arc4_encode_decode/contract.py:175:12 debug: encountered already materialized expression (decoded), reusing result: (decoded.0#0, decoded.1#0)
-arc4_encode_decode/contract.py:175:23 debug: encountered already materialized expression (value), reusing result: (value.0#0, value.1#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_encode_decode.contract.test_named_tuple
 debug: Sealing block@0
-arc4_encode_decode/contract.py:183:12 debug: encountered already materialized expression (decoded), reusing result: (decoded.x#0, decoded.y#0)
-arc4_encode_decode/contract.py:183:23 debug: encountered already materialized expression (value), reusing result: (value.x#0, value.y#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_encode_decode.contract.test_arc4_dynamic_array
 debug: Sealing block@0

--- a/test_cases/arc4_encode_decode/puya_unoptimized.log
+++ b/test_cases/arc4_encode_decode/puya_unoptimized.log
@@ -451,13 +451,9 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_encode_decode.contract.test_tuple
 debug: Sealing block@0
-arc4_encode_decode/contract.py:175:12 debug: encountered already materialized expression (decoded), reusing result: (decoded.0#0, decoded.1#0)
-arc4_encode_decode/contract.py:175:23 debug: encountered already materialized expression (value), reusing result: (value.0#0, value.1#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_encode_decode.contract.test_named_tuple
 debug: Sealing block@0
-arc4_encode_decode/contract.py:183:12 debug: encountered already materialized expression (decoded), reusing result: (decoded.x#0, decoded.y#0)
-arc4_encode_decode/contract.py:183:23 debug: encountered already materialized expression (value), reusing result: (value.x#0, value.y#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_encode_decode.contract.test_arc4_dynamic_array
 debug: Sealing block@0

--- a/test_cases/arc4_types/puya.log
+++ b/test_cases/arc4_types/puya.log
@@ -747,7 +747,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_types.tuples.Arc4TuplesTypeContract.test_copy
 debug: Sealing block@0
-arc4_types/tuples.py:72:9 debug: encountered already materialized expression (tup), reusing result: tup#0
 debug: Terminated block@0
 debug: Building IR for function algopy._contract.Contract.__init__
 debug: Sealing block@0
@@ -990,7 +989,6 @@ debug: Added coord_1#1 to Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(c
 debug: Replacing trivial Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3) (coord_1#1) with coord_1#0
 debug: Deleting Phi assignment: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3)
 debug: Replaced trivial Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3) (coord_1#1) with coord_1#0 in current definition for 3 blocks
-arc4_types/structs.py:55:9 debug: encountered already materialized expression (copy), reusing result: copy#0
 debug: Terminated block@4
 debug: Building IR for function test_cases.arc4_types.structs.Arc4StructsTypeContract.clear_state_program
 debug: Sealing block@0
@@ -1022,7 +1020,6 @@ debug: Added coord_1#1 to Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(c
 debug: Replacing trivial Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3) (coord_1#1) with coord_1#0
 debug: Deleting Phi assignment: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3)
 debug: Replaced trivial Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3) (coord_1#1) with coord_1#0 in current definition for 3 blocks
-arc4_types/structs.py:55:9 debug: encountered already materialized expression (copy), reusing result: copy#0
 debug: Terminated block@4
 debug: removing unused subroutine _puya_lib.util.ensure_budget
 debug: removing unused subroutine _puya_lib.bytes_.is_substring
@@ -1376,8 +1373,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_types.mutation.Arc4MutationContract.array_of_array_dynamic
 debug: Sealing block@0
-arc4_types/mutation.py:78:9 debug: encountered already materialized expression (array_of_array), reusing result: array_of_array#2
-arc4_types/mutation.py:78:24 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_types.mutation.Arc4MutationContract.array_of_array_static
 debug: Sealing block@0
@@ -1667,8 +1662,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_types.mutable_params.Arc4MutableParamsContract.mutating_copies
 debug: Sealing block@0
-arc4_types/mutable_params.py:90:16 debug: encountered already materialized expression (originals), reusing result: (originals.0#0, originals.1#0, originals.2#0)
-arc4_types/mutable_params.py:90:16 debug: encountered already materialized expression (originals), reusing result: (originals.0#0, originals.1#0, originals.2#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_types.mutable_params.Arc4MutableParamsContract.other_routine
 debug: Sealing block@0

--- a/test_cases/arc4_types/puya_O2.log
+++ b/test_cases/arc4_types/puya_O2.log
@@ -746,7 +746,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_types.tuples.Arc4TuplesTypeContract.test_copy
 debug: Sealing block@0
-arc4_types/tuples.py:72:9 debug: encountered already materialized expression (tup), reusing result: tup#0
 debug: Terminated block@0
 debug: Building IR for function algopy._contract.Contract.__init__
 debug: Sealing block@0
@@ -989,7 +988,6 @@ debug: Added coord_1#1 to Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(c
 debug: Replacing trivial Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3) (coord_1#1) with coord_1#0
 debug: Deleting Phi assignment: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3)
 debug: Replaced trivial Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3) (coord_1#1) with coord_1#0 in current definition for 3 blocks
-arc4_types/structs.py:55:9 debug: encountered already materialized expression (copy), reusing result: copy#0
 debug: Terminated block@4
 debug: Building IR for function test_cases.arc4_types.structs.Arc4StructsTypeContract.clear_state_program
 debug: Sealing block@0
@@ -1021,7 +1019,6 @@ debug: Added coord_1#1 to Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(c
 debug: Replacing trivial Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3) (coord_1#1) with coord_1#0
 debug: Deleting Phi assignment: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3)
 debug: Replaced trivial Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3) (coord_1#1) with coord_1#0 in current definition for 3 blocks
-arc4_types/structs.py:55:9 debug: encountered already materialized expression (copy), reusing result: copy#0
 debug: Terminated block@4
 debug: removing unused subroutine _puya_lib.util.ensure_budget
 debug: removing unused subroutine _puya_lib.bytes_.is_substring
@@ -1375,8 +1372,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_types.mutation.Arc4MutationContract.array_of_array_dynamic
 debug: Sealing block@0
-arc4_types/mutation.py:78:9 debug: encountered already materialized expression (array_of_array), reusing result: array_of_array#2
-arc4_types/mutation.py:78:24 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_types.mutation.Arc4MutationContract.array_of_array_static
 debug: Sealing block@0
@@ -1666,8 +1661,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_types.mutable_params.Arc4MutableParamsContract.mutating_copies
 debug: Sealing block@0
-arc4_types/mutable_params.py:90:16 debug: encountered already materialized expression (originals), reusing result: (originals.0#0, originals.1#0, originals.2#0)
-arc4_types/mutable_params.py:90:16 debug: encountered already materialized expression (originals), reusing result: (originals.0#0, originals.1#0, originals.2#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_types.mutable_params.Arc4MutableParamsContract.other_routine
 debug: Sealing block@0

--- a/test_cases/arc4_types/puya_unoptimized.log
+++ b/test_cases/arc4_types/puya_unoptimized.log
@@ -746,7 +746,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_types.tuples.Arc4TuplesTypeContract.test_copy
 debug: Sealing block@0
-arc4_types/tuples.py:72:9 debug: encountered already materialized expression (tup), reusing result: tup#0
 debug: Terminated block@0
 debug: Building IR for function algopy._contract.Contract.__init__
 debug: Sealing block@0
@@ -989,7 +988,6 @@ debug: Added coord_1#1 to Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(c
 debug: Replacing trivial Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3) (coord_1#1) with coord_1#0
 debug: Deleting Phi assignment: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3)
 debug: Replaced trivial Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3) (coord_1#1) with coord_1#0 in current definition for 3 blocks
-arc4_types/structs.py:55:9 debug: encountered already materialized expression (copy), reusing result: copy#0
 debug: Terminated block@4
 debug: Building IR for function test_cases.arc4_types.structs.Arc4StructsTypeContract.clear_state_program
 debug: Sealing block@0
@@ -1021,7 +1019,6 @@ debug: Added coord_1#1 to Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(c
 debug: Replacing trivial Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3) (coord_1#1) with coord_1#0
 debug: Deleting Phi assignment: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3)
 debug: Replaced trivial Phi node: let coord_1#1: Encoded(uint64,uint64) = φ(coord_1#0 <- block@0, coord_1#1 <- block@3) (coord_1#1) with coord_1#0 in current definition for 3 blocks
-arc4_types/structs.py:55:9 debug: encountered already materialized expression (copy), reusing result: copy#0
 debug: Terminated block@4
 debug: removing unused subroutine _puya_lib.util.ensure_budget
 debug: removing unused subroutine _puya_lib.bytes_.is_substring
@@ -1375,8 +1372,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_types.mutation.Arc4MutationContract.array_of_array_dynamic
 debug: Sealing block@0
-arc4_types/mutation.py:78:9 debug: encountered already materialized expression (array_of_array), reusing result: array_of_array#2
-arc4_types/mutation.py:78:24 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_types.mutation.Arc4MutationContract.array_of_array_static
 debug: Sealing block@0
@@ -1666,8 +1661,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_types.mutable_params.Arc4MutableParamsContract.mutating_copies
 debug: Sealing block@0
-arc4_types/mutable_params.py:90:16 debug: encountered already materialized expression (originals), reusing result: (originals.0#0, originals.1#0, originals.2#0)
-arc4_types/mutable_params.py:90:16 debug: encountered already materialized expression (originals), reusing result: (originals.0#0, originals.1#0, originals.2#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.arc4_types.mutable_params.Arc4MutableParamsContract.other_routine
 debug: Sealing block@0

--- a/test_cases/array/puya.log
+++ b/test_cases/array/puya.log
@@ -1342,17 +1342,8 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.uint64.Contract.test_array
 debug: Sealing block@0
-array/uint64.py:21:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:25:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:29:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:33:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:38:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:42:16 debug: encountered already materialized expression (arr), reusing result: arr#0
 array/uint64.py:44:9 debug: encountered already materialized expression (test_cases.array.uint64.return_ref(arr, arr)), reusing result: tmp%46#0
-array/uint64.py:44:30 debug: encountered already materialized expression (0u), reusing result: 0u
 array/uint64.py:44:9 debug: base assignment target is in a slot
-array/uint64.py:47:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:48:16 debug: encountered already materialized expression (arr), reusing result: arr#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.uint64.Contract.test_array_extend
 debug: Sealing block@0
@@ -1406,9 +1397,6 @@ debug: Replacing trivial Phi node: let array#1: Encoded(uint64[])* = φ(array#0 
 debug: Deleting Phi assignment: let array#1: Encoded(uint64[])* = φ(array#0 <- block@0, array#1 <- block@3)
 debug: Replaced trivial Phi node: let array#1: Encoded(uint64[])* = φ(array#0 <- block@0, array#1 <- block@3) (array#1) with array#0 in current definition for 3 blocks
 debug: Sealing block@4
-array/uint64.py:93:16 debug: encountered already materialized expression (array), reusing result: array#0
-array/uint64.py:96:16 debug: encountered already materialized expression (array2), reusing result: array2#0
-array/uint64.py:101:16 debug: encountered already materialized expression (array), reusing result: array#0
 debug: Terminated block@4
 debug: Building IR for function test_cases.array.uint64.Contract.test_array_evaluation_order
 debug: Sealing block@0
@@ -1770,8 +1758,6 @@ debug: Sealing block@4
 debug: Terminated block@4
 debug: Building IR for function test_cases.array.static_size.StaticSizeContract.test_extend_from_tuple
 debug: Sealing block@0
-array/static_size.py:63:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/static_size.py:66:16 debug: encountered already materialized expression (result), reusing result: result#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.static_size.StaticSizeContract.test_extend_from_arc4_tuple
 debug: Sealing block@0
@@ -1911,7 +1897,6 @@ debug: Sealing block@4
 debug: Terminated block@4
 debug: Building IR for function test_cases.array.static_size.StaticSizeContract.xtra
 debug: Sealing block@0
-array/static_size.py:127:9 debug: encountered already materialized expression ('count'), reusing result: "count"
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.static_size.StaticSizeContract.more
 debug: Sealing block@0
@@ -2432,19 +2417,9 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_uint64_array
 debug: Sealing block@0
-array/immutable.py:101:16 debug: encountered already materialized expression (arr), reusing result: arr#1
-array/immutable.py:105:16 debug: encountered already materialized expression (arr), reusing result: arr#2
-array/immutable.py:109:16 debug: encountered already materialized expression (arr), reusing result: arr#3
-array/immutable.py:114:16 debug: encountered already materialized expression (arr), reusing result: arr#4
-array/immutable.py:118:16 debug: encountered already materialized expression (arr), reusing result: arr#5
-array/immutable.py:122:16 debug: encountered already materialized expression (arr), reusing result: arr#6
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_biguint_array
 debug: Sealing block@0
-array/immutable.py:137:16 debug: encountered already materialized expression (arr), reusing result: arr#1
-array/immutable.py:141:16 debug: encountered already materialized expression (arr), reusing result: arr#2
-array/immutable.py:145:16 debug: encountered already materialized expression (arr), reusing result: arr#3
-array/immutable.py:150:16 debug: encountered already materialized expression (arr), reusing result: arr#4
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_bool_array
 debug: Sealing block@0
@@ -2557,8 +2532,6 @@ debug: Added value_internal%0#2 to Phi node: let value_internal%0#1: uint64 = φ
 debug: Added arr#0 to Phi node: let arr#1: Encoded(len+(uint64,uint64)[]) = φ(arr#0 <- block@0) in block@0
 debug: Added arr#2 to Phi node: let arr#1: Encoded(len+(uint64,uint64)[]) = φ(arr#0 <- block@0, arr#2 <- block@3) in block@3
 debug: Sealing block@4
-array/immutable.py:189:16 debug: encountered already materialized expression (arr), reusing result: arr#1
-array/immutable.py:194:16 debug: encountered already materialized expression (arr), reusing result: arr#3
 debug: Terminated block@4
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_fixed_size_named_tuple_array
 debug: Sealing block@0
@@ -2616,7 +2589,6 @@ debug: Replacing trivial Phi node: let arr#3: Encoded(len+(uint64,(len+uint8[]))
 debug: Deleting Phi assignment: let arr#3: Encoded(len+(uint64,(len+uint8[]))[]) = φ(arr#1 <- block@4, arr#3 <- block@7)
 debug: Replaced trivial Phi node: let arr#3: Encoded(len+(uint64,(len+uint8[]))[]) = φ(arr#1 <- block@4, arr#3 <- block@7) (arr#3) with arr#1 in current definition for 3 blocks
 debug: Sealing block@8
-array/immutable.py:228:16 debug: encountered already materialized expression (arr), reusing result: arr#4
 debug: Terminated block@8
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_dynamic_sized_named_tuple_array
 debug: Sealing block@0
@@ -2655,7 +2627,6 @@ debug: Replacing trivial Phi node: let arr#3: Encoded(len+(uint64,(len+utf8[]))[
 debug: Deleting Phi assignment: let arr#3: Encoded(len+(uint64,(len+utf8[]))[]) = φ(arr#1 <- block@4, arr#3 <- block@7)
 debug: Replaced trivial Phi node: let arr#3: Encoded(len+(uint64,(len+utf8[]))[]) = φ(arr#1 <- block@4, arr#3 <- block@7) (arr#3) with arr#1 in current definition for 3 blocks
 debug: Sealing block@8
-array/immutable.py:247:16 debug: encountered already materialized expression (arr), reusing result: arr#4
 debug: Terminated block@8
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_implicit_conversion_log
 debug: Sealing block@0
@@ -2753,9 +2724,6 @@ debug: Sealing block@4
 debug: Terminated block@4
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.sum_uints_and_lengths_and_trues
 debug: Sealing block@0
-array/immutable.py:349:37 debug: encountered already materialized expression (0u), reusing result: 0u
-array/immutable.py:349:37 debug: encountered already materialized expression (0u), reusing result: 0u
-array/immutable.py:349:37 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@0
 debug: Looking for 'item_index_internal%0' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let item_index_internal%0#1: uint64 = undefined while trying to resolve 'item_index_internal%0' in block@1
@@ -3164,8 +3132,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_imm_fixed_arr
 debug: Sealing block@0
-array/immutable.py:455:35 debug: encountered already materialized expression (struct12), reusing result: struct12#0
-array/immutable.py:455:35 debug: encountered already materialized expression (struct12), reusing result: struct12#0
 debug: Terminated block@0
 debug: Looking for 'value_internal%0' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let value_internal%0#1: uint64 = undefined while trying to resolve 'value_internal%0' in block@1

--- a/test_cases/array/puya_O2.log
+++ b/test_cases/array/puya_O2.log
@@ -1341,17 +1341,8 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.uint64.Contract.test_array
 debug: Sealing block@0
-array/uint64.py:21:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:25:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:29:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:33:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:38:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:42:16 debug: encountered already materialized expression (arr), reusing result: arr#0
 array/uint64.py:44:9 debug: encountered already materialized expression (test_cases.array.uint64.return_ref(arr, arr)), reusing result: tmp%46#0
-array/uint64.py:44:30 debug: encountered already materialized expression (0u), reusing result: 0u
 array/uint64.py:44:9 debug: base assignment target is in a slot
-array/uint64.py:47:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:48:16 debug: encountered already materialized expression (arr), reusing result: arr#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.uint64.Contract.test_array_extend
 debug: Sealing block@0
@@ -1405,9 +1396,6 @@ debug: Replacing trivial Phi node: let array#1: Encoded(uint64[])* = φ(array#0 
 debug: Deleting Phi assignment: let array#1: Encoded(uint64[])* = φ(array#0 <- block@0, array#1 <- block@3)
 debug: Replaced trivial Phi node: let array#1: Encoded(uint64[])* = φ(array#0 <- block@0, array#1 <- block@3) (array#1) with array#0 in current definition for 3 blocks
 debug: Sealing block@4
-array/uint64.py:93:16 debug: encountered already materialized expression (array), reusing result: array#0
-array/uint64.py:96:16 debug: encountered already materialized expression (array2), reusing result: array2#0
-array/uint64.py:101:16 debug: encountered already materialized expression (array), reusing result: array#0
 debug: Terminated block@4
 debug: Building IR for function test_cases.array.uint64.Contract.test_array_evaluation_order
 debug: Sealing block@0
@@ -1769,8 +1757,6 @@ debug: Sealing block@4
 debug: Terminated block@4
 debug: Building IR for function test_cases.array.static_size.StaticSizeContract.test_extend_from_tuple
 debug: Sealing block@0
-array/static_size.py:63:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/static_size.py:66:16 debug: encountered already materialized expression (result), reusing result: result#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.static_size.StaticSizeContract.test_extend_from_arc4_tuple
 debug: Sealing block@0
@@ -1910,7 +1896,6 @@ debug: Sealing block@4
 debug: Terminated block@4
 debug: Building IR for function test_cases.array.static_size.StaticSizeContract.xtra
 debug: Sealing block@0
-array/static_size.py:127:9 debug: encountered already materialized expression ('count'), reusing result: "count"
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.static_size.StaticSizeContract.more
 debug: Sealing block@0
@@ -2431,19 +2416,9 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_uint64_array
 debug: Sealing block@0
-array/immutable.py:101:16 debug: encountered already materialized expression (arr), reusing result: arr#1
-array/immutable.py:105:16 debug: encountered already materialized expression (arr), reusing result: arr#2
-array/immutable.py:109:16 debug: encountered already materialized expression (arr), reusing result: arr#3
-array/immutable.py:114:16 debug: encountered already materialized expression (arr), reusing result: arr#4
-array/immutable.py:118:16 debug: encountered already materialized expression (arr), reusing result: arr#5
-array/immutable.py:122:16 debug: encountered already materialized expression (arr), reusing result: arr#6
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_biguint_array
 debug: Sealing block@0
-array/immutable.py:137:16 debug: encountered already materialized expression (arr), reusing result: arr#1
-array/immutable.py:141:16 debug: encountered already materialized expression (arr), reusing result: arr#2
-array/immutable.py:145:16 debug: encountered already materialized expression (arr), reusing result: arr#3
-array/immutable.py:150:16 debug: encountered already materialized expression (arr), reusing result: arr#4
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_bool_array
 debug: Sealing block@0
@@ -2556,8 +2531,6 @@ debug: Added value_internal%0#2 to Phi node: let value_internal%0#1: uint64 = φ
 debug: Added arr#0 to Phi node: let arr#1: Encoded(len+(uint64,uint64)[]) = φ(arr#0 <- block@0) in block@0
 debug: Added arr#2 to Phi node: let arr#1: Encoded(len+(uint64,uint64)[]) = φ(arr#0 <- block@0, arr#2 <- block@3) in block@3
 debug: Sealing block@4
-array/immutable.py:189:16 debug: encountered already materialized expression (arr), reusing result: arr#1
-array/immutable.py:194:16 debug: encountered already materialized expression (arr), reusing result: arr#3
 debug: Terminated block@4
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_fixed_size_named_tuple_array
 debug: Sealing block@0
@@ -2615,7 +2588,6 @@ debug: Replacing trivial Phi node: let arr#3: Encoded(len+(uint64,(len+uint8[]))
 debug: Deleting Phi assignment: let arr#3: Encoded(len+(uint64,(len+uint8[]))[]) = φ(arr#1 <- block@4, arr#3 <- block@7)
 debug: Replaced trivial Phi node: let arr#3: Encoded(len+(uint64,(len+uint8[]))[]) = φ(arr#1 <- block@4, arr#3 <- block@7) (arr#3) with arr#1 in current definition for 3 blocks
 debug: Sealing block@8
-array/immutable.py:228:16 debug: encountered already materialized expression (arr), reusing result: arr#4
 debug: Terminated block@8
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_dynamic_sized_named_tuple_array
 debug: Sealing block@0
@@ -2654,7 +2626,6 @@ debug: Replacing trivial Phi node: let arr#3: Encoded(len+(uint64,(len+utf8[]))[
 debug: Deleting Phi assignment: let arr#3: Encoded(len+(uint64,(len+utf8[]))[]) = φ(arr#1 <- block@4, arr#3 <- block@7)
 debug: Replaced trivial Phi node: let arr#3: Encoded(len+(uint64,(len+utf8[]))[]) = φ(arr#1 <- block@4, arr#3 <- block@7) (arr#3) with arr#1 in current definition for 3 blocks
 debug: Sealing block@8
-array/immutable.py:247:16 debug: encountered already materialized expression (arr), reusing result: arr#4
 debug: Terminated block@8
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_implicit_conversion_log
 debug: Sealing block@0
@@ -2752,9 +2723,6 @@ debug: Sealing block@4
 debug: Terminated block@4
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.sum_uints_and_lengths_and_trues
 debug: Sealing block@0
-array/immutable.py:349:37 debug: encountered already materialized expression (0u), reusing result: 0u
-array/immutable.py:349:37 debug: encountered already materialized expression (0u), reusing result: 0u
-array/immutable.py:349:37 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@0
 debug: Looking for 'item_index_internal%0' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let item_index_internal%0#1: uint64 = undefined while trying to resolve 'item_index_internal%0' in block@1
@@ -3163,8 +3131,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_imm_fixed_arr
 debug: Sealing block@0
-array/immutable.py:455:35 debug: encountered already materialized expression (struct12), reusing result: struct12#0
-array/immutable.py:455:35 debug: encountered already materialized expression (struct12), reusing result: struct12#0
 debug: Terminated block@0
 debug: Looking for 'value_internal%0' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let value_internal%0#1: uint64 = undefined while trying to resolve 'value_internal%0' in block@1

--- a/test_cases/array/puya_unoptimized.log
+++ b/test_cases/array/puya_unoptimized.log
@@ -1341,17 +1341,8 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.uint64.Contract.test_array
 debug: Sealing block@0
-array/uint64.py:21:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:25:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:29:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:33:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:38:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:42:16 debug: encountered already materialized expression (arr), reusing result: arr#0
 array/uint64.py:44:9 debug: encountered already materialized expression (test_cases.array.uint64.return_ref(arr, arr)), reusing result: tmp%46#0
-array/uint64.py:44:30 debug: encountered already materialized expression (0u), reusing result: 0u
 array/uint64.py:44:9 debug: base assignment target is in a slot
-array/uint64.py:47:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/uint64.py:48:16 debug: encountered already materialized expression (arr), reusing result: arr#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.uint64.Contract.test_array_extend
 debug: Sealing block@0
@@ -1405,9 +1396,6 @@ debug: Replacing trivial Phi node: let array#1: Encoded(uint64[])* = φ(array#0 
 debug: Deleting Phi assignment: let array#1: Encoded(uint64[])* = φ(array#0 <- block@0, array#1 <- block@3)
 debug: Replaced trivial Phi node: let array#1: Encoded(uint64[])* = φ(array#0 <- block@0, array#1 <- block@3) (array#1) with array#0 in current definition for 3 blocks
 debug: Sealing block@4
-array/uint64.py:93:16 debug: encountered already materialized expression (array), reusing result: array#0
-array/uint64.py:96:16 debug: encountered already materialized expression (array2), reusing result: array2#0
-array/uint64.py:101:16 debug: encountered already materialized expression (array), reusing result: array#0
 debug: Terminated block@4
 debug: Building IR for function test_cases.array.uint64.Contract.test_array_evaluation_order
 debug: Sealing block@0
@@ -1769,8 +1757,6 @@ debug: Sealing block@4
 debug: Terminated block@4
 debug: Building IR for function test_cases.array.static_size.StaticSizeContract.test_extend_from_tuple
 debug: Sealing block@0
-array/static_size.py:63:16 debug: encountered already materialized expression (arr), reusing result: arr#0
-array/static_size.py:66:16 debug: encountered already materialized expression (result), reusing result: result#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.static_size.StaticSizeContract.test_extend_from_arc4_tuple
 debug: Sealing block@0
@@ -1910,7 +1896,6 @@ debug: Sealing block@4
 debug: Terminated block@4
 debug: Building IR for function test_cases.array.static_size.StaticSizeContract.xtra
 debug: Sealing block@0
-array/static_size.py:127:9 debug: encountered already materialized expression ('count'), reusing result: "count"
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.static_size.StaticSizeContract.more
 debug: Sealing block@0
@@ -2431,19 +2416,9 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_uint64_array
 debug: Sealing block@0
-array/immutable.py:101:16 debug: encountered already materialized expression (arr), reusing result: arr#1
-array/immutable.py:105:16 debug: encountered already materialized expression (arr), reusing result: arr#2
-array/immutable.py:109:16 debug: encountered already materialized expression (arr), reusing result: arr#3
-array/immutable.py:114:16 debug: encountered already materialized expression (arr), reusing result: arr#4
-array/immutable.py:118:16 debug: encountered already materialized expression (arr), reusing result: arr#5
-array/immutable.py:122:16 debug: encountered already materialized expression (arr), reusing result: arr#6
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_biguint_array
 debug: Sealing block@0
-array/immutable.py:137:16 debug: encountered already materialized expression (arr), reusing result: arr#1
-array/immutable.py:141:16 debug: encountered already materialized expression (arr), reusing result: arr#2
-array/immutable.py:145:16 debug: encountered already materialized expression (arr), reusing result: arr#3
-array/immutable.py:150:16 debug: encountered already materialized expression (arr), reusing result: arr#4
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_bool_array
 debug: Sealing block@0
@@ -2556,8 +2531,6 @@ debug: Added value_internal%0#2 to Phi node: let value_internal%0#1: uint64 = φ
 debug: Added arr#0 to Phi node: let arr#1: Encoded(len+(uint64,uint64)[]) = φ(arr#0 <- block@0) in block@0
 debug: Added arr#2 to Phi node: let arr#1: Encoded(len+(uint64,uint64)[]) = φ(arr#0 <- block@0, arr#2 <- block@3) in block@3
 debug: Sealing block@4
-array/immutable.py:189:16 debug: encountered already materialized expression (arr), reusing result: arr#1
-array/immutable.py:194:16 debug: encountered already materialized expression (arr), reusing result: arr#3
 debug: Terminated block@4
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_fixed_size_named_tuple_array
 debug: Sealing block@0
@@ -2615,7 +2588,6 @@ debug: Replacing trivial Phi node: let arr#3: Encoded(len+(uint64,(len+uint8[]))
 debug: Deleting Phi assignment: let arr#3: Encoded(len+(uint64,(len+uint8[]))[]) = φ(arr#1 <- block@4, arr#3 <- block@7)
 debug: Replaced trivial Phi node: let arr#3: Encoded(len+(uint64,(len+uint8[]))[]) = φ(arr#1 <- block@4, arr#3 <- block@7) (arr#3) with arr#1 in current definition for 3 blocks
 debug: Sealing block@8
-array/immutable.py:228:16 debug: encountered already materialized expression (arr), reusing result: arr#4
 debug: Terminated block@8
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_dynamic_sized_named_tuple_array
 debug: Sealing block@0
@@ -2654,7 +2626,6 @@ debug: Replacing trivial Phi node: let arr#3: Encoded(len+(uint64,(len+utf8[]))[
 debug: Deleting Phi assignment: let arr#3: Encoded(len+(uint64,(len+utf8[]))[]) = φ(arr#1 <- block@4, arr#3 <- block@7)
 debug: Replaced trivial Phi node: let arr#3: Encoded(len+(uint64,(len+utf8[]))[]) = φ(arr#1 <- block@4, arr#3 <- block@7) (arr#3) with arr#1 in current definition for 3 blocks
 debug: Sealing block@8
-array/immutable.py:247:16 debug: encountered already materialized expression (arr), reusing result: arr#4
 debug: Terminated block@8
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_implicit_conversion_log
 debug: Sealing block@0
@@ -2752,9 +2723,6 @@ debug: Sealing block@4
 debug: Terminated block@4
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.sum_uints_and_lengths_and_trues
 debug: Sealing block@0
-array/immutable.py:349:37 debug: encountered already materialized expression (0u), reusing result: 0u
-array/immutable.py:349:37 debug: encountered already materialized expression (0u), reusing result: 0u
-array/immutable.py:349:37 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@0
 debug: Looking for 'item_index_internal%0' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let item_index_internal%0#1: uint64 = undefined while trying to resolve 'item_index_internal%0' in block@1
@@ -3163,8 +3131,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.array.immutable.ImmutableArrayContract.test_imm_fixed_arr
 debug: Sealing block@0
-array/immutable.py:455:35 debug: encountered already materialized expression (struct12), reusing result: struct12#0
-array/immutable.py:455:35 debug: encountered already materialized expression (struct12), reusing result: struct12#0
 debug: Terminated block@0
 debug: Looking for 'value_internal%0' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let value_internal%0#1: uint64 = undefined while trying to resolve 'value_internal%0' in block@1

--- a/test_cases/augmented_assignment/puya.log
+++ b/test_cases/augmented_assignment/puya.log
@@ -435,15 +435,7 @@ debug: Added me#0 to Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- b
 debug: Replacing trivial Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3) (me#1) with me#0
 debug: Deleting Phi assignment: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3)
 debug: Replaced trivial Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3) (me#1) with me#0 in current definition for 1 blocks
-augmented_assignment/contract.py:34:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
-augmented_assignment/contract.py:34:26 debug: encountered already materialized expression (me), reusing result: me#0
-augmented_assignment/contract.py:35:13 debug: encountered already materialized expression ('my_bytes'), reusing result: "my_bytes"
-augmented_assignment/contract.py:35:27 debug: encountered already materialized expression (me), reusing result: me#0
-augmented_assignment/contract.py:38:13 debug: encountered already materialized expression ('global_uint'), reusing result: "global_uint"
-augmented_assignment/contract.py:39:13 debug: encountered already materialized expression ('global_bytes'), reusing result: "global_bytes"
-augmented_assignment/contract.py:43:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
 augmented_assignment/contract.py:43:26 debug: encountered already materialized expression (this::get_sender_with_side_effect()), reusing result: tmp%13#0
-augmented_assignment/contract.py:45:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
 augmented_assignment/contract.py:45:26 debug: encountered already materialized expression (this::get_sender_with_side_effect()), reusing result: tmp%16#0
 debug: Terminated block@5
 debug: Sealing block@6
@@ -453,7 +445,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.augmented_assignment.contract.Augmented.get_sender_with_side_effect
 debug: Sealing block@0
-augmented_assignment/contract.py:55:9 debug: encountered already materialized expression ('counter'), reusing result: "counter"
 debug: Terminated block@0
 debug: Building IR for function algopy._contract.Contract.__init__
 debug: Sealing block@0
@@ -476,15 +467,7 @@ debug: Added me#0 to Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- b
 debug: Replacing trivial Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3) (me#1) with me#0
 debug: Deleting Phi assignment: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3)
 debug: Replaced trivial Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3) (me#1) with me#0 in current definition for 1 blocks
-augmented_assignment/contract.py:34:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
-augmented_assignment/contract.py:34:26 debug: encountered already materialized expression (me), reusing result: me#0
-augmented_assignment/contract.py:35:13 debug: encountered already materialized expression ('my_bytes'), reusing result: "my_bytes"
-augmented_assignment/contract.py:35:27 debug: encountered already materialized expression (me), reusing result: me#0
-augmented_assignment/contract.py:38:13 debug: encountered already materialized expression ('global_uint'), reusing result: "global_uint"
-augmented_assignment/contract.py:39:13 debug: encountered already materialized expression ('global_bytes'), reusing result: "global_bytes"
-augmented_assignment/contract.py:43:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
 augmented_assignment/contract.py:43:26 debug: encountered already materialized expression (this::get_sender_with_side_effect()), reusing result: tmp%13#0
-augmented_assignment/contract.py:45:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
 augmented_assignment/contract.py:45:26 debug: encountered already materialized expression (this::get_sender_with_side_effect()), reusing result: tmp%16#0
 debug: Terminated block@5
 debug: Sealing block@6

--- a/test_cases/augmented_assignment/puya_O2.log
+++ b/test_cases/augmented_assignment/puya_O2.log
@@ -434,15 +434,7 @@ debug: Added me#0 to Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- b
 debug: Replacing trivial Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3) (me#1) with me#0
 debug: Deleting Phi assignment: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3)
 debug: Replaced trivial Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3) (me#1) with me#0 in current definition for 1 blocks
-augmented_assignment/contract.py:34:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
-augmented_assignment/contract.py:34:26 debug: encountered already materialized expression (me), reusing result: me#0
-augmented_assignment/contract.py:35:13 debug: encountered already materialized expression ('my_bytes'), reusing result: "my_bytes"
-augmented_assignment/contract.py:35:27 debug: encountered already materialized expression (me), reusing result: me#0
-augmented_assignment/contract.py:38:13 debug: encountered already materialized expression ('global_uint'), reusing result: "global_uint"
-augmented_assignment/contract.py:39:13 debug: encountered already materialized expression ('global_bytes'), reusing result: "global_bytes"
-augmented_assignment/contract.py:43:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
 augmented_assignment/contract.py:43:26 debug: encountered already materialized expression (this::get_sender_with_side_effect()), reusing result: tmp%13#0
-augmented_assignment/contract.py:45:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
 augmented_assignment/contract.py:45:26 debug: encountered already materialized expression (this::get_sender_with_side_effect()), reusing result: tmp%16#0
 debug: Terminated block@5
 debug: Sealing block@6
@@ -452,7 +444,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.augmented_assignment.contract.Augmented.get_sender_with_side_effect
 debug: Sealing block@0
-augmented_assignment/contract.py:55:9 debug: encountered already materialized expression ('counter'), reusing result: "counter"
 debug: Terminated block@0
 debug: Building IR for function algopy._contract.Contract.__init__
 debug: Sealing block@0
@@ -475,15 +466,7 @@ debug: Added me#0 to Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- b
 debug: Replacing trivial Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3) (me#1) with me#0
 debug: Deleting Phi assignment: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3)
 debug: Replaced trivial Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3) (me#1) with me#0 in current definition for 1 blocks
-augmented_assignment/contract.py:34:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
-augmented_assignment/contract.py:34:26 debug: encountered already materialized expression (me), reusing result: me#0
-augmented_assignment/contract.py:35:13 debug: encountered already materialized expression ('my_bytes'), reusing result: "my_bytes"
-augmented_assignment/contract.py:35:27 debug: encountered already materialized expression (me), reusing result: me#0
-augmented_assignment/contract.py:38:13 debug: encountered already materialized expression ('global_uint'), reusing result: "global_uint"
-augmented_assignment/contract.py:39:13 debug: encountered already materialized expression ('global_bytes'), reusing result: "global_bytes"
-augmented_assignment/contract.py:43:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
 augmented_assignment/contract.py:43:26 debug: encountered already materialized expression (this::get_sender_with_side_effect()), reusing result: tmp%13#0
-augmented_assignment/contract.py:45:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
 augmented_assignment/contract.py:45:26 debug: encountered already materialized expression (this::get_sender_with_side_effect()), reusing result: tmp%16#0
 debug: Terminated block@5
 debug: Sealing block@6

--- a/test_cases/augmented_assignment/puya_unoptimized.log
+++ b/test_cases/augmented_assignment/puya_unoptimized.log
@@ -434,15 +434,7 @@ debug: Added me#0 to Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- b
 debug: Replacing trivial Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3) (me#1) with me#0
 debug: Deleting Phi assignment: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3)
 debug: Replaced trivial Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3) (me#1) with me#0 in current definition for 1 blocks
-augmented_assignment/contract.py:34:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
-augmented_assignment/contract.py:34:26 debug: encountered already materialized expression (me), reusing result: me#0
-augmented_assignment/contract.py:35:13 debug: encountered already materialized expression ('my_bytes'), reusing result: "my_bytes"
-augmented_assignment/contract.py:35:27 debug: encountered already materialized expression (me), reusing result: me#0
-augmented_assignment/contract.py:38:13 debug: encountered already materialized expression ('global_uint'), reusing result: "global_uint"
-augmented_assignment/contract.py:39:13 debug: encountered already materialized expression ('global_bytes'), reusing result: "global_bytes"
-augmented_assignment/contract.py:43:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
 augmented_assignment/contract.py:43:26 debug: encountered already materialized expression (this::get_sender_with_side_effect()), reusing result: tmp%13#0
-augmented_assignment/contract.py:45:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
 augmented_assignment/contract.py:45:26 debug: encountered already materialized expression (this::get_sender_with_side_effect()), reusing result: tmp%16#0
 debug: Terminated block@5
 debug: Sealing block@6
@@ -452,7 +444,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.augmented_assignment.contract.Augmented.get_sender_with_side_effect
 debug: Sealing block@0
-augmented_assignment/contract.py:55:9 debug: encountered already materialized expression ('counter'), reusing result: "counter"
 debug: Terminated block@0
 debug: Building IR for function algopy._contract.Contract.__init__
 debug: Sealing block@0
@@ -475,15 +466,7 @@ debug: Added me#0 to Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- b
 debug: Replacing trivial Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3) (me#1) with me#0
 debug: Deleting Phi assignment: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3)
 debug: Replaced trivial Phi node: let me#1: account = φ(me#0 <- block@2, me#0 <- block@3) (me#1) with me#0 in current definition for 1 blocks
-augmented_assignment/contract.py:34:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
-augmented_assignment/contract.py:34:26 debug: encountered already materialized expression (me), reusing result: me#0
-augmented_assignment/contract.py:35:13 debug: encountered already materialized expression ('my_bytes'), reusing result: "my_bytes"
-augmented_assignment/contract.py:35:27 debug: encountered already materialized expression (me), reusing result: me#0
-augmented_assignment/contract.py:38:13 debug: encountered already materialized expression ('global_uint'), reusing result: "global_uint"
-augmented_assignment/contract.py:39:13 debug: encountered already materialized expression ('global_bytes'), reusing result: "global_bytes"
-augmented_assignment/contract.py:43:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
 augmented_assignment/contract.py:43:26 debug: encountered already materialized expression (this::get_sender_with_side_effect()), reusing result: tmp%13#0
-augmented_assignment/contract.py:45:13 debug: encountered already materialized expression ('my_uint'), reusing result: "my_uint"
 augmented_assignment/contract.py:45:26 debug: encountered already materialized expression (this::get_sender_with_side_effect()), reusing result: tmp%16#0
 debug: Terminated block@5
 debug: Sealing block@6

--- a/test_cases/avm_types_in_abi/puya.log
+++ b/test_cases/avm_types_in_abi/puya.log
@@ -439,14 +439,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.avm_types_in_abi.contract.TestContract.create
 debug: Sealing block@0
-avm_types_in_abi/contract.py:16:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0, result.4#0)
-avm_types_in_abi/contract.py:16:26 debug: encountered already materialized expression (tuple_param), reusing result: (tuple_param.0#0, tuple_param.1#0, tuple_param.2#0, tuple_param.3#0, tuple_param.4#0)
-avm_types_in_abi/contract.py:16:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0, result.4#0)
-avm_types_in_abi/contract.py:16:26 debug: encountered already materialized expression (tuple_param), reusing result: (tuple_param.0#0, tuple_param.1#0, tuple_param.2#0, tuple_param.3#0, tuple_param.4#0)
-avm_types_in_abi/contract.py:16:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0, result.4#0)
-avm_types_in_abi/contract.py:16:26 debug: encountered already materialized expression (tuple_param), reusing result: (tuple_param.0#0, tuple_param.1#0, tuple_param.2#0, tuple_param.3#0, tuple_param.4#0)
-avm_types_in_abi/contract.py:16:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0, result.4#0)
-avm_types_in_abi/contract.py:16:26 debug: encountered already materialized expression (tuple_param), reusing result: (tuple_param.0#0, tuple_param.1#0, tuple_param.2#0, tuple_param.3#0, tuple_param.4#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.avm_types_in_abi.contract.TestContract.tuple_of_arc4
 debug: Sealing block@0

--- a/test_cases/avm_types_in_abi/puya_O2.log
+++ b/test_cases/avm_types_in_abi/puya_O2.log
@@ -438,14 +438,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.avm_types_in_abi.contract.TestContract.create
 debug: Sealing block@0
-avm_types_in_abi/contract.py:16:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0, result.4#0)
-avm_types_in_abi/contract.py:16:26 debug: encountered already materialized expression (tuple_param), reusing result: (tuple_param.0#0, tuple_param.1#0, tuple_param.2#0, tuple_param.3#0, tuple_param.4#0)
-avm_types_in_abi/contract.py:16:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0, result.4#0)
-avm_types_in_abi/contract.py:16:26 debug: encountered already materialized expression (tuple_param), reusing result: (tuple_param.0#0, tuple_param.1#0, tuple_param.2#0, tuple_param.3#0, tuple_param.4#0)
-avm_types_in_abi/contract.py:16:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0, result.4#0)
-avm_types_in_abi/contract.py:16:26 debug: encountered already materialized expression (tuple_param), reusing result: (tuple_param.0#0, tuple_param.1#0, tuple_param.2#0, tuple_param.3#0, tuple_param.4#0)
-avm_types_in_abi/contract.py:16:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0, result.4#0)
-avm_types_in_abi/contract.py:16:26 debug: encountered already materialized expression (tuple_param), reusing result: (tuple_param.0#0, tuple_param.1#0, tuple_param.2#0, tuple_param.3#0, tuple_param.4#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.avm_types_in_abi.contract.TestContract.tuple_of_arc4
 debug: Sealing block@0

--- a/test_cases/avm_types_in_abi/puya_unoptimized.log
+++ b/test_cases/avm_types_in_abi/puya_unoptimized.log
@@ -438,14 +438,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.avm_types_in_abi.contract.TestContract.create
 debug: Sealing block@0
-avm_types_in_abi/contract.py:16:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0, result.4#0)
-avm_types_in_abi/contract.py:16:26 debug: encountered already materialized expression (tuple_param), reusing result: (tuple_param.0#0, tuple_param.1#0, tuple_param.2#0, tuple_param.3#0, tuple_param.4#0)
-avm_types_in_abi/contract.py:16:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0, result.4#0)
-avm_types_in_abi/contract.py:16:26 debug: encountered already materialized expression (tuple_param), reusing result: (tuple_param.0#0, tuple_param.1#0, tuple_param.2#0, tuple_param.3#0, tuple_param.4#0)
-avm_types_in_abi/contract.py:16:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0, result.4#0)
-avm_types_in_abi/contract.py:16:26 debug: encountered already materialized expression (tuple_param), reusing result: (tuple_param.0#0, tuple_param.1#0, tuple_param.2#0, tuple_param.3#0, tuple_param.4#0)
-avm_types_in_abi/contract.py:16:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0, result.4#0)
-avm_types_in_abi/contract.py:16:26 debug: encountered already materialized expression (tuple_param), reusing result: (tuple_param.0#0, tuple_param.1#0, tuple_param.2#0, tuple_param.3#0, tuple_param.4#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.avm_types_in_abi.contract.TestContract.tuple_of_arc4
 debug: Sealing block@0

--- a/test_cases/boolean_binary_ops/puya.log
+++ b/test_cases/boolean_binary_ops/puya.log
@@ -558,13 +558,10 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.boolean_binary_ops.contract.type_coercion
 debug: Sealing block@0
-boolean_binary_ops/contract.py:64:9 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@0
 debug: Sealing block@1
-boolean_binary_ops/contract.py:66:9 debug: encountered already materialized expression (appl), reusing result: appl
 debug: Terminated block@1
 debug: Sealing block@2
-boolean_binary_ops/contract.py:66:44 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Created Phi assignment: let ternary_result%0#2: uint64 = undefined while trying to resolve 'ternary_result%0' in block@3
@@ -840,7 +837,6 @@ debug: Sealing block@41
 debug: Created Phi assignment: let ternary_result%2#2: bool = undefined while trying to resolve 'ternary_result%2' in block@41
 debug: Added ternary_result%2#0 to Phi node: let ternary_result%2#2: bool = φ(ternary_result%2#0 <- block@36) in block@36
 debug: Added ternary_result%2#1 to Phi node: let ternary_result%2#2: bool = φ(ternary_result%2#0 <- block@36, ternary_result%2#1 <- block@40) in block@40
-boolean_binary_ops/contract.py:87:30 debug: encountered already materialized expression (hex<"6E65766572207365656E">), reusing result: 0x6e65766572207365656e
 debug: Terminated block@41
 debug: Looking for 'item_index_internal%0' in an unsealed block creating an incomplete Phi: block@42
 debug: Created Phi assignment: let item_index_internal%0#1: uint64 = undefined while trying to resolve 'item_index_internal%0' in block@42
@@ -860,8 +856,6 @@ debug: Replacing trivial Phi node: let bytes_to_iterate#1: bytes = φ(bytes_to_i
 debug: Deleting Phi assignment: let bytes_to_iterate#1: bytes = φ(bytes_to_iterate#0 <- block@41, bytes_to_iterate#1 <- block@44)
 debug: Replaced trivial Phi node: let bytes_to_iterate#1: bytes = φ(bytes_to_iterate#0 <- block@41, bytes_to_iterate#1 <- block@44) (bytes_to_iterate#1) with bytes_to_iterate#0 in current definition for 3 blocks
 debug: Sealing block@45
-boolean_binary_ops/contract.py:89:13 debug: encountered already materialized expression (hex<"6C656674">), reusing result: 0x6c656674
-boolean_binary_ops/contract.py:90:13 debug: encountered already materialized expression (hex<"6C656674">), reusing result: 0x6c656674
 debug: Terminated block@45
 debug: Sealing block@46
 debug: Terminated block@46
@@ -871,8 +865,6 @@ debug: Sealing block@48
 debug: Created Phi assignment: let ternary_result%5#2: string = undefined while trying to resolve 'ternary_result%5' in block@48
 debug: Added ternary_result%5#0 to Phi node: let ternary_result%5#2: string = φ(ternary_result%5#0 <- block@46) in block@46
 debug: Added ternary_result%5#1 to Phi node: let ternary_result%5#2: string = φ(ternary_result%5#0 <- block@46, ternary_result%5#1 <- block@47) in block@47
-boolean_binary_ops/contract.py:93:13 debug: encountered already materialized expression (1u), reusing result: 1u
-boolean_binary_ops/contract.py:94:14 debug: encountered already materialized expression (1u), reusing result: 1u
 debug: Terminated block@48
 debug: Building IR for function test_cases.boolean_binary_ops.contract.test_literal_boolean_binary_ops
 debug: Sealing block@0
@@ -971,8 +963,6 @@ debug: Terminated block@22
 debug: Sealing block@23
 debug: Terminated block@23
 debug: Sealing block@24
-boolean_binary_ops/contract.py:122:22 debug: encountered already materialized expression (one), reusing result: one#0
-boolean_binary_ops/contract.py:124:22 debug: encountered already materialized expression (empty_bytes), reusing result: empty_bytes#0
 debug: Terminated block@24
 debug: Building IR for function test_cases.boolean_binary_ops.contract.test_bool_numeric_comparison
 debug: Sealing block@0
@@ -1048,7 +1038,6 @@ debug: Added ternary_result%0#0 to Phi node: let ternary_result%0#2: uint64 = φ
 debug: Added ternary_result%0#1 to Phi node: let ternary_result%0#2: uint64 = φ(ternary_result%0#0 <- block@9, ternary_result%0#1 <- block@10) in block@10
 debug: Terminated block@11
 debug: Sealing block@12
-boolean_binary_ops/contract.py:150:9 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@12
 debug: Sealing block@13
 debug: Created Phi assignment: let true#3: bool = undefined while trying to resolve 'true' in block@11

--- a/test_cases/boolean_binary_ops/puya_O2.log
+++ b/test_cases/boolean_binary_ops/puya_O2.log
@@ -557,13 +557,10 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.boolean_binary_ops.contract.type_coercion
 debug: Sealing block@0
-boolean_binary_ops/contract.py:64:9 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@0
 debug: Sealing block@1
-boolean_binary_ops/contract.py:66:9 debug: encountered already materialized expression (appl), reusing result: appl
 debug: Terminated block@1
 debug: Sealing block@2
-boolean_binary_ops/contract.py:66:44 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Created Phi assignment: let ternary_result%0#2: uint64 = undefined while trying to resolve 'ternary_result%0' in block@3
@@ -839,7 +836,6 @@ debug: Sealing block@41
 debug: Created Phi assignment: let ternary_result%2#2: bool = undefined while trying to resolve 'ternary_result%2' in block@41
 debug: Added ternary_result%2#0 to Phi node: let ternary_result%2#2: bool = φ(ternary_result%2#0 <- block@36) in block@36
 debug: Added ternary_result%2#1 to Phi node: let ternary_result%2#2: bool = φ(ternary_result%2#0 <- block@36, ternary_result%2#1 <- block@40) in block@40
-boolean_binary_ops/contract.py:87:30 debug: encountered already materialized expression (hex<"6E65766572207365656E">), reusing result: 0x6e65766572207365656e
 debug: Terminated block@41
 debug: Looking for 'item_index_internal%0' in an unsealed block creating an incomplete Phi: block@42
 debug: Created Phi assignment: let item_index_internal%0#1: uint64 = undefined while trying to resolve 'item_index_internal%0' in block@42
@@ -859,8 +855,6 @@ debug: Replacing trivial Phi node: let bytes_to_iterate#1: bytes = φ(bytes_to_i
 debug: Deleting Phi assignment: let bytes_to_iterate#1: bytes = φ(bytes_to_iterate#0 <- block@41, bytes_to_iterate#1 <- block@44)
 debug: Replaced trivial Phi node: let bytes_to_iterate#1: bytes = φ(bytes_to_iterate#0 <- block@41, bytes_to_iterate#1 <- block@44) (bytes_to_iterate#1) with bytes_to_iterate#0 in current definition for 3 blocks
 debug: Sealing block@45
-boolean_binary_ops/contract.py:89:13 debug: encountered already materialized expression (hex<"6C656674">), reusing result: 0x6c656674
-boolean_binary_ops/contract.py:90:13 debug: encountered already materialized expression (hex<"6C656674">), reusing result: 0x6c656674
 debug: Terminated block@45
 debug: Sealing block@46
 debug: Terminated block@46
@@ -870,8 +864,6 @@ debug: Sealing block@48
 debug: Created Phi assignment: let ternary_result%5#2: string = undefined while trying to resolve 'ternary_result%5' in block@48
 debug: Added ternary_result%5#0 to Phi node: let ternary_result%5#2: string = φ(ternary_result%5#0 <- block@46) in block@46
 debug: Added ternary_result%5#1 to Phi node: let ternary_result%5#2: string = φ(ternary_result%5#0 <- block@46, ternary_result%5#1 <- block@47) in block@47
-boolean_binary_ops/contract.py:93:13 debug: encountered already materialized expression (1u), reusing result: 1u
-boolean_binary_ops/contract.py:94:14 debug: encountered already materialized expression (1u), reusing result: 1u
 debug: Terminated block@48
 debug: Building IR for function test_cases.boolean_binary_ops.contract.test_literal_boolean_binary_ops
 debug: Sealing block@0
@@ -970,8 +962,6 @@ debug: Terminated block@22
 debug: Sealing block@23
 debug: Terminated block@23
 debug: Sealing block@24
-boolean_binary_ops/contract.py:122:22 debug: encountered already materialized expression (one), reusing result: one#0
-boolean_binary_ops/contract.py:124:22 debug: encountered already materialized expression (empty_bytes), reusing result: empty_bytes#0
 debug: Terminated block@24
 debug: Building IR for function test_cases.boolean_binary_ops.contract.test_bool_numeric_comparison
 debug: Sealing block@0
@@ -1047,7 +1037,6 @@ debug: Added ternary_result%0#0 to Phi node: let ternary_result%0#2: uint64 = φ
 debug: Added ternary_result%0#1 to Phi node: let ternary_result%0#2: uint64 = φ(ternary_result%0#0 <- block@9, ternary_result%0#1 <- block@10) in block@10
 debug: Terminated block@11
 debug: Sealing block@12
-boolean_binary_ops/contract.py:150:9 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@12
 debug: Sealing block@13
 debug: Created Phi assignment: let true#3: bool = undefined while trying to resolve 'true' in block@11

--- a/test_cases/boolean_binary_ops/puya_unoptimized.log
+++ b/test_cases/boolean_binary_ops/puya_unoptimized.log
@@ -557,13 +557,10 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.boolean_binary_ops.contract.type_coercion
 debug: Sealing block@0
-boolean_binary_ops/contract.py:64:9 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@0
 debug: Sealing block@1
-boolean_binary_ops/contract.py:66:9 debug: encountered already materialized expression (appl), reusing result: appl
 debug: Terminated block@1
 debug: Sealing block@2
-boolean_binary_ops/contract.py:66:44 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Created Phi assignment: let ternary_result%0#2: uint64 = undefined while trying to resolve 'ternary_result%0' in block@3
@@ -839,7 +836,6 @@ debug: Sealing block@41
 debug: Created Phi assignment: let ternary_result%2#2: bool = undefined while trying to resolve 'ternary_result%2' in block@41
 debug: Added ternary_result%2#0 to Phi node: let ternary_result%2#2: bool = φ(ternary_result%2#0 <- block@36) in block@36
 debug: Added ternary_result%2#1 to Phi node: let ternary_result%2#2: bool = φ(ternary_result%2#0 <- block@36, ternary_result%2#1 <- block@40) in block@40
-boolean_binary_ops/contract.py:87:30 debug: encountered already materialized expression (hex<"6E65766572207365656E">), reusing result: 0x6e65766572207365656e
 debug: Terminated block@41
 debug: Looking for 'item_index_internal%0' in an unsealed block creating an incomplete Phi: block@42
 debug: Created Phi assignment: let item_index_internal%0#1: uint64 = undefined while trying to resolve 'item_index_internal%0' in block@42
@@ -859,8 +855,6 @@ debug: Replacing trivial Phi node: let bytes_to_iterate#1: bytes = φ(bytes_to_i
 debug: Deleting Phi assignment: let bytes_to_iterate#1: bytes = φ(bytes_to_iterate#0 <- block@41, bytes_to_iterate#1 <- block@44)
 debug: Replaced trivial Phi node: let bytes_to_iterate#1: bytes = φ(bytes_to_iterate#0 <- block@41, bytes_to_iterate#1 <- block@44) (bytes_to_iterate#1) with bytes_to_iterate#0 in current definition for 3 blocks
 debug: Sealing block@45
-boolean_binary_ops/contract.py:89:13 debug: encountered already materialized expression (hex<"6C656674">), reusing result: 0x6c656674
-boolean_binary_ops/contract.py:90:13 debug: encountered already materialized expression (hex<"6C656674">), reusing result: 0x6c656674
 debug: Terminated block@45
 debug: Sealing block@46
 debug: Terminated block@46
@@ -870,8 +864,6 @@ debug: Sealing block@48
 debug: Created Phi assignment: let ternary_result%5#2: string = undefined while trying to resolve 'ternary_result%5' in block@48
 debug: Added ternary_result%5#0 to Phi node: let ternary_result%5#2: string = φ(ternary_result%5#0 <- block@46) in block@46
 debug: Added ternary_result%5#1 to Phi node: let ternary_result%5#2: string = φ(ternary_result%5#0 <- block@46, ternary_result%5#1 <- block@47) in block@47
-boolean_binary_ops/contract.py:93:13 debug: encountered already materialized expression (1u), reusing result: 1u
-boolean_binary_ops/contract.py:94:14 debug: encountered already materialized expression (1u), reusing result: 1u
 debug: Terminated block@48
 debug: Building IR for function test_cases.boolean_binary_ops.contract.test_literal_boolean_binary_ops
 debug: Sealing block@0
@@ -970,8 +962,6 @@ debug: Terminated block@22
 debug: Sealing block@23
 debug: Terminated block@23
 debug: Sealing block@24
-boolean_binary_ops/contract.py:122:22 debug: encountered already materialized expression (one), reusing result: one#0
-boolean_binary_ops/contract.py:124:22 debug: encountered already materialized expression (empty_bytes), reusing result: empty_bytes#0
 debug: Terminated block@24
 debug: Building IR for function test_cases.boolean_binary_ops.contract.test_bool_numeric_comparison
 debug: Sealing block@0
@@ -1047,7 +1037,6 @@ debug: Added ternary_result%0#0 to Phi node: let ternary_result%0#2: uint64 = φ
 debug: Added ternary_result%0#1 to Phi node: let ternary_result%0#2: uint64 = φ(ternary_result%0#0 <- block@9, ternary_result%0#1 <- block@10) in block@10
 debug: Terminated block@11
 debug: Sealing block@12
-boolean_binary_ops/contract.py:150:9 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@12
 debug: Sealing block@13
 debug: Created Phi assignment: let true#3: bool = undefined while trying to resolve 'true' in block@11

--- a/test_cases/compile/puya.log
+++ b/test_cases/compile/puya.log
@@ -1421,12 +1421,6 @@ debug: Sealing block@3
 debug: Terminated block@3
 debug: Building IR for function test_cases.compile.factory.HelloFactory.test_arc4_create_tmpl
 debug: Sealing block@0
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
@@ -1436,12 +1430,6 @@ debug: Sealing block@3
 debug: Terminated block@3
 debug: Building IR for function test_cases.compile.factory.HelloFactory.test_arc4_create_prfx
 debug: Sealing block@0
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
@@ -1460,14 +1448,6 @@ debug: Sealing block@3
 debug: Terminated block@3
 debug: Building IR for function test_cases.compile.factory.HelloFactory.test_arc4_create_modified_compiled
 debug: Sealing block@0
-compile/factory.py:239:20 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:239:20 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1

--- a/test_cases/compile/puya_O2.log
+++ b/test_cases/compile/puya_O2.log
@@ -1420,12 +1420,6 @@ debug: Sealing block@3
 debug: Terminated block@3
 debug: Building IR for function test_cases.compile.factory.HelloFactory.test_arc4_create_tmpl
 debug: Sealing block@0
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
@@ -1435,12 +1429,6 @@ debug: Sealing block@3
 debug: Terminated block@3
 debug: Building IR for function test_cases.compile.factory.HelloFactory.test_arc4_create_prfx
 debug: Sealing block@0
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
@@ -1459,14 +1447,6 @@ debug: Sealing block@3
 debug: Terminated block@3
 debug: Building IR for function test_cases.compile.factory.HelloFactory.test_arc4_create_modified_compiled
 debug: Sealing block@0
-compile/factory.py:239:20 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:239:20 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1

--- a/test_cases/compile/puya_unoptimized.log
+++ b/test_cases/compile/puya_unoptimized.log
@@ -1420,12 +1420,6 @@ debug: Sealing block@3
 debug: Terminated block@3
 debug: Building IR for function test_cases.compile.factory.HelloFactory.test_arc4_create_tmpl
 debug: Sealing block@0
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:183:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
@@ -1435,12 +1429,6 @@ debug: Sealing block@3
 debug: Terminated block@3
 debug: Building IR for function test_cases.compile.factory.HelloFactory.test_arc4_create_prfx
 debug: Sealing block@0
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:206:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
@@ -1459,14 +1447,6 @@ debug: Sealing block@3
 debug: Terminated block@3
 debug: Building IR for function test_cases.compile.factory.HelloFactory.test_arc4_create_modified_compiled
 debug: Sealing block@0
-compile/factory.py:239:20 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:239:20 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#0, compiled.approval_program.1#0, compiled.clear_state_program.0#0, compiled.clear_state_program.1#0, compiled.extra_program_pages#0, compiled.global_uints#0, compiled.global_bytes#0, compiled.local_uints#0, compiled.local_bytes#0)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
-compile/factory.py:248:22 debug: encountered already materialized expression (compiled), reusing result: (compiled.approval_program.0#1, compiled.approval_program.1#1, compiled.clear_state_program.0#1, compiled.clear_state_program.1#1, compiled.extra_program_pages#1, compiled.global_uints#1, compiled.global_bytes#1, compiled.local_uints#1, compiled.local_bytes#1)
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1

--- a/test_cases/conditional_expressions/puya.log
+++ b/test_cases/conditional_expressions/puya.log
@@ -497,8 +497,6 @@ debug: removing unused subroutine test_cases.conditional_expressions.literals.Li
 debug: removing unused subroutine algopy._contract.Contract.__init__
 debug: Building IR for function test_cases.conditional_expressions.contract.MyContract.approval_program
 debug: Sealing block@0
-conditional_expressions/contract.py:11:13 debug: encountered already materialized expression (a), reusing result: a#0
-conditional_expressions/contract.py:12:13 debug: encountered already materialized expression (b), reusing result: b#0
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
@@ -739,8 +737,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.conditional_expressions.contract.MyContract.approval_program
 debug: Sealing block@0
-conditional_expressions/contract.py:11:13 debug: encountered already materialized expression (a), reusing result: a#0
-conditional_expressions/contract.py:12:13 debug: encountered already materialized expression (b), reusing result: b#0
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1

--- a/test_cases/conditional_expressions/puya_O2.log
+++ b/test_cases/conditional_expressions/puya_O2.log
@@ -496,8 +496,6 @@ debug: removing unused subroutine test_cases.conditional_expressions.literals.Li
 debug: removing unused subroutine algopy._contract.Contract.__init__
 debug: Building IR for function test_cases.conditional_expressions.contract.MyContract.approval_program
 debug: Sealing block@0
-conditional_expressions/contract.py:11:13 debug: encountered already materialized expression (a), reusing result: a#0
-conditional_expressions/contract.py:12:13 debug: encountered already materialized expression (b), reusing result: b#0
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
@@ -738,8 +736,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.conditional_expressions.contract.MyContract.approval_program
 debug: Sealing block@0
-conditional_expressions/contract.py:11:13 debug: encountered already materialized expression (a), reusing result: a#0
-conditional_expressions/contract.py:12:13 debug: encountered already materialized expression (b), reusing result: b#0
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1

--- a/test_cases/conditional_expressions/puya_unoptimized.log
+++ b/test_cases/conditional_expressions/puya_unoptimized.log
@@ -496,8 +496,6 @@ debug: removing unused subroutine test_cases.conditional_expressions.literals.Li
 debug: removing unused subroutine algopy._contract.Contract.__init__
 debug: Building IR for function test_cases.conditional_expressions.contract.MyContract.approval_program
 debug: Sealing block@0
-conditional_expressions/contract.py:11:13 debug: encountered already materialized expression (a), reusing result: a#0
-conditional_expressions/contract.py:12:13 debug: encountered already materialized expression (b), reusing result: b#0
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
@@ -738,8 +736,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.conditional_expressions.contract.MyContract.approval_program
 debug: Sealing block@0
-conditional_expressions/contract.py:11:13 debug: encountered already materialized expression (a), reusing result: a#0
-conditional_expressions/contract.py:12:13 debug: encountered already materialized expression (b), reusing result: b#0
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1

--- a/test_cases/contains/puya.log
+++ b/test_cases/contains/puya.log
@@ -457,8 +457,6 @@ debug: Building IR for function test_cases.contains.contract.MyContract.is_in_tu
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-contains/contract.py:44:16 debug: encountered already materialized expression (x), reusing result: x#0
-contains/contract.py:44:21 debug: encountered already materialized expression (y), reusing result: (y.0#0, y.1#0, y.2#0)
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -473,8 +471,6 @@ debug: Building IR for function test_cases.contains.contract.MyContract.is_in_tu
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-contains/contract.py:48:16 debug: encountered already materialized expression (x), reusing result: x#0
-contains/contract.py:48:21 debug: encountered already materialized expression (y), reusing result: (y.0#0, y.1#0, y.2#0)
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -489,8 +485,6 @@ debug: Building IR for function test_cases.contains.contract.MyContract.is_in_tu
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-contains/contract.py:52:16 debug: encountered already materialized expression (x), reusing result: x#0
-contains/contract.py:52:21 debug: encountered already materialized expression (y), reusing result: (y.0#0, y.1#0)
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -674,10 +668,8 @@ debug: Added or_result%3#0 to Phi node: let or_result%3#2: bool = φ(or_result%3
 debug: Added or_result%3#1 to Phi node: let or_result%3#2: bool = φ(or_result%3#0 <- block@16, or_result%3#1 <- block@17) in block@17
 debug: Terminated block@18
 debug: Sealing block@19
-contains/contract.py:93:16 debug: encountered already materialized expression (2u), reusing result: 2u
 debug: Terminated block@19
 debug: Sealing block@20
-contains/contract.py:93:16 debug: encountered already materialized expression (2u), reusing result: 2u
 debug: Terminated block@20
 debug: Sealing block@21
 debug: Terminated block@21
@@ -770,7 +762,6 @@ debug: Added or_result%11#0 to Phi node: let or_result%11#2: bool = φ(or_result
 debug: Added or_result%11#1 to Phi node: let or_result%11#2: bool = φ(or_result%11#0 <- block@51, or_result%11#1 <- block@52) in block@52
 debug: Terminated block@53
 debug: Sealing block@54
-contains/contract.py:102:16 debug: encountered already materialized expression (2u), reusing result: 2u
 debug: Terminated block@54
 debug: Sealing block@55
 debug: Terminated block@55
@@ -850,7 +841,6 @@ debug: Added or_result%18#0 to Phi node: let or_result%18#2: bool = φ(or_result
 debug: Added or_result%18#1 to Phi node: let or_result%18#2: bool = φ(or_result%18#0 <- block@80, or_result%18#1 <- block@81) in block@81
 debug: Terminated block@82
 debug: Sealing block@83
-contains/contract.py:115:16 debug: encountered already materialized expression (2u), reusing result: 2u
 debug: Terminated block@83
 debug: Sealing block@84
 debug: Terminated block@84
@@ -906,7 +896,6 @@ debug: Added or_result%23#0 to Phi node: let or_result%23#2: bool = φ(or_result
 debug: Added or_result%23#1 to Phi node: let or_result%23#2: bool = φ(or_result%23#0 <- block@100, or_result%23#1 <- block@101) in block@101
 debug: Terminated block@102
 debug: Sealing block@103
-contains/contract.py:130:16 debug: encountered already materialized expression (65_arc4u8), reusing result: 0x41
 debug: Terminated block@103
 debug: Sealing block@104
 debug: Terminated block@104

--- a/test_cases/contains/puya_O2.log
+++ b/test_cases/contains/puya_O2.log
@@ -456,8 +456,6 @@ debug: Building IR for function test_cases.contains.contract.MyContract.is_in_tu
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-contains/contract.py:44:16 debug: encountered already materialized expression (x), reusing result: x#0
-contains/contract.py:44:21 debug: encountered already materialized expression (y), reusing result: (y.0#0, y.1#0, y.2#0)
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -472,8 +470,6 @@ debug: Building IR for function test_cases.contains.contract.MyContract.is_in_tu
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-contains/contract.py:48:16 debug: encountered already materialized expression (x), reusing result: x#0
-contains/contract.py:48:21 debug: encountered already materialized expression (y), reusing result: (y.0#0, y.1#0, y.2#0)
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -488,8 +484,6 @@ debug: Building IR for function test_cases.contains.contract.MyContract.is_in_tu
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-contains/contract.py:52:16 debug: encountered already materialized expression (x), reusing result: x#0
-contains/contract.py:52:21 debug: encountered already materialized expression (y), reusing result: (y.0#0, y.1#0)
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -673,10 +667,8 @@ debug: Added or_result%3#0 to Phi node: let or_result%3#2: bool = φ(or_result%3
 debug: Added or_result%3#1 to Phi node: let or_result%3#2: bool = φ(or_result%3#0 <- block@16, or_result%3#1 <- block@17) in block@17
 debug: Terminated block@18
 debug: Sealing block@19
-contains/contract.py:93:16 debug: encountered already materialized expression (2u), reusing result: 2u
 debug: Terminated block@19
 debug: Sealing block@20
-contains/contract.py:93:16 debug: encountered already materialized expression (2u), reusing result: 2u
 debug: Terminated block@20
 debug: Sealing block@21
 debug: Terminated block@21
@@ -769,7 +761,6 @@ debug: Added or_result%11#0 to Phi node: let or_result%11#2: bool = φ(or_result
 debug: Added or_result%11#1 to Phi node: let or_result%11#2: bool = φ(or_result%11#0 <- block@51, or_result%11#1 <- block@52) in block@52
 debug: Terminated block@53
 debug: Sealing block@54
-contains/contract.py:102:16 debug: encountered already materialized expression (2u), reusing result: 2u
 debug: Terminated block@54
 debug: Sealing block@55
 debug: Terminated block@55
@@ -849,7 +840,6 @@ debug: Added or_result%18#0 to Phi node: let or_result%18#2: bool = φ(or_result
 debug: Added or_result%18#1 to Phi node: let or_result%18#2: bool = φ(or_result%18#0 <- block@80, or_result%18#1 <- block@81) in block@81
 debug: Terminated block@82
 debug: Sealing block@83
-contains/contract.py:115:16 debug: encountered already materialized expression (2u), reusing result: 2u
 debug: Terminated block@83
 debug: Sealing block@84
 debug: Terminated block@84
@@ -905,7 +895,6 @@ debug: Added or_result%23#0 to Phi node: let or_result%23#2: bool = φ(or_result
 debug: Added or_result%23#1 to Phi node: let or_result%23#2: bool = φ(or_result%23#0 <- block@100, or_result%23#1 <- block@101) in block@101
 debug: Terminated block@102
 debug: Sealing block@103
-contains/contract.py:130:16 debug: encountered already materialized expression (65_arc4u8), reusing result: 0x41
 debug: Terminated block@103
 debug: Sealing block@104
 debug: Terminated block@104

--- a/test_cases/contains/puya_unoptimized.log
+++ b/test_cases/contains/puya_unoptimized.log
@@ -456,8 +456,6 @@ debug: Building IR for function test_cases.contains.contract.MyContract.is_in_tu
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-contains/contract.py:44:16 debug: encountered already materialized expression (x), reusing result: x#0
-contains/contract.py:44:21 debug: encountered already materialized expression (y), reusing result: (y.0#0, y.1#0, y.2#0)
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -472,8 +470,6 @@ debug: Building IR for function test_cases.contains.contract.MyContract.is_in_tu
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-contains/contract.py:48:16 debug: encountered already materialized expression (x), reusing result: x#0
-contains/contract.py:48:21 debug: encountered already materialized expression (y), reusing result: (y.0#0, y.1#0, y.2#0)
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -488,8 +484,6 @@ debug: Building IR for function test_cases.contains.contract.MyContract.is_in_tu
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-contains/contract.py:52:16 debug: encountered already materialized expression (x), reusing result: x#0
-contains/contract.py:52:21 debug: encountered already materialized expression (y), reusing result: (y.0#0, y.1#0)
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -673,10 +667,8 @@ debug: Added or_result%3#0 to Phi node: let or_result%3#2: bool = φ(or_result%3
 debug: Added or_result%3#1 to Phi node: let or_result%3#2: bool = φ(or_result%3#0 <- block@16, or_result%3#1 <- block@17) in block@17
 debug: Terminated block@18
 debug: Sealing block@19
-contains/contract.py:93:16 debug: encountered already materialized expression (2u), reusing result: 2u
 debug: Terminated block@19
 debug: Sealing block@20
-contains/contract.py:93:16 debug: encountered already materialized expression (2u), reusing result: 2u
 debug: Terminated block@20
 debug: Sealing block@21
 debug: Terminated block@21
@@ -769,7 +761,6 @@ debug: Added or_result%11#0 to Phi node: let or_result%11#2: bool = φ(or_result
 debug: Added or_result%11#1 to Phi node: let or_result%11#2: bool = φ(or_result%11#0 <- block@51, or_result%11#1 <- block@52) in block@52
 debug: Terminated block@53
 debug: Sealing block@54
-contains/contract.py:102:16 debug: encountered already materialized expression (2u), reusing result: 2u
 debug: Terminated block@54
 debug: Sealing block@55
 debug: Terminated block@55
@@ -849,7 +840,6 @@ debug: Added or_result%18#0 to Phi node: let or_result%18#2: bool = φ(or_result
 debug: Added or_result%18#1 to Phi node: let or_result%18#2: bool = φ(or_result%18#0 <- block@80, or_result%18#1 <- block@81) in block@81
 debug: Terminated block@82
 debug: Sealing block@83
-contains/contract.py:115:16 debug: encountered already materialized expression (2u), reusing result: 2u
 debug: Terminated block@83
 debug: Sealing block@84
 debug: Terminated block@84
@@ -905,7 +895,6 @@ debug: Added or_result%23#0 to Phi node: let or_result%23#2: bool = φ(or_result
 debug: Added or_result%23#1 to Phi node: let or_result%23#2: bool = φ(or_result%23#0 <- block@100, or_result%23#1 <- block@101) in block@101
 debug: Terminated block@102
 debug: Sealing block@103
-contains/contract.py:130:16 debug: encountered already materialized expression (65_arc4u8), reusing result: 0x41
 debug: Terminated block@103
 debug: Sealing block@104
 debug: Terminated block@104

--- a/test_cases/debug/puya.log
+++ b/test_cases/debug/puya.log
@@ -656,7 +656,6 @@ debug: Added bee#0 to Phi node: let bee#1: bytes = φ(bee#0 <- block@18, bee#0 <
 debug: Replacing trivial Phi node: let bee#1: bytes = φ(bee#0 <- block@18, bee#0 <- block@19) (bee#1) with bee#0
 debug: Deleting Phi assignment: let bee#1: bytes = φ(bee#0 <- block@18, bee#0 <- block@19)
 debug: Replaced trivial Phi node: let bee#1: bytes = φ(bee#0 <- block@18, bee#0 <- block@19) (bee#1) with bee#0 in current definition for 1 blocks
-debug/contract.py:36:32 debug: encountered already materialized expression (' '), reusing result: " "
 debug: Created Phi assignment: let cea#1: bytes = undefined while trying to resolve 'cea' in block@20
 debug: Created Phi assignment: let cea#2: bytes = undefined while trying to resolve 'cea' in block@18
 debug: Created Phi assignment: let cea#3: bytes = undefined while trying to resolve 'cea' in block@16

--- a/test_cases/debug/puya_O2.log
+++ b/test_cases/debug/puya_O2.log
@@ -655,7 +655,6 @@ debug: Added bee#0 to Phi node: let bee#1: bytes = φ(bee#0 <- block@18, bee#0 <
 debug: Replacing trivial Phi node: let bee#1: bytes = φ(bee#0 <- block@18, bee#0 <- block@19) (bee#1) with bee#0
 debug: Deleting Phi assignment: let bee#1: bytes = φ(bee#0 <- block@18, bee#0 <- block@19)
 debug: Replaced trivial Phi node: let bee#1: bytes = φ(bee#0 <- block@18, bee#0 <- block@19) (bee#1) with bee#0 in current definition for 1 blocks
-debug/contract.py:36:32 debug: encountered already materialized expression (' '), reusing result: " "
 debug: Created Phi assignment: let cea#1: bytes = undefined while trying to resolve 'cea' in block@20
 debug: Created Phi assignment: let cea#2: bytes = undefined while trying to resolve 'cea' in block@18
 debug: Created Phi assignment: let cea#3: bytes = undefined while trying to resolve 'cea' in block@16

--- a/test_cases/debug/puya_unoptimized.log
+++ b/test_cases/debug/puya_unoptimized.log
@@ -655,7 +655,6 @@ debug: Added bee#0 to Phi node: let bee#1: bytes = φ(bee#0 <- block@18, bee#0 <
 debug: Replacing trivial Phi node: let bee#1: bytes = φ(bee#0 <- block@18, bee#0 <- block@19) (bee#1) with bee#0
 debug: Deleting Phi assignment: let bee#1: bytes = φ(bee#0 <- block@18, bee#0 <- block@19)
 debug: Replaced trivial Phi node: let bee#1: bytes = φ(bee#0 <- block@18, bee#0 <- block@19) (bee#1) with bee#0 in current definition for 1 blocks
-debug/contract.py:36:32 debug: encountered already materialized expression (' '), reusing result: " "
 debug: Created Phi assignment: let cea#1: bytes = undefined while trying to resolve 'cea' in block@20
 debug: Created Phi assignment: let cea#2: bytes = undefined while trying to resolve 'cea' in block@18
 debug: Created Phi assignment: let cea#3: bytes = undefined while trying to resolve 'cea' in block@16

--- a/test_cases/everything/puya.log
+++ b/test_cases/everything/puya.log
@@ -478,7 +478,6 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-everything/contract.py:53:17 debug: encountered already materialized expression ('counter'), reusing result: "counter"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -517,7 +516,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.everything.contract.Everything._remove_sender
 debug: Sealing block@0
-everything/contract.py:83:9 debug: encountered already materialized expression ('counter'), reusing result: "counter"
 debug: Terminated block@0
 debug: Building IR for function algopy.arc4.ARC4Contract.approval_program
 debug: Sealing block@0

--- a/test_cases/everything/puya_O2.log
+++ b/test_cases/everything/puya_O2.log
@@ -477,7 +477,6 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-everything/contract.py:53:17 debug: encountered already materialized expression ('counter'), reusing result: "counter"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -516,7 +515,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.everything.contract.Everything._remove_sender
 debug: Sealing block@0
-everything/contract.py:83:9 debug: encountered already materialized expression ('counter'), reusing result: "counter"
 debug: Terminated block@0
 debug: Building IR for function algopy.arc4.ARC4Contract.approval_program
 debug: Sealing block@0

--- a/test_cases/everything/puya_unoptimized.log
+++ b/test_cases/everything/puya_unoptimized.log
@@ -477,7 +477,6 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-everything/contract.py:53:17 debug: encountered already materialized expression ('counter'), reusing result: "counter"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -516,7 +515,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.everything.contract.Everything._remove_sender
 debug: Sealing block@0
-everything/contract.py:83:9 debug: encountered already materialized expression ('counter'), reusing result: "counter"
 debug: Terminated block@0
 debug: Building IR for function algopy.arc4.ARC4Contract.approval_program
 debug: Sealing block@0

--- a/test_cases/fixed_bytes_ops/puya.log
+++ b/test_cases/fixed_bytes_ops/puya.log
@@ -434,9 +434,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.test_augmented_assignment_with_bytes
 debug: Sealing block@0
-fixed_bytes_ops/contract.py:360:13 debug: encountered already materialized expression (other), reusing result: other#0
-fixed_bytes_ops/contract.py:365:13 debug: encountered already materialized expression (other), reusing result: other#0
-fixed_bytes_ops/contract.py:370:13 debug: encountered already materialized expression (other), reusing result: other#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.test_augmented_assignment_with_literal_bytes
 debug: Sealing block@0
@@ -529,8 +526,6 @@ debug: Terminated block@5
 debug: Sealing block@6
 debug: Looking for 'val' in an unsealed block creating an incomplete Phi: block@5
 debug: Created Phi assignment: let val#2: bytes[3] = undefined while trying to resolve 'val' in block@5
-fixed_bytes_ops/contract.py:543:20 debug: encountered already materialized expression (byte), reusing result: byte#0
-fixed_bytes_ops/contract.py:546:20 debug: encountered already materialized expression (byte), reusing result: byte#0
 debug: Terminated block@6
 debug: Sealing block@7
 debug: Terminated block@7
@@ -543,8 +538,6 @@ debug: Replacing trivial Phi node: let val#2: bytes[3] = φ(val#0 <- block@4, va
 debug: Deleting Phi assignment: let val#2: bytes[3] = φ(val#0 <- block@4, val#2 <- block@7)
 debug: Replaced trivial Phi node: let val#2: bytes[3] = φ(val#0 <- block@4, val#2 <- block@7) (val#2) with val#0 in current definition for 3 blocks
 debug: Sealing block@8
-fixed_bytes_ops/contract.py:548:43 debug: encountered already materialized expression (val), reusing result: val#0
-fixed_bytes_ops/contract.py:548:43 debug: encountered already materialized expression (val), reusing result: val#0
 debug: Terminated block@8
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.test_size_of
 debug: Sealing block@0
@@ -664,15 +657,12 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.FixedBytesOps.test_augmented_or_assignment_with_bytes
 debug: Sealing block@0
-fixed_bytes_ops/contract.py:134:17 debug: encountered already materialized expression (other), reusing result: other#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.FixedBytesOps.test_augmented_and_assignment_with_bytes
 debug: Sealing block@0
-fixed_bytes_ops/contract.py:142:17 debug: encountered already materialized expression (other), reusing result: other#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.FixedBytesOps.test_augmented_xor_assignment_with_bytes
 debug: Sealing block@0
-fixed_bytes_ops/contract.py:150:17 debug: encountered already materialized expression (other), reusing result: other#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.FixedBytesOps.validate_fixed_bytes_3
 debug: Sealing block@0

--- a/test_cases/fixed_bytes_ops/puya_O2.log
+++ b/test_cases/fixed_bytes_ops/puya_O2.log
@@ -433,9 +433,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.test_augmented_assignment_with_bytes
 debug: Sealing block@0
-fixed_bytes_ops/contract.py:360:13 debug: encountered already materialized expression (other), reusing result: other#0
-fixed_bytes_ops/contract.py:365:13 debug: encountered already materialized expression (other), reusing result: other#0
-fixed_bytes_ops/contract.py:370:13 debug: encountered already materialized expression (other), reusing result: other#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.test_augmented_assignment_with_literal_bytes
 debug: Sealing block@0
@@ -528,8 +525,6 @@ debug: Terminated block@5
 debug: Sealing block@6
 debug: Looking for 'val' in an unsealed block creating an incomplete Phi: block@5
 debug: Created Phi assignment: let val#2: bytes[3] = undefined while trying to resolve 'val' in block@5
-fixed_bytes_ops/contract.py:543:20 debug: encountered already materialized expression (byte), reusing result: byte#0
-fixed_bytes_ops/contract.py:546:20 debug: encountered already materialized expression (byte), reusing result: byte#0
 debug: Terminated block@6
 debug: Sealing block@7
 debug: Terminated block@7
@@ -542,8 +537,6 @@ debug: Replacing trivial Phi node: let val#2: bytes[3] = φ(val#0 <- block@4, va
 debug: Deleting Phi assignment: let val#2: bytes[3] = φ(val#0 <- block@4, val#2 <- block@7)
 debug: Replaced trivial Phi node: let val#2: bytes[3] = φ(val#0 <- block@4, val#2 <- block@7) (val#2) with val#0 in current definition for 3 blocks
 debug: Sealing block@8
-fixed_bytes_ops/contract.py:548:43 debug: encountered already materialized expression (val), reusing result: val#0
-fixed_bytes_ops/contract.py:548:43 debug: encountered already materialized expression (val), reusing result: val#0
 debug: Terminated block@8
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.test_size_of
 debug: Sealing block@0
@@ -663,15 +656,12 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.FixedBytesOps.test_augmented_or_assignment_with_bytes
 debug: Sealing block@0
-fixed_bytes_ops/contract.py:134:17 debug: encountered already materialized expression (other), reusing result: other#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.FixedBytesOps.test_augmented_and_assignment_with_bytes
 debug: Sealing block@0
-fixed_bytes_ops/contract.py:142:17 debug: encountered already materialized expression (other), reusing result: other#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.FixedBytesOps.test_augmented_xor_assignment_with_bytes
 debug: Sealing block@0
-fixed_bytes_ops/contract.py:150:17 debug: encountered already materialized expression (other), reusing result: other#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.FixedBytesOps.validate_fixed_bytes_3
 debug: Sealing block@0

--- a/test_cases/fixed_bytes_ops/puya_unoptimized.log
+++ b/test_cases/fixed_bytes_ops/puya_unoptimized.log
@@ -433,9 +433,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.test_augmented_assignment_with_bytes
 debug: Sealing block@0
-fixed_bytes_ops/contract.py:360:13 debug: encountered already materialized expression (other), reusing result: other#0
-fixed_bytes_ops/contract.py:365:13 debug: encountered already materialized expression (other), reusing result: other#0
-fixed_bytes_ops/contract.py:370:13 debug: encountered already materialized expression (other), reusing result: other#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.test_augmented_assignment_with_literal_bytes
 debug: Sealing block@0
@@ -528,8 +525,6 @@ debug: Terminated block@5
 debug: Sealing block@6
 debug: Looking for 'val' in an unsealed block creating an incomplete Phi: block@5
 debug: Created Phi assignment: let val#2: bytes[3] = undefined while trying to resolve 'val' in block@5
-fixed_bytes_ops/contract.py:543:20 debug: encountered already materialized expression (byte), reusing result: byte#0
-fixed_bytes_ops/contract.py:546:20 debug: encountered already materialized expression (byte), reusing result: byte#0
 debug: Terminated block@6
 debug: Sealing block@7
 debug: Terminated block@7
@@ -542,8 +537,6 @@ debug: Replacing trivial Phi node: let val#2: bytes[3] = φ(val#0 <- block@4, va
 debug: Deleting Phi assignment: let val#2: bytes[3] = φ(val#0 <- block@4, val#2 <- block@7)
 debug: Replaced trivial Phi node: let val#2: bytes[3] = φ(val#0 <- block@4, val#2 <- block@7) (val#2) with val#0 in current definition for 3 blocks
 debug: Sealing block@8
-fixed_bytes_ops/contract.py:548:43 debug: encountered already materialized expression (val), reusing result: val#0
-fixed_bytes_ops/contract.py:548:43 debug: encountered already materialized expression (val), reusing result: val#0
 debug: Terminated block@8
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.test_size_of
 debug: Sealing block@0
@@ -663,15 +656,12 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.FixedBytesOps.test_augmented_or_assignment_with_bytes
 debug: Sealing block@0
-fixed_bytes_ops/contract.py:134:17 debug: encountered already materialized expression (other), reusing result: other#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.FixedBytesOps.test_augmented_and_assignment_with_bytes
 debug: Sealing block@0
-fixed_bytes_ops/contract.py:142:17 debug: encountered already materialized expression (other), reusing result: other#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.FixedBytesOps.test_augmented_xor_assignment_with_bytes
 debug: Sealing block@0
-fixed_bytes_ops/contract.py:150:17 debug: encountered already materialized expression (other), reusing result: other#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.fixed_bytes_ops.contract.FixedBytesOps.validate_fixed_bytes_3
 debug: Sealing block@0

--- a/test_cases/inner_transactions/puya.log
+++ b/test_cases/inner_transactions/puya.log
@@ -1948,7 +1948,6 @@ debug: Building IR for function test_cases.inner_transactions.contract.MyContrac
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-inner_transactions/contract.py:95:26 debug: encountered already materialized expression (args), reusing result: (args.0#0, args.1#0)
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2

--- a/test_cases/inner_transactions/puya_O2.log
+++ b/test_cases/inner_transactions/puya_O2.log
@@ -1947,7 +1947,6 @@ debug: Building IR for function test_cases.inner_transactions.contract.MyContrac
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-inner_transactions/contract.py:95:26 debug: encountered already materialized expression (args), reusing result: (args.0#0, args.1#0)
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2

--- a/test_cases/inner_transactions/puya_unoptimized.log
+++ b/test_cases/inner_transactions/puya_unoptimized.log
@@ -1947,7 +1947,6 @@ debug: Building IR for function test_cases.inner_transactions.contract.MyContrac
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-inner_transactions/contract.py:95:26 debug: encountered already materialized expression (args), reusing result: (args.0#0, args.1#0)
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2

--- a/test_cases/large_box_operations/puya.log
+++ b/test_cases/large_box_operations/puya.log
@@ -425,8 +425,6 @@ debug: Looking for 'new' in an unsealed block creating an incomplete Phi: block@
 debug: Created Phi assignment: let new#1: Encoded(len+uint64[]) = undefined while trying to resolve 'new' in block@1
 debug: Looking for 'inc' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let inc#1: uint64 = undefined while trying to resolve 'inc' in block@1
-large_box_operations/struct_multiple_array_uint64.py:97:9 debug: encountered already materialized expression (new), reusing result: new#1
-large_box_operations/struct_multiple_array_uint64.py:97:13 debug: encountered already materialized expression (idx), reusing result: idx#0
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -506,43 +504,30 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.bootstrap
 debug: Sealing block@0
 large_box_operations/struct_multiple_array_uint64.py:46:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_multiple_array_uint64.py:46:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.append
 debug: Sealing block@0
 large_box_operations/struct_multiple_array_uint64.py:51:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_multiple_array_uint64.py:51:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:52:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%1#0
-large_box_operations/struct_multiple_array_uint64.py:52:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:53:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%2#0
-large_box_operations/struct_multiple_array_uint64.py:53:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.concat
 debug: Sealing block@0
 large_box_operations/struct_multiple_array_uint64.py:57:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_multiple_array_uint64.py:57:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:58:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%1#0
-large_box_operations/struct_multiple_array_uint64.py:58:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:59:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%2#0
-large_box_operations/struct_multiple_array_uint64.py:59:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.pop
 debug: Sealing block@0
 large_box_operations/struct_multiple_array_uint64.py:63:18 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_multiple_array_uint64.py:63:18 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:64:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%1#0
-large_box_operations/struct_multiple_array_uint64.py:64:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:65:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%2#0
-large_box_operations/struct_multiple_array_uint64.py:65:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.get
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.set
 debug: Sealing block@0
-large_box_operations/struct_multiple_array_uint64.py:77:9 debug: encountered already materialized expression ('box'), reusing result: "box"
-large_box_operations/struct_multiple_array_uint64.py:78:9 debug: encountered already materialized expression ('box'), reusing result: "box"
-large_box_operations/struct_multiple_array_uint64.py:79:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.verify
 debug: Sealing block@0
@@ -710,29 +695,24 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.bootstrap
 debug: Sealing block@0
 large_box_operations/struct_array_uint64.py:29:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_array_uint64.py:29:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.append
 debug: Sealing block@0
 large_box_operations/struct_array_uint64.py:34:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_array_uint64.py:34:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.concat
 debug: Sealing block@0
 large_box_operations/struct_array_uint64.py:38:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_array_uint64.py:38:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.pop
 debug: Sealing block@0
 large_box_operations/struct_array_uint64.py:42:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_array_uint64.py:42:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.get
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.set
 debug: Sealing block@0
-large_box_operations/struct_array_uint64.py:50:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.verify
 debug: Sealing block@0
@@ -891,19 +871,15 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.bootstrap
 debug: Sealing block@0
 large_box_operations/nested_item.py:60:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:60:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/nested_item.py:61:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%1#0
-large_box_operations/nested_item.py:61:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.append
 debug: Sealing block@0
 large_box_operations/nested_item.py:66:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:66:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.pop
 debug: Sealing block@0
 large_box_operations/nested_item.py:70:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:70:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.nested_uint
 debug: Sealing block@0
@@ -914,29 +890,22 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.nested_arr_append
 debug: Sealing block@0
 large_box_operations/nested_item.py:82:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:82:30 debug: encountered already materialized expression (item_idx), reusing result: item_idx#0
-large_box_operations/nested_item.py:82:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.nested_arr_pop
 debug: Sealing block@0
 large_box_operations/nested_item.py:86:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:86:37 debug: encountered already materialized expression (item_idx), reusing result: item_idx#0
-large_box_operations/nested_item.py:86:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.dynamic_append
 debug: Sealing block@0
 large_box_operations/nested_item.py:90:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:90:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.dynamic_pop
 debug: Sealing block@0
 large_box_operations/nested_item.py:94:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:94:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.clear_padding
 debug: Sealing block@0
 large_box_operations/nested_item.py:98:22 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:98:22 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.__algopy_default_create
 debug: Sealing block@0
@@ -1083,29 +1052,24 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.bootstrap
 debug: Sealing block@0
 large_box_operations/nested.py:41:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested.py:41:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.append
 debug: Sealing block@0
 large_box_operations/nested.py:46:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested.py:46:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.concat
 debug: Sealing block@0
 large_box_operations/nested.py:50:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested.py:50:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.pop
 debug: Sealing block@0
 large_box_operations/nested.py:54:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested.py:54:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.get
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.set
 debug: Sealing block@0
-large_box_operations/nested.py:62:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.verify
 debug: Sealing block@0
@@ -1249,22 +1213,18 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.bootstrap
 debug: Sealing block@0
 large_box_operations/dynamic_offset_middle.py:47:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_middle.py:47:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.concat
 debug: Sealing block@0
 large_box_operations/dynamic_offset_middle.py:52:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_middle.py:52:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.append
 debug: Sealing block@0
 large_box_operations/dynamic_offset_middle.py:56:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_middle.py:56:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.pop
 debug: Sealing block@0
 large_box_operations/dynamic_offset_middle.py:60:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_middle.py:60:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.verify
 debug: Sealing block@0
@@ -1274,7 +1234,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.set
 debug: Sealing block@0
-large_box_operations/dynamic_offset_middle.py:79:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.__algopy_default_create
 debug: Sealing block@0
@@ -1415,22 +1374,18 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.bootstrap
 debug: Sealing block@0
 large_box_operations/dynamic_offset_last.py:47:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_last.py:47:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.concat
 debug: Sealing block@0
 large_box_operations/dynamic_offset_last.py:52:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_last.py:52:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.append
 debug: Sealing block@0
 large_box_operations/dynamic_offset_last.py:56:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_last.py:56:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.pop
 debug: Sealing block@0
 large_box_operations/dynamic_offset_last.py:60:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_last.py:60:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.verify
 debug: Sealing block@0
@@ -1440,7 +1395,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.set
 debug: Sealing block@0
-large_box_operations/dynamic_offset_last.py:79:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.__algopy_default_create
 debug: Sealing block@0
@@ -1581,22 +1535,18 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.bootstrap
 debug: Sealing block@0
 large_box_operations/dynamic_offset_first.py:47:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_first.py:47:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.concat
 debug: Sealing block@0
 large_box_operations/dynamic_offset_first.py:52:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_first.py:52:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.append
 debug: Sealing block@0
 large_box_operations/dynamic_offset_first.py:56:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_first.py:56:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.pop
 debug: Sealing block@0
 large_box_operations/dynamic_offset_first.py:60:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_first.py:60:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.verify
 debug: Sealing block@0
@@ -1606,7 +1556,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.set
 debug: Sealing block@0
-large_box_operations/dynamic_offset_first.py:79:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.__algopy_default_create
 debug: Sealing block@0
@@ -1749,22 +1698,18 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.append
 debug: Sealing block@0
-large_box_operations/array_uint64.py:20:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.concat
 debug: Sealing block@0
-large_box_operations/array_uint64.py:24:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.pop
 debug: Sealing block@0
-large_box_operations/array_uint64.py:28:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.get
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.set
 debug: Sealing block@0
-large_box_operations/array_uint64.py:36:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.verify
 debug: Sealing block@0

--- a/test_cases/large_box_operations/puya_O2.log
+++ b/test_cases/large_box_operations/puya_O2.log
@@ -424,8 +424,6 @@ debug: Looking for 'new' in an unsealed block creating an incomplete Phi: block@
 debug: Created Phi assignment: let new#1: Encoded(len+uint64[]) = undefined while trying to resolve 'new' in block@1
 debug: Looking for 'inc' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let inc#1: uint64 = undefined while trying to resolve 'inc' in block@1
-large_box_operations/struct_multiple_array_uint64.py:97:9 debug: encountered already materialized expression (new), reusing result: new#1
-large_box_operations/struct_multiple_array_uint64.py:97:13 debug: encountered already materialized expression (idx), reusing result: idx#0
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -505,43 +503,30 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.bootstrap
 debug: Sealing block@0
 large_box_operations/struct_multiple_array_uint64.py:46:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_multiple_array_uint64.py:46:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.append
 debug: Sealing block@0
 large_box_operations/struct_multiple_array_uint64.py:51:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_multiple_array_uint64.py:51:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:52:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%1#0
-large_box_operations/struct_multiple_array_uint64.py:52:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:53:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%2#0
-large_box_operations/struct_multiple_array_uint64.py:53:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.concat
 debug: Sealing block@0
 large_box_operations/struct_multiple_array_uint64.py:57:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_multiple_array_uint64.py:57:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:58:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%1#0
-large_box_operations/struct_multiple_array_uint64.py:58:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:59:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%2#0
-large_box_operations/struct_multiple_array_uint64.py:59:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.pop
 debug: Sealing block@0
 large_box_operations/struct_multiple_array_uint64.py:63:18 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_multiple_array_uint64.py:63:18 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:64:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%1#0
-large_box_operations/struct_multiple_array_uint64.py:64:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:65:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%2#0
-large_box_operations/struct_multiple_array_uint64.py:65:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.get
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.set
 debug: Sealing block@0
-large_box_operations/struct_multiple_array_uint64.py:77:9 debug: encountered already materialized expression ('box'), reusing result: "box"
-large_box_operations/struct_multiple_array_uint64.py:78:9 debug: encountered already materialized expression ('box'), reusing result: "box"
-large_box_operations/struct_multiple_array_uint64.py:79:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.verify
 debug: Sealing block@0
@@ -709,29 +694,24 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.bootstrap
 debug: Sealing block@0
 large_box_operations/struct_array_uint64.py:29:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_array_uint64.py:29:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.append
 debug: Sealing block@0
 large_box_operations/struct_array_uint64.py:34:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_array_uint64.py:34:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.concat
 debug: Sealing block@0
 large_box_operations/struct_array_uint64.py:38:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_array_uint64.py:38:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.pop
 debug: Sealing block@0
 large_box_operations/struct_array_uint64.py:42:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_array_uint64.py:42:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.get
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.set
 debug: Sealing block@0
-large_box_operations/struct_array_uint64.py:50:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.verify
 debug: Sealing block@0
@@ -890,19 +870,15 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.bootstrap
 debug: Sealing block@0
 large_box_operations/nested_item.py:60:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:60:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/nested_item.py:61:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%1#0
-large_box_operations/nested_item.py:61:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.append
 debug: Sealing block@0
 large_box_operations/nested_item.py:66:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:66:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.pop
 debug: Sealing block@0
 large_box_operations/nested_item.py:70:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:70:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.nested_uint
 debug: Sealing block@0
@@ -913,29 +889,22 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.nested_arr_append
 debug: Sealing block@0
 large_box_operations/nested_item.py:82:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:82:30 debug: encountered already materialized expression (item_idx), reusing result: item_idx#0
-large_box_operations/nested_item.py:82:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.nested_arr_pop
 debug: Sealing block@0
 large_box_operations/nested_item.py:86:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:86:37 debug: encountered already materialized expression (item_idx), reusing result: item_idx#0
-large_box_operations/nested_item.py:86:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.dynamic_append
 debug: Sealing block@0
 large_box_operations/nested_item.py:90:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:90:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.dynamic_pop
 debug: Sealing block@0
 large_box_operations/nested_item.py:94:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:94:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.clear_padding
 debug: Sealing block@0
 large_box_operations/nested_item.py:98:22 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:98:22 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.__algopy_default_create
 debug: Sealing block@0
@@ -1082,29 +1051,24 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.bootstrap
 debug: Sealing block@0
 large_box_operations/nested.py:41:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested.py:41:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.append
 debug: Sealing block@0
 large_box_operations/nested.py:46:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested.py:46:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.concat
 debug: Sealing block@0
 large_box_operations/nested.py:50:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested.py:50:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.pop
 debug: Sealing block@0
 large_box_operations/nested.py:54:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested.py:54:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.get
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.set
 debug: Sealing block@0
-large_box_operations/nested.py:62:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.verify
 debug: Sealing block@0
@@ -1248,22 +1212,18 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.bootstrap
 debug: Sealing block@0
 large_box_operations/dynamic_offset_middle.py:47:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_middle.py:47:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.concat
 debug: Sealing block@0
 large_box_operations/dynamic_offset_middle.py:52:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_middle.py:52:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.append
 debug: Sealing block@0
 large_box_operations/dynamic_offset_middle.py:56:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_middle.py:56:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.pop
 debug: Sealing block@0
 large_box_operations/dynamic_offset_middle.py:60:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_middle.py:60:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.verify
 debug: Sealing block@0
@@ -1273,7 +1233,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.set
 debug: Sealing block@0
-large_box_operations/dynamic_offset_middle.py:79:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.__algopy_default_create
 debug: Sealing block@0
@@ -1414,22 +1373,18 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.bootstrap
 debug: Sealing block@0
 large_box_operations/dynamic_offset_last.py:47:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_last.py:47:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.concat
 debug: Sealing block@0
 large_box_operations/dynamic_offset_last.py:52:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_last.py:52:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.append
 debug: Sealing block@0
 large_box_operations/dynamic_offset_last.py:56:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_last.py:56:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.pop
 debug: Sealing block@0
 large_box_operations/dynamic_offset_last.py:60:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_last.py:60:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.verify
 debug: Sealing block@0
@@ -1439,7 +1394,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.set
 debug: Sealing block@0
-large_box_operations/dynamic_offset_last.py:79:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.__algopy_default_create
 debug: Sealing block@0
@@ -1580,22 +1534,18 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.bootstrap
 debug: Sealing block@0
 large_box_operations/dynamic_offset_first.py:47:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_first.py:47:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.concat
 debug: Sealing block@0
 large_box_operations/dynamic_offset_first.py:52:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_first.py:52:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.append
 debug: Sealing block@0
 large_box_operations/dynamic_offset_first.py:56:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_first.py:56:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.pop
 debug: Sealing block@0
 large_box_operations/dynamic_offset_first.py:60:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_first.py:60:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.verify
 debug: Sealing block@0
@@ -1605,7 +1555,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.set
 debug: Sealing block@0
-large_box_operations/dynamic_offset_first.py:79:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.__algopy_default_create
 debug: Sealing block@0
@@ -1748,22 +1697,18 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.append
 debug: Sealing block@0
-large_box_operations/array_uint64.py:20:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.concat
 debug: Sealing block@0
-large_box_operations/array_uint64.py:24:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.pop
 debug: Sealing block@0
-large_box_operations/array_uint64.py:28:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.get
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.set
 debug: Sealing block@0
-large_box_operations/array_uint64.py:36:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.verify
 debug: Sealing block@0

--- a/test_cases/large_box_operations/puya_unoptimized.log
+++ b/test_cases/large_box_operations/puya_unoptimized.log
@@ -424,8 +424,6 @@ debug: Looking for 'new' in an unsealed block creating an incomplete Phi: block@
 debug: Created Phi assignment: let new#1: Encoded(len+uint64[]) = undefined while trying to resolve 'new' in block@1
 debug: Looking for 'inc' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let inc#1: uint64 = undefined while trying to resolve 'inc' in block@1
-large_box_operations/struct_multiple_array_uint64.py:97:9 debug: encountered already materialized expression (new), reusing result: new#1
-large_box_operations/struct_multiple_array_uint64.py:97:13 debug: encountered already materialized expression (idx), reusing result: idx#0
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -505,43 +503,30 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.bootstrap
 debug: Sealing block@0
 large_box_operations/struct_multiple_array_uint64.py:46:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_multiple_array_uint64.py:46:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.append
 debug: Sealing block@0
 large_box_operations/struct_multiple_array_uint64.py:51:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_multiple_array_uint64.py:51:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:52:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%1#0
-large_box_operations/struct_multiple_array_uint64.py:52:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:53:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%2#0
-large_box_operations/struct_multiple_array_uint64.py:53:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.concat
 debug: Sealing block@0
 large_box_operations/struct_multiple_array_uint64.py:57:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_multiple_array_uint64.py:57:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:58:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%1#0
-large_box_operations/struct_multiple_array_uint64.py:58:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:59:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%2#0
-large_box_operations/struct_multiple_array_uint64.py:59:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.pop
 debug: Sealing block@0
 large_box_operations/struct_multiple_array_uint64.py:63:18 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_multiple_array_uint64.py:63:18 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:64:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%1#0
-large_box_operations/struct_multiple_array_uint64.py:64:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/struct_multiple_array_uint64.py:65:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%2#0
-large_box_operations/struct_multiple_array_uint64.py:65:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.get
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.set
 debug: Sealing block@0
-large_box_operations/struct_multiple_array_uint64.py:77:9 debug: encountered already materialized expression ('box'), reusing result: "box"
-large_box_operations/struct_multiple_array_uint64.py:78:9 debug: encountered already materialized expression ('box'), reusing result: "box"
-large_box_operations/struct_multiple_array_uint64.py:79:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_multiple_array_uint64.StructMultipleArrayUInt64.verify
 debug: Sealing block@0
@@ -709,29 +694,24 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.bootstrap
 debug: Sealing block@0
 large_box_operations/struct_array_uint64.py:29:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_array_uint64.py:29:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.append
 debug: Sealing block@0
 large_box_operations/struct_array_uint64.py:34:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_array_uint64.py:34:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.concat
 debug: Sealing block@0
 large_box_operations/struct_array_uint64.py:38:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_array_uint64.py:38:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.pop
 debug: Sealing block@0
 large_box_operations/struct_array_uint64.py:42:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/struct_array_uint64.py:42:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.get
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.set
 debug: Sealing block@0
-large_box_operations/struct_array_uint64.py:50:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.struct_array_uint64.StructArrayUInt64.verify
 debug: Sealing block@0
@@ -890,19 +870,15 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.bootstrap
 debug: Sealing block@0
 large_box_operations/nested_item.py:60:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:60:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 large_box_operations/nested_item.py:61:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%1#0
-large_box_operations/nested_item.py:61:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.append
 debug: Sealing block@0
 large_box_operations/nested_item.py:66:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:66:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.pop
 debug: Sealing block@0
 large_box_operations/nested_item.py:70:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:70:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.nested_uint
 debug: Sealing block@0
@@ -913,29 +889,22 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.nested_arr_append
 debug: Sealing block@0
 large_box_operations/nested_item.py:82:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:82:30 debug: encountered already materialized expression (item_idx), reusing result: item_idx#0
-large_box_operations/nested_item.py:82:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.nested_arr_pop
 debug: Sealing block@0
 large_box_operations/nested_item.py:86:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:86:37 debug: encountered already materialized expression (item_idx), reusing result: item_idx#0
-large_box_operations/nested_item.py:86:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.dynamic_append
 debug: Sealing block@0
 large_box_operations/nested_item.py:90:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:90:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.dynamic_pop
 debug: Sealing block@0
 large_box_operations/nested_item.py:94:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:94:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.clear_padding
 debug: Sealing block@0
 large_box_operations/nested_item.py:98:22 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested_item.py:98:22 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested_item.NestedItemArrayUInt64.__algopy_default_create
 debug: Sealing block@0
@@ -1082,29 +1051,24 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.bootstrap
 debug: Sealing block@0
 large_box_operations/nested.py:41:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested.py:41:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.append
 debug: Sealing block@0
 large_box_operations/nested.py:46:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested.py:46:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.concat
 debug: Sealing block@0
 large_box_operations/nested.py:50:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested.py:50:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.pop
 debug: Sealing block@0
 large_box_operations/nested.py:54:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/nested.py:54:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.get
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.set
 debug: Sealing block@0
-large_box_operations/nested.py:62:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.nested.NestedArrayUInt64.verify
 debug: Sealing block@0
@@ -1248,22 +1212,18 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.bootstrap
 debug: Sealing block@0
 large_box_operations/dynamic_offset_middle.py:47:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_middle.py:47:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.concat
 debug: Sealing block@0
 large_box_operations/dynamic_offset_middle.py:52:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_middle.py:52:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.append
 debug: Sealing block@0
 large_box_operations/dynamic_offset_middle.py:56:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_middle.py:56:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.pop
 debug: Sealing block@0
 large_box_operations/dynamic_offset_middle.py:60:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_middle.py:60:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.verify
 debug: Sealing block@0
@@ -1273,7 +1233,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.set
 debug: Sealing block@0
-large_box_operations/dynamic_offset_middle.py:79:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_middle.DynamicOffsetMiddle.__algopy_default_create
 debug: Sealing block@0
@@ -1414,22 +1373,18 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.bootstrap
 debug: Sealing block@0
 large_box_operations/dynamic_offset_last.py:47:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_last.py:47:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.concat
 debug: Sealing block@0
 large_box_operations/dynamic_offset_last.py:52:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_last.py:52:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.append
 debug: Sealing block@0
 large_box_operations/dynamic_offset_last.py:56:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_last.py:56:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.pop
 debug: Sealing block@0
 large_box_operations/dynamic_offset_last.py:60:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_last.py:60:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.verify
 debug: Sealing block@0
@@ -1439,7 +1394,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.set
 debug: Sealing block@0
-large_box_operations/dynamic_offset_last.py:79:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_last.DynamicOffsetLast.__algopy_default_create
 debug: Sealing block@0
@@ -1580,22 +1534,18 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.bootstrap
 debug: Sealing block@0
 large_box_operations/dynamic_offset_first.py:47:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_first.py:47:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.concat
 debug: Sealing block@0
 large_box_operations/dynamic_offset_first.py:52:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_first.py:52:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.append
 debug: Sealing block@0
 large_box_operations/dynamic_offset_first.py:56:9 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_first.py:56:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.pop
 debug: Sealing block@0
 large_box_operations/dynamic_offset_first.py:60:16 debug: encountered already materialized expression (Box['box']), reusing result: storage_value%0#0
-large_box_operations/dynamic_offset_first.py:60:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.verify
 debug: Sealing block@0
@@ -1605,7 +1555,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.set
 debug: Sealing block@0
-large_box_operations/dynamic_offset_first.py:79:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.dynamic_offset_first.DynamicOffsetFirst.__algopy_default_create
 debug: Sealing block@0
@@ -1748,22 +1697,18 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.append
 debug: Sealing block@0
-large_box_operations/array_uint64.py:20:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.concat
 debug: Sealing block@0
-large_box_operations/array_uint64.py:24:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.pop
 debug: Sealing block@0
-large_box_operations/array_uint64.py:28:16 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.get
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.set
 debug: Sealing block@0
-large_box_operations/array_uint64.py:36:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.large_box_operations.array_uint64.ArrayUInt64.verify
 debug: Sealing block@0

--- a/test_cases/log/puya.log
+++ b/test_cases/log/puya.log
@@ -416,15 +416,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.log.contract.MyContract.approval_program
 debug: Sealing block@0
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
 debug: Terminated block@0
 debug: Building IR for function test_cases.log.contract.MyContract.clear_state_program
 debug: Sealing block@0
@@ -434,15 +425,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.log.contract.MyContract.approval_program
 debug: Sealing block@0
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
 debug: Terminated block@0
 debug: removing unused subroutine _puya_lib.util.ensure_budget
 debug: removing unused subroutine _puya_lib.bytes_.is_substring

--- a/test_cases/log/puya_O2.log
+++ b/test_cases/log/puya_O2.log
@@ -415,15 +415,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.log.contract.MyContract.approval_program
 debug: Sealing block@0
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
 debug: Terminated block@0
 debug: Building IR for function test_cases.log.contract.MyContract.clear_state_program
 debug: Sealing block@0
@@ -433,15 +424,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.log.contract.MyContract.approval_program
 debug: Sealing block@0
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
 debug: Terminated block@0
 debug: removing unused subroutine _puya_lib.util.ensure_budget
 debug: removing unused subroutine _puya_lib.bytes_.is_substring

--- a/test_cases/log/puya_unoptimized.log
+++ b/test_cases/log/puya_unoptimized.log
@@ -415,15 +415,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.log.contract.MyContract.approval_program
 debug: Sealing block@0
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
 debug: Terminated block@0
 debug: Building IR for function test_cases.log.contract.MyContract.clear_state_program
 debug: Sealing block@0
@@ -433,15 +424,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.log.contract.MyContract.approval_program
 debug: Sealing block@0
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:11:9 debug: encountered already materialized expression (''), reusing result: ""
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:24:17 debug: encountered already materialized expression (hex<"5F">), reusing result: 0x5f
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
-log/contract.py:32:17 debug: encountered already materialized expression ('_'), reusing result: "_"
 debug: Terminated block@0
 debug: removing unused subroutine _puya_lib.util.ensure_budget
 debug: removing unused subroutine _puya_lib.bytes_.is_substring

--- a/test_cases/loop_else/puya.log
+++ b/test_cases/loop_else/puya.log
@@ -512,8 +512,6 @@ debug: Terminated block@17
 debug: Looking for 'secret_index' in an unsealed block creating an incomplete Phi: block@18
 debug: Created Phi assignment: let secret_index#1: uint64 = undefined while trying to resolve 'secret_index' in block@18
 loop_else/loop_else.py:29:13 debug: encountered already materialized expression (itob(secret_index + 48u)), reusing result: tmp%12#0
-loop_else/loop_else.py:27:9 debug: encountered already materialized expression (''), reusing result: ""
-loop_else/loop_else.py:27:9 debug: encountered already materialized expression (''), reusing result: ""
 debug: Looking for 'account_index' in an unsealed block creating an incomplete Phi: block@18
 debug: Created Phi assignment: let account_index#1: uint64 = undefined while trying to resolve 'account_index' in block@18
 loop_else/loop_else.py:31:13 debug: encountered already materialized expression (itob(account_index + 48u)), reusing result: tmp%20#0
@@ -599,8 +597,6 @@ debug: Terminated block@17
 debug: Looking for 'secret_index' in an unsealed block creating an incomplete Phi: block@18
 debug: Created Phi assignment: let secret_index#1: uint64 = undefined while trying to resolve 'secret_index' in block@18
 loop_else/loop_else.py:29:13 debug: encountered already materialized expression (itob(secret_index + 48u)), reusing result: tmp%12#0
-loop_else/loop_else.py:27:9 debug: encountered already materialized expression (''), reusing result: ""
-loop_else/loop_else.py:27:9 debug: encountered already materialized expression (''), reusing result: ""
 debug: Looking for 'account_index' in an unsealed block creating an incomplete Phi: block@18
 debug: Created Phi assignment: let account_index#1: uint64 = undefined while trying to resolve 'account_index' in block@18
 loop_else/loop_else.py:31:13 debug: encountered already materialized expression (itob(account_index + 48u)), reusing result: tmp%20#0

--- a/test_cases/loop_else/puya_O2.log
+++ b/test_cases/loop_else/puya_O2.log
@@ -511,8 +511,6 @@ debug: Terminated block@17
 debug: Looking for 'secret_index' in an unsealed block creating an incomplete Phi: block@18
 debug: Created Phi assignment: let secret_index#1: uint64 = undefined while trying to resolve 'secret_index' in block@18
 loop_else/loop_else.py:29:13 debug: encountered already materialized expression (itob(secret_index + 48u)), reusing result: tmp%12#0
-loop_else/loop_else.py:27:9 debug: encountered already materialized expression (''), reusing result: ""
-loop_else/loop_else.py:27:9 debug: encountered already materialized expression (''), reusing result: ""
 debug: Looking for 'account_index' in an unsealed block creating an incomplete Phi: block@18
 debug: Created Phi assignment: let account_index#1: uint64 = undefined while trying to resolve 'account_index' in block@18
 loop_else/loop_else.py:31:13 debug: encountered already materialized expression (itob(account_index + 48u)), reusing result: tmp%20#0
@@ -598,8 +596,6 @@ debug: Terminated block@17
 debug: Looking for 'secret_index' in an unsealed block creating an incomplete Phi: block@18
 debug: Created Phi assignment: let secret_index#1: uint64 = undefined while trying to resolve 'secret_index' in block@18
 loop_else/loop_else.py:29:13 debug: encountered already materialized expression (itob(secret_index + 48u)), reusing result: tmp%12#0
-loop_else/loop_else.py:27:9 debug: encountered already materialized expression (''), reusing result: ""
-loop_else/loop_else.py:27:9 debug: encountered already materialized expression (''), reusing result: ""
 debug: Looking for 'account_index' in an unsealed block creating an incomplete Phi: block@18
 debug: Created Phi assignment: let account_index#1: uint64 = undefined while trying to resolve 'account_index' in block@18
 loop_else/loop_else.py:31:13 debug: encountered already materialized expression (itob(account_index + 48u)), reusing result: tmp%20#0

--- a/test_cases/loop_else/puya_unoptimized.log
+++ b/test_cases/loop_else/puya_unoptimized.log
@@ -511,8 +511,6 @@ debug: Terminated block@17
 debug: Looking for 'secret_index' in an unsealed block creating an incomplete Phi: block@18
 debug: Created Phi assignment: let secret_index#1: uint64 = undefined while trying to resolve 'secret_index' in block@18
 loop_else/loop_else.py:29:13 debug: encountered already materialized expression (itob(secret_index + 48u)), reusing result: tmp%12#0
-loop_else/loop_else.py:27:9 debug: encountered already materialized expression (''), reusing result: ""
-loop_else/loop_else.py:27:9 debug: encountered already materialized expression (''), reusing result: ""
 debug: Looking for 'account_index' in an unsealed block creating an incomplete Phi: block@18
 debug: Created Phi assignment: let account_index#1: uint64 = undefined while trying to resolve 'account_index' in block@18
 loop_else/loop_else.py:31:13 debug: encountered already materialized expression (itob(account_index + 48u)), reusing result: tmp%20#0
@@ -598,8 +596,6 @@ debug: Terminated block@17
 debug: Looking for 'secret_index' in an unsealed block creating an incomplete Phi: block@18
 debug: Created Phi assignment: let secret_index#1: uint64 = undefined while trying to resolve 'secret_index' in block@18
 loop_else/loop_else.py:29:13 debug: encountered already materialized expression (itob(secret_index + 48u)), reusing result: tmp%12#0
-loop_else/loop_else.py:27:9 debug: encountered already materialized expression (''), reusing result: ""
-loop_else/loop_else.py:27:9 debug: encountered already materialized expression (''), reusing result: ""
 debug: Looking for 'account_index' in an unsealed block creating an incomplete Phi: block@18
 debug: Created Phi assignment: let account_index#1: uint64 = undefined while trying to resolve 'account_index' in block@18
 loop_else/loop_else.py:31:13 debug: encountered already materialized expression (itob(account_index + 48u)), reusing result: tmp%20#0

--- a/test_cases/match/puya.log
+++ b/test_cases/match/puya.log
@@ -433,7 +433,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.match.counter.Counter.increment_counter
 debug: Sealing block@0
-match/counter.py:22:9 debug: encountered already materialized expression ('counter'), reusing result: "counter"
 debug: Terminated block@0
 debug: Building IR for function algopy._contract.Contract.__init__
 debug: Sealing block@0

--- a/test_cases/match/puya_O2.log
+++ b/test_cases/match/puya_O2.log
@@ -432,7 +432,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.match.counter.Counter.increment_counter
 debug: Sealing block@0
-match/counter.py:22:9 debug: encountered already materialized expression ('counter'), reusing result: "counter"
 debug: Terminated block@0
 debug: Building IR for function algopy._contract.Contract.__init__
 debug: Sealing block@0

--- a/test_cases/match/puya_unoptimized.log
+++ b/test_cases/match/puya_unoptimized.log
@@ -432,7 +432,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.match.counter.Counter.increment_counter
 debug: Sealing block@0
-match/counter.py:22:9 debug: encountered already materialized expression ('counter'), reusing result: "counter"
 debug: Terminated block@0
 debug: Building IR for function algopy._contract.Contract.__init__
 debug: Sealing block@0

--- a/test_cases/mutable_native_types/puya.log
+++ b/test_cases/mutable_native_types/puya.log
@@ -442,8 +442,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.tuple_conversion
 debug: Sealing block@0
-mutable_native_types/contract.py:292:18 debug: encountered already materialized expression (arr3), reusing result: arr3#0
-mutable_native_types/contract.py:292:18 debug: encountered already materialized expression (arr3), reusing result: arr3#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.argument_subtype
 debug: Sealing block@0
@@ -477,12 +475,9 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.fixed_array_dynamic_elements.FixedArrayDynamicElements.__init__
 debug: Sealing block@0
-mutable_native_types/fixed_array_dynamic_elements.py:14:62 debug: encountered already materialized expression (default), reusing result: default#0
-mutable_native_types/fixed_array_dynamic_elements.py:14:62 debug: encountered already materialized expression (default), reusing result: default#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.fixed_array_dynamic_elements.FixedArrayDynamicElements.write_at_index
 debug: Sealing block@0
-mutable_native_types/fixed_array_dynamic_elements.py:18:9 debug: encountered already materialized expression ('data'), reusing result: "data"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.fixed_array_dynamic_elements.FixedArrayDynamicElements.read_at_index
 debug: Sealing block@0
@@ -668,23 +663,16 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.test_imm_fixed_array
 debug: Sealing block@0
-mutable_native_types/contract.py:97:57 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.fixed_initialize
 debug: Sealing block@0
-mutable_native_types/contract.py:113:47 debug: encountered already materialized expression (1u), reusing result: 1u
-mutable_native_types/contract.py:113:47 debug: encountered already materialized expression (1u), reusing result: 1u
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.add_payment
 debug: Sealing block@0
-mutable_native_types/contract.py:134:9 debug: encountered already materialized expression ('payments'), reusing result: "payments"
-mutable_native_types/contract.py:135:9 debug: encountered already materialized expression ('num_payments'), reusing result: "num_payments"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.increment_payment
 debug: Sealing block@0
 mutable_native_types/contract.py:140:9 debug: encountered already materialized expression (GlobalState['payments']), reusing result: maybe_value%1#0
-mutable_native_types/contract.py:140:23 debug: encountered already materialized expression (index), reusing result: index#0
-mutable_native_types/contract.py:140:9 debug: encountered already materialized expression ('payments'), reusing result: "payments"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.create_storage
 debug: Sealing block@0
@@ -698,11 +686,7 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.struct_arg
 debug: Sealing block@0
-mutable_native_types/contract.py:170:9 debug: encountered already materialized expression ('nested'), reusing result: "nested"
-mutable_native_types/contract.py:171:9 debug: encountered already materialized expression (hex<"70">), reusing result: 0x70
-mutable_native_types/contract.py:172:9 debug: encountered already materialized expression (hex<"6C">), reusing result: 0x6c
 mutable_native_types/contract.py:172:27 debug: encountered already materialized expression (txn<Sender>()), reusing result: tmp%0#0
-mutable_native_types/contract.py:173:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 mutable_native_types/contract.py:174:9 debug: encountered already materialized expression (MapKey(prefix='box_map', key=box_key)), reusing result: map_prefixed_key%0#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.struct_return
@@ -945,18 +929,13 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case3_with_mutable_struct.Case3WithStruct.create_box
 debug: Sealing block@0
-mutable_native_types/case3_with_mutable_struct.py:41:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case3_with_mutable_struct.py:42:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case3_with_mutable_struct.py:43:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case3_with_mutable_struct.Case3WithStruct.num_tups
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case3_with_mutable_struct.Case3WithStruct.add_tup
 debug: Sealing block@0
-mutable_native_types/case3_with_mutable_struct.py:53:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 mutable_native_types/case3_with_mutable_struct.py:54:9 debug: encountered already materialized expression (Box['tup_bag']), reusing result: storage_value%3#0
-mutable_native_types/case3_with_mutable_struct.py:54:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case3_with_mutable_struct.Case3WithStruct.get_tup
 debug: Sealing block@0
@@ -1033,7 +1012,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'a' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let a#1: uint64 = undefined while trying to resolve 'a' in block@1
-mutable_native_types/case3_with_mutable_struct.py:84:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1056,7 +1034,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'b' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let b#1: uint64 = undefined while trying to resolve 'b' in block@1
-mutable_native_types/case3_with_mutable_struct.py:90:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1284,18 +1261,13 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case2_with_immutable_struct.Case2WithImmStruct.create_box
 debug: Sealing block@0
-mutable_native_types/case2_with_immutable_struct.py:41:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case2_with_immutable_struct.py:42:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case2_with_immutable_struct.py:43:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case2_with_immutable_struct.Case2WithImmStruct.num_tups
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case2_with_immutable_struct.Case2WithImmStruct.add_tup
 debug: Sealing block@0
-mutable_native_types/case2_with_immutable_struct.py:53:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 mutable_native_types/case2_with_immutable_struct.py:54:9 debug: encountered already materialized expression (Box['tup_bag']), reusing result: storage_value%3#0
-mutable_native_types/case2_with_immutable_struct.py:54:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case2_with_immutable_struct.Case2WithImmStruct.get_tup
 debug: Sealing block@0
@@ -1358,7 +1330,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'a' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let a#1: uint64 = undefined while trying to resolve 'a' in block@1
-mutable_native_types/case2_with_immutable_struct.py:85:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1381,7 +1352,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'b' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let b#1: uint64 = undefined while trying to resolve 'b' in block@1
-mutable_native_types/case2_with_immutable_struct.py:92:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1609,18 +1579,13 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case1_with_tups.Case1WithTups.create_box
 debug: Sealing block@0
-mutable_native_types/case1_with_tups.py:48:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case1_with_tups.py:49:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case1_with_tups.py:50:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case1_with_tups.Case1WithTups.num_tups
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case1_with_tups.Case1WithTups.add_tup
 debug: Sealing block@0
-mutable_native_types/case1_with_tups.py:60:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 mutable_native_types/case1_with_tups.py:61:9 debug: encountered already materialized expression (Box['tup_bag']), reusing result: storage_value%3#0
-mutable_native_types/case1_with_tups.py:61:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case1_with_tups.Case1WithTups.get_tup
 debug: Sealing block@0
@@ -1683,7 +1648,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'a' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let a#1: uint64 = undefined while trying to resolve 'a' in block@1
-mutable_native_types/case1_with_tups.py:92:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1706,7 +1670,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'b' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let b#1: uint64 = undefined while trying to resolve 'b' in block@1
-mutable_native_types/case1_with_tups.py:99:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3

--- a/test_cases/mutable_native_types/puya_O2.log
+++ b/test_cases/mutable_native_types/puya_O2.log
@@ -441,8 +441,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.tuple_conversion
 debug: Sealing block@0
-mutable_native_types/contract.py:292:18 debug: encountered already materialized expression (arr3), reusing result: arr3#0
-mutable_native_types/contract.py:292:18 debug: encountered already materialized expression (arr3), reusing result: arr3#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.argument_subtype
 debug: Sealing block@0
@@ -476,12 +474,9 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.fixed_array_dynamic_elements.FixedArrayDynamicElements.__init__
 debug: Sealing block@0
-mutable_native_types/fixed_array_dynamic_elements.py:14:62 debug: encountered already materialized expression (default), reusing result: default#0
-mutable_native_types/fixed_array_dynamic_elements.py:14:62 debug: encountered already materialized expression (default), reusing result: default#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.fixed_array_dynamic_elements.FixedArrayDynamicElements.write_at_index
 debug: Sealing block@0
-mutable_native_types/fixed_array_dynamic_elements.py:18:9 debug: encountered already materialized expression ('data'), reusing result: "data"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.fixed_array_dynamic_elements.FixedArrayDynamicElements.read_at_index
 debug: Sealing block@0
@@ -667,23 +662,16 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.test_imm_fixed_array
 debug: Sealing block@0
-mutable_native_types/contract.py:97:57 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.fixed_initialize
 debug: Sealing block@0
-mutable_native_types/contract.py:113:47 debug: encountered already materialized expression (1u), reusing result: 1u
-mutable_native_types/contract.py:113:47 debug: encountered already materialized expression (1u), reusing result: 1u
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.add_payment
 debug: Sealing block@0
-mutable_native_types/contract.py:134:9 debug: encountered already materialized expression ('payments'), reusing result: "payments"
-mutable_native_types/contract.py:135:9 debug: encountered already materialized expression ('num_payments'), reusing result: "num_payments"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.increment_payment
 debug: Sealing block@0
 mutable_native_types/contract.py:140:9 debug: encountered already materialized expression (GlobalState['payments']), reusing result: maybe_value%1#0
-mutable_native_types/contract.py:140:23 debug: encountered already materialized expression (index), reusing result: index#0
-mutable_native_types/contract.py:140:9 debug: encountered already materialized expression ('payments'), reusing result: "payments"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.create_storage
 debug: Sealing block@0
@@ -697,11 +685,7 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.struct_arg
 debug: Sealing block@0
-mutable_native_types/contract.py:170:9 debug: encountered already materialized expression ('nested'), reusing result: "nested"
-mutable_native_types/contract.py:171:9 debug: encountered already materialized expression (hex<"70">), reusing result: 0x70
-mutable_native_types/contract.py:172:9 debug: encountered already materialized expression (hex<"6C">), reusing result: 0x6c
 mutable_native_types/contract.py:172:27 debug: encountered already materialized expression (txn<Sender>()), reusing result: tmp%0#0
-mutable_native_types/contract.py:173:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 mutable_native_types/contract.py:174:9 debug: encountered already materialized expression (MapKey(prefix='box_map', key=box_key)), reusing result: map_prefixed_key%0#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.struct_return
@@ -944,18 +928,13 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case3_with_mutable_struct.Case3WithStruct.create_box
 debug: Sealing block@0
-mutable_native_types/case3_with_mutable_struct.py:41:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case3_with_mutable_struct.py:42:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case3_with_mutable_struct.py:43:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case3_with_mutable_struct.Case3WithStruct.num_tups
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case3_with_mutable_struct.Case3WithStruct.add_tup
 debug: Sealing block@0
-mutable_native_types/case3_with_mutable_struct.py:53:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 mutable_native_types/case3_with_mutable_struct.py:54:9 debug: encountered already materialized expression (Box['tup_bag']), reusing result: storage_value%3#0
-mutable_native_types/case3_with_mutable_struct.py:54:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case3_with_mutable_struct.Case3WithStruct.get_tup
 debug: Sealing block@0
@@ -1032,7 +1011,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'a' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let a#1: uint64 = undefined while trying to resolve 'a' in block@1
-mutable_native_types/case3_with_mutable_struct.py:84:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1055,7 +1033,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'b' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let b#1: uint64 = undefined while trying to resolve 'b' in block@1
-mutable_native_types/case3_with_mutable_struct.py:90:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1283,18 +1260,13 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case2_with_immutable_struct.Case2WithImmStruct.create_box
 debug: Sealing block@0
-mutable_native_types/case2_with_immutable_struct.py:41:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case2_with_immutable_struct.py:42:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case2_with_immutable_struct.py:43:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case2_with_immutable_struct.Case2WithImmStruct.num_tups
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case2_with_immutable_struct.Case2WithImmStruct.add_tup
 debug: Sealing block@0
-mutable_native_types/case2_with_immutable_struct.py:53:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 mutable_native_types/case2_with_immutable_struct.py:54:9 debug: encountered already materialized expression (Box['tup_bag']), reusing result: storage_value%3#0
-mutable_native_types/case2_with_immutable_struct.py:54:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case2_with_immutable_struct.Case2WithImmStruct.get_tup
 debug: Sealing block@0
@@ -1357,7 +1329,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'a' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let a#1: uint64 = undefined while trying to resolve 'a' in block@1
-mutable_native_types/case2_with_immutable_struct.py:85:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1380,7 +1351,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'b' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let b#1: uint64 = undefined while trying to resolve 'b' in block@1
-mutable_native_types/case2_with_immutable_struct.py:92:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1608,18 +1578,13 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case1_with_tups.Case1WithTups.create_box
 debug: Sealing block@0
-mutable_native_types/case1_with_tups.py:48:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case1_with_tups.py:49:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case1_with_tups.py:50:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case1_with_tups.Case1WithTups.num_tups
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case1_with_tups.Case1WithTups.add_tup
 debug: Sealing block@0
-mutable_native_types/case1_with_tups.py:60:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 mutable_native_types/case1_with_tups.py:61:9 debug: encountered already materialized expression (Box['tup_bag']), reusing result: storage_value%3#0
-mutable_native_types/case1_with_tups.py:61:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case1_with_tups.Case1WithTups.get_tup
 debug: Sealing block@0
@@ -1682,7 +1647,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'a' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let a#1: uint64 = undefined while trying to resolve 'a' in block@1
-mutable_native_types/case1_with_tups.py:92:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1705,7 +1669,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'b' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let b#1: uint64 = undefined while trying to resolve 'b' in block@1
-mutable_native_types/case1_with_tups.py:99:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3

--- a/test_cases/mutable_native_types/puya_unoptimized.log
+++ b/test_cases/mutable_native_types/puya_unoptimized.log
@@ -441,8 +441,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.tuple_conversion
 debug: Sealing block@0
-mutable_native_types/contract.py:292:18 debug: encountered already materialized expression (arr3), reusing result: arr3#0
-mutable_native_types/contract.py:292:18 debug: encountered already materialized expression (arr3), reusing result: arr3#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.argument_subtype
 debug: Sealing block@0
@@ -476,12 +474,9 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.fixed_array_dynamic_elements.FixedArrayDynamicElements.__init__
 debug: Sealing block@0
-mutable_native_types/fixed_array_dynamic_elements.py:14:62 debug: encountered already materialized expression (default), reusing result: default#0
-mutable_native_types/fixed_array_dynamic_elements.py:14:62 debug: encountered already materialized expression (default), reusing result: default#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.fixed_array_dynamic_elements.FixedArrayDynamicElements.write_at_index
 debug: Sealing block@0
-mutable_native_types/fixed_array_dynamic_elements.py:18:9 debug: encountered already materialized expression ('data'), reusing result: "data"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.fixed_array_dynamic_elements.FixedArrayDynamicElements.read_at_index
 debug: Sealing block@0
@@ -667,23 +662,16 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.test_imm_fixed_array
 debug: Sealing block@0
-mutable_native_types/contract.py:97:57 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.fixed_initialize
 debug: Sealing block@0
-mutable_native_types/contract.py:113:47 debug: encountered already materialized expression (1u), reusing result: 1u
-mutable_native_types/contract.py:113:47 debug: encountered already materialized expression (1u), reusing result: 1u
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.add_payment
 debug: Sealing block@0
-mutable_native_types/contract.py:134:9 debug: encountered already materialized expression ('payments'), reusing result: "payments"
-mutable_native_types/contract.py:135:9 debug: encountered already materialized expression ('num_payments'), reusing result: "num_payments"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.increment_payment
 debug: Sealing block@0
 mutable_native_types/contract.py:140:9 debug: encountered already materialized expression (GlobalState['payments']), reusing result: maybe_value%1#0
-mutable_native_types/contract.py:140:23 debug: encountered already materialized expression (index), reusing result: index#0
-mutable_native_types/contract.py:140:9 debug: encountered already materialized expression ('payments'), reusing result: "payments"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.create_storage
 debug: Sealing block@0
@@ -697,11 +685,7 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.struct_arg
 debug: Sealing block@0
-mutable_native_types/contract.py:170:9 debug: encountered already materialized expression ('nested'), reusing result: "nested"
-mutable_native_types/contract.py:171:9 debug: encountered already materialized expression (hex<"70">), reusing result: 0x70
-mutable_native_types/contract.py:172:9 debug: encountered already materialized expression (hex<"6C">), reusing result: 0x6c
 mutable_native_types/contract.py:172:27 debug: encountered already materialized expression (txn<Sender>()), reusing result: tmp%0#0
-mutable_native_types/contract.py:173:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 mutable_native_types/contract.py:174:9 debug: encountered already materialized expression (MapKey(prefix='box_map', key=box_key)), reusing result: map_prefixed_key%0#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.contract.Contract.struct_return
@@ -944,18 +928,13 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case3_with_mutable_struct.Case3WithStruct.create_box
 debug: Sealing block@0
-mutable_native_types/case3_with_mutable_struct.py:41:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case3_with_mutable_struct.py:42:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case3_with_mutable_struct.py:43:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case3_with_mutable_struct.Case3WithStruct.num_tups
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case3_with_mutable_struct.Case3WithStruct.add_tup
 debug: Sealing block@0
-mutable_native_types/case3_with_mutable_struct.py:53:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 mutable_native_types/case3_with_mutable_struct.py:54:9 debug: encountered already materialized expression (Box['tup_bag']), reusing result: storage_value%3#0
-mutable_native_types/case3_with_mutable_struct.py:54:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case3_with_mutable_struct.Case3WithStruct.get_tup
 debug: Sealing block@0
@@ -1032,7 +1011,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'a' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let a#1: uint64 = undefined while trying to resolve 'a' in block@1
-mutable_native_types/case3_with_mutable_struct.py:84:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1055,7 +1033,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'b' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let b#1: uint64 = undefined while trying to resolve 'b' in block@1
-mutable_native_types/case3_with_mutable_struct.py:90:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1283,18 +1260,13 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case2_with_immutable_struct.Case2WithImmStruct.create_box
 debug: Sealing block@0
-mutable_native_types/case2_with_immutable_struct.py:41:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case2_with_immutable_struct.py:42:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case2_with_immutable_struct.py:43:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case2_with_immutable_struct.Case2WithImmStruct.num_tups
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case2_with_immutable_struct.Case2WithImmStruct.add_tup
 debug: Sealing block@0
-mutable_native_types/case2_with_immutable_struct.py:53:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 mutable_native_types/case2_with_immutable_struct.py:54:9 debug: encountered already materialized expression (Box['tup_bag']), reusing result: storage_value%3#0
-mutable_native_types/case2_with_immutable_struct.py:54:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case2_with_immutable_struct.Case2WithImmStruct.get_tup
 debug: Sealing block@0
@@ -1357,7 +1329,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'a' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let a#1: uint64 = undefined while trying to resolve 'a' in block@1
-mutable_native_types/case2_with_immutable_struct.py:85:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1380,7 +1351,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'b' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let b#1: uint64 = undefined while trying to resolve 'b' in block@1
-mutable_native_types/case2_with_immutable_struct.py:92:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1608,18 +1578,13 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case1_with_tups.Case1WithTups.create_box
 debug: Sealing block@0
-mutable_native_types/case1_with_tups.py:48:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case1_with_tups.py:49:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
-mutable_native_types/case1_with_tups.py:50:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case1_with_tups.Case1WithTups.num_tups
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case1_with_tups.Case1WithTups.add_tup
 debug: Sealing block@0
-mutable_native_types/case1_with_tups.py:60:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 mutable_native_types/case1_with_tups.py:61:9 debug: encountered already materialized expression (Box['tup_bag']), reusing result: storage_value%3#0
-mutable_native_types/case1_with_tups.py:61:9 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@0
 debug: Building IR for function test_cases.mutable_native_types.case1_with_tups.Case1WithTups.get_tup
 debug: Sealing block@0
@@ -1682,7 +1647,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'a' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let a#1: uint64 = undefined while trying to resolve 'a' in block@1
-mutable_native_types/case1_with_tups.py:92:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1705,7 +1669,6 @@ debug: Terminated block@1
 debug: Sealing block@2
 debug: Looking for 'b' in an unsealed block creating an incomplete Phi: block@1
 debug: Created Phi assignment: let b#1: uint64 = undefined while trying to resolve 'b' in block@1
-mutable_native_types/case1_with_tups.py:99:13 debug: encountered already materialized expression ('tup_bag'), reusing result: "tup_bag"
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3

--- a/test_cases/mylib/puya.log
+++ b/test_cases/mylib/puya.log
@@ -509,6 +509,5 @@ debug: Sealing block@10
 debug: Terminated block@10
 debug: Building IR for function test_cases.mylib.simple_functions.test_and_uint64
 debug: Sealing block@0
-mylib/simple_functions.py:76:12 debug: encountered already materialized expression (1u), reusing result: 1u
 debug: Terminated block@0
 warning: No contracts or logic signatures discovered in any source files

--- a/test_cases/mylib/puya_O2.log
+++ b/test_cases/mylib/puya_O2.log
@@ -508,6 +508,5 @@ debug: Sealing block@10
 debug: Terminated block@10
 debug: Building IR for function test_cases.mylib.simple_functions.test_and_uint64
 debug: Sealing block@0
-mylib/simple_functions.py:76:12 debug: encountered already materialized expression (1u), reusing result: 1u
 debug: Terminated block@0
 warning: No contracts or logic signatures discovered in any source files

--- a/test_cases/mylib/puya_unoptimized.log
+++ b/test_cases/mylib/puya_unoptimized.log
@@ -508,6 +508,5 @@ debug: Sealing block@10
 debug: Terminated block@10
 debug: Building IR for function test_cases.mylib.simple_functions.test_and_uint64
 debug: Sealing block@0
-mylib/simple_functions.py:76:12 debug: encountered already materialized expression (1u), reusing result: 1u
 debug: Terminated block@0
 warning: No contracts or logic signatures discovered in any source files

--- a/test_cases/named_tuples/puya.log
+++ b/test_cases/named_tuples/puya.log
@@ -451,12 +451,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.named_tuples.contract.NamedTuplesContract.build_tuple
 debug: Sealing block@0
-named_tuples/contract.py:26:16 debug: encountered already materialized expression (t1), reusing result: (t1.a#0, t1.b#0, t1.c#0, t1.d#0)
-named_tuples/contract.py:26:22 debug: encountered already materialized expression (t2), reusing result: (t2.a#0, t2.b#0, t2.c#0, t2.d#0)
-named_tuples/contract.py:26:16 debug: encountered already materialized expression (t1), reusing result: (t1.a#0, t1.b#0, t1.c#0, t1.d#0)
-named_tuples/contract.py:26:22 debug: encountered already materialized expression (t2), reusing result: (t2.a#0, t2.b#0, t2.c#0, t2.d#0)
-named_tuples/contract.py:26:16 debug: encountered already materialized expression (t1), reusing result: (t1.a#0, t1.b#0, t1.c#0, t1.d#0)
-named_tuples/contract.py:26:22 debug: encountered already materialized expression (t2), reusing result: (t2.a#0, t2.b#0, t2.c#0, t2.d#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.named_tuples.contract.NamedTuplesContract.build_tuple_by_name
 debug: Sealing block@0

--- a/test_cases/named_tuples/puya_O2.log
+++ b/test_cases/named_tuples/puya_O2.log
@@ -450,12 +450,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.named_tuples.contract.NamedTuplesContract.build_tuple
 debug: Sealing block@0
-named_tuples/contract.py:26:16 debug: encountered already materialized expression (t1), reusing result: (t1.a#0, t1.b#0, t1.c#0, t1.d#0)
-named_tuples/contract.py:26:22 debug: encountered already materialized expression (t2), reusing result: (t2.a#0, t2.b#0, t2.c#0, t2.d#0)
-named_tuples/contract.py:26:16 debug: encountered already materialized expression (t1), reusing result: (t1.a#0, t1.b#0, t1.c#0, t1.d#0)
-named_tuples/contract.py:26:22 debug: encountered already materialized expression (t2), reusing result: (t2.a#0, t2.b#0, t2.c#0, t2.d#0)
-named_tuples/contract.py:26:16 debug: encountered already materialized expression (t1), reusing result: (t1.a#0, t1.b#0, t1.c#0, t1.d#0)
-named_tuples/contract.py:26:22 debug: encountered already materialized expression (t2), reusing result: (t2.a#0, t2.b#0, t2.c#0, t2.d#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.named_tuples.contract.NamedTuplesContract.build_tuple_by_name
 debug: Sealing block@0

--- a/test_cases/named_tuples/puya_unoptimized.log
+++ b/test_cases/named_tuples/puya_unoptimized.log
@@ -450,12 +450,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.named_tuples.contract.NamedTuplesContract.build_tuple
 debug: Sealing block@0
-named_tuples/contract.py:26:16 debug: encountered already materialized expression (t1), reusing result: (t1.a#0, t1.b#0, t1.c#0, t1.d#0)
-named_tuples/contract.py:26:22 debug: encountered already materialized expression (t2), reusing result: (t2.a#0, t2.b#0, t2.c#0, t2.d#0)
-named_tuples/contract.py:26:16 debug: encountered already materialized expression (t1), reusing result: (t1.a#0, t1.b#0, t1.c#0, t1.d#0)
-named_tuples/contract.py:26:22 debug: encountered already materialized expression (t2), reusing result: (t2.a#0, t2.b#0, t2.c#0, t2.d#0)
-named_tuples/contract.py:26:16 debug: encountered already materialized expression (t1), reusing result: (t1.a#0, t1.b#0, t1.c#0, t1.d#0)
-named_tuples/contract.py:26:22 debug: encountered already materialized expression (t2), reusing result: (t2.a#0, t2.b#0, t2.c#0, t2.d#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.named_tuples.contract.NamedTuplesContract.build_tuple_by_name
 debug: Sealing block@0

--- a/test_cases/regression_tests/puya.log
+++ b/test_cases/regression_tests/puya.log
@@ -6122,7 +6122,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.regression_tests.biguint_opt.ConstBigIntToIntOverflow.get_abs_bound1
 debug: Sealing block@0
-regression_tests/biguint_opt.py:7:35 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1

--- a/test_cases/regression_tests/puya_O2.log
+++ b/test_cases/regression_tests/puya_O2.log
@@ -6121,7 +6121,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.regression_tests.biguint_opt.ConstBigIntToIntOverflow.get_abs_bound1
 debug: Sealing block@0
-regression_tests/biguint_opt.py:7:35 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1

--- a/test_cases/regression_tests/puya_unoptimized.log
+++ b/test_cases/regression_tests/puya_unoptimized.log
@@ -6121,7 +6121,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.regression_tests.biguint_opt.ConstBigIntToIntOverflow.get_abs_bound1
 debug: Sealing block@0
-regression_tests/biguint_opt.py:7:35 debug: encountered already materialized expression (0u), reusing result: 0u
 debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1

--- a/test_cases/simplish/puya.log
+++ b/test_cases/simplish/puya.log
@@ -442,7 +442,6 @@ debug: Terminated block@3
 debug: Sealing block@4
 debug: Terminated block@4
 debug: Sealing block@5
-simplish/contract.py:35:12 debug: encountered already materialized expression (oca), reusing result: oca#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Created Phi assignment: let oca#1: uint64 = undefined while trying to resolve 'oca' in block@6
@@ -565,7 +564,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.simplish.base_class.CallCounter.increment_counter
 debug: Sealing block@0
-simplish/base_class.py:13:9 debug: encountered already materialized expression ('counter'), reusing result: "counter"
 debug: Terminated block@0
 debug: Building IR for function test_cases.simplish.base_class.CallCounter.set_sender_nickname
 debug: Sealing block@0
@@ -585,7 +583,6 @@ debug: Terminated block@3
 debug: Sealing block@4
 debug: Terminated block@4
 debug: Sealing block@5
-simplish/contract.py:35:12 debug: encountered already materialized expression (oca), reusing result: oca#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Created Phi assignment: let oca#1: uint64 = undefined while trying to resolve 'oca' in block@6

--- a/test_cases/simplish/puya_O2.log
+++ b/test_cases/simplish/puya_O2.log
@@ -441,7 +441,6 @@ debug: Terminated block@3
 debug: Sealing block@4
 debug: Terminated block@4
 debug: Sealing block@5
-simplish/contract.py:35:12 debug: encountered already materialized expression (oca), reusing result: oca#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Created Phi assignment: let oca#1: uint64 = undefined while trying to resolve 'oca' in block@6
@@ -564,7 +563,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.simplish.base_class.CallCounter.increment_counter
 debug: Sealing block@0
-simplish/base_class.py:13:9 debug: encountered already materialized expression ('counter'), reusing result: "counter"
 debug: Terminated block@0
 debug: Building IR for function test_cases.simplish.base_class.CallCounter.set_sender_nickname
 debug: Sealing block@0
@@ -584,7 +582,6 @@ debug: Terminated block@3
 debug: Sealing block@4
 debug: Terminated block@4
 debug: Sealing block@5
-simplish/contract.py:35:12 debug: encountered already materialized expression (oca), reusing result: oca#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Created Phi assignment: let oca#1: uint64 = undefined while trying to resolve 'oca' in block@6

--- a/test_cases/simplish/puya_unoptimized.log
+++ b/test_cases/simplish/puya_unoptimized.log
@@ -441,7 +441,6 @@ debug: Terminated block@3
 debug: Sealing block@4
 debug: Terminated block@4
 debug: Sealing block@5
-simplish/contract.py:35:12 debug: encountered already materialized expression (oca), reusing result: oca#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Created Phi assignment: let oca#1: uint64 = undefined while trying to resolve 'oca' in block@6
@@ -564,7 +563,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.simplish.base_class.CallCounter.increment_counter
 debug: Sealing block@0
-simplish/base_class.py:13:9 debug: encountered already materialized expression ('counter'), reusing result: "counter"
 debug: Terminated block@0
 debug: Building IR for function test_cases.simplish.base_class.CallCounter.set_sender_nickname
 debug: Sealing block@0
@@ -584,7 +582,6 @@ debug: Terminated block@3
 debug: Sealing block@4
 debug: Terminated block@4
 debug: Sealing block@5
-simplish/contract.py:35:12 debug: encountered already materialized expression (oca), reusing result: oca#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Created Phi assignment: let oca#1: uint64 = undefined while trying to resolve 'oca' in block@6

--- a/test_cases/state_mutations/puya.log
+++ b/test_cases/state_mutations/puya.log
@@ -463,18 +463,12 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.state_mutations.contract.Contract.append
 debug: Sealing block@0
-state_mutations/contract.py:39:9 debug: encountered already materialized expression ('glob'), reusing result: "glob"
-state_mutations/contract.py:40:9 debug: encountered already materialized expression ('loc'), reusing result: "loc"
 state_mutations/contract.py:40:18 debug: encountered already materialized expression (txn<Sender>()), reusing result: tmp%3#0
-state_mutations/contract.py:41:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 state_mutations/contract.py:42:9 debug: encountered already materialized expression (MapKey(prefix='map', key=txn<Sender>())), reusing result: map_prefixed_key%0#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.state_mutations.contract.Contract.modify
 debug: Sealing block@0
-state_mutations/contract.py:46:9 debug: encountered already materialized expression ('glob'), reusing result: "glob"
-state_mutations/contract.py:47:9 debug: encountered already materialized expression ('loc'), reusing result: "loc"
 state_mutations/contract.py:47:18 debug: encountered already materialized expression (txn<Sender>()), reusing result: tmp%2#0
-state_mutations/contract.py:48:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 state_mutations/contract.py:49:9 debug: encountered already materialized expression (MapKey(prefix='map', key=txn<Sender>())), reusing result: map_prefixed_key%0#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.state_mutations.contract.Contract.get

--- a/test_cases/state_mutations/puya_O2.log
+++ b/test_cases/state_mutations/puya_O2.log
@@ -462,18 +462,12 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.state_mutations.contract.Contract.append
 debug: Sealing block@0
-state_mutations/contract.py:39:9 debug: encountered already materialized expression ('glob'), reusing result: "glob"
-state_mutations/contract.py:40:9 debug: encountered already materialized expression ('loc'), reusing result: "loc"
 state_mutations/contract.py:40:18 debug: encountered already materialized expression (txn<Sender>()), reusing result: tmp%3#0
-state_mutations/contract.py:41:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 state_mutations/contract.py:42:9 debug: encountered already materialized expression (MapKey(prefix='map', key=txn<Sender>())), reusing result: map_prefixed_key%0#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.state_mutations.contract.Contract.modify
 debug: Sealing block@0
-state_mutations/contract.py:46:9 debug: encountered already materialized expression ('glob'), reusing result: "glob"
-state_mutations/contract.py:47:9 debug: encountered already materialized expression ('loc'), reusing result: "loc"
 state_mutations/contract.py:47:18 debug: encountered already materialized expression (txn<Sender>()), reusing result: tmp%2#0
-state_mutations/contract.py:48:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 state_mutations/contract.py:49:9 debug: encountered already materialized expression (MapKey(prefix='map', key=txn<Sender>())), reusing result: map_prefixed_key%0#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.state_mutations.contract.Contract.get

--- a/test_cases/state_mutations/puya_unoptimized.log
+++ b/test_cases/state_mutations/puya_unoptimized.log
@@ -462,18 +462,12 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.state_mutations.contract.Contract.append
 debug: Sealing block@0
-state_mutations/contract.py:39:9 debug: encountered already materialized expression ('glob'), reusing result: "glob"
-state_mutations/contract.py:40:9 debug: encountered already materialized expression ('loc'), reusing result: "loc"
 state_mutations/contract.py:40:18 debug: encountered already materialized expression (txn<Sender>()), reusing result: tmp%3#0
-state_mutations/contract.py:41:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 state_mutations/contract.py:42:9 debug: encountered already materialized expression (MapKey(prefix='map', key=txn<Sender>())), reusing result: map_prefixed_key%0#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.state_mutations.contract.Contract.modify
 debug: Sealing block@0
-state_mutations/contract.py:46:9 debug: encountered already materialized expression ('glob'), reusing result: "glob"
-state_mutations/contract.py:47:9 debug: encountered already materialized expression ('loc'), reusing result: "loc"
 state_mutations/contract.py:47:18 debug: encountered already materialized expression (txn<Sender>()), reusing result: tmp%2#0
-state_mutations/contract.py:48:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 state_mutations/contract.py:49:9 debug: encountered already materialized expression (MapKey(prefix='map', key=txn<Sender>())), reusing result: map_prefixed_key%0#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.state_mutations.contract.Contract.get

--- a/test_cases/stubs/puya.log
+++ b/test_cases/stubs/puya.log
@@ -434,14 +434,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.stubs.uint64.Uint64Contract.approval_program
 debug: Sealing block@0
-stubs/uint64.py:55:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:56:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:57:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:58:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:59:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:60:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:61:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:62:17 debug: encountered already materialized expression (false), reusing result: false#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.stubs.uint64.Uint64Contract.clear_state_program
 debug: Sealing block@0
@@ -451,14 +443,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.stubs.uint64.Uint64Contract.approval_program
 debug: Sealing block@0
-stubs/uint64.py:55:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:56:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:57:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:58:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:59:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:60:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:61:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:62:17 debug: encountered already materialized expression (false), reusing result: false#0
 debug: Terminated block@0
 debug: removing unused subroutine _puya_lib.util.ensure_budget
 debug: removing unused subroutine _puya_lib.bytes_.is_substring
@@ -543,7 +527,6 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-stubs/string.py:26:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:26:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%17#0
 debug: Terminated block@2
 debug: Sealing block@3
@@ -560,7 +543,6 @@ debug: Terminated block@3
 debug: Sealing block@4
 debug: Terminated block@4
 debug: Sealing block@5
-stubs/string.py:27:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:27:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='a')))), reusing result: tmp%21#0
 debug: Terminated block@5
 debug: Sealing block@6
@@ -577,7 +559,6 @@ debug: Terminated block@6
 debug: Sealing block@7
 debug: Terminated block@7
 debug: Sealing block@8
-stubs/string.py:28:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:28:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='ab')))), reusing result: tmp%25#0
 debug: Terminated block@8
 debug: Sealing block@9
@@ -594,7 +575,6 @@ debug: Terminated block@9
 debug: Sealing block@10
 debug: Terminated block@10
 debug: Sealing block@11
-stubs/string.py:29:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:29:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='b')))), reusing result: tmp%29#0
 debug: Terminated block@11
 debug: Sealing block@12
@@ -611,9 +591,7 @@ debug: Terminated block@12
 debug: Sealing block@13
 debug: Terminated block@13
 debug: Sealing block@14
-stubs/string.py:30:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:30:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%34#0
-stubs/string.py:30:33 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 debug: Terminated block@14
 debug: Sealing block@15
 debug: Created Phi assignment: let ternary_result%4#2: bool = undefined while trying to resolve 'ternary_result%4' in block@15
@@ -629,7 +607,6 @@ debug: Terminated block@15
 debug: Sealing block@16
 debug: Terminated block@16
 debug: Sealing block@17
-stubs/string.py:31:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:31:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source=alpha + '!')))), reusing result: tmp%38#0
 debug: Terminated block@17
 debug: Sealing block@18
@@ -646,7 +623,6 @@ debug: Terminated block@18
 debug: Sealing block@19
 debug: Terminated block@19
 debug: Sealing block@20
-stubs/string.py:33:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%44#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%43#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%43#0
@@ -665,7 +641,6 @@ debug: Terminated block@21
 debug: Sealing block@22
 debug: Terminated block@22
 debug: Sealing block@23
-stubs/string.py:34:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%49#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='g')))), reusing result: tmp%48#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='g')))), reusing result: tmp%48#0
@@ -684,7 +659,6 @@ debug: Terminated block@24
 debug: Sealing block@25
 debug: Terminated block@25
 debug: Sealing block@26
-stubs/string.py:35:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%54#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='fg')))), reusing result: tmp%53#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='fg')))), reusing result: tmp%53#0
@@ -703,7 +677,6 @@ debug: Terminated block@27
 debug: Sealing block@28
 debug: Terminated block@28
 debug: Sealing block@29
-stubs/string.py:36:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%59#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='f')))), reusing result: tmp%58#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='f')))), reusing result: tmp%58#0
@@ -722,11 +695,9 @@ debug: Terminated block@30
 debug: Sealing block@31
 debug: Terminated block@31
 debug: Sealing block@32
-stubs/string.py:37:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%65#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%64#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%64#0
-stubs/string.py:37:31 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 debug: Terminated block@32
 debug: Sealing block@33
 debug: Created Phi assignment: let ternary_result%10#2: bool = undefined while trying to resolve 'ternary_result%10' in block@33
@@ -742,7 +713,6 @@ debug: Terminated block@33
 debug: Sealing block@34
 debug: Terminated block@34
 debug: Sealing block@35
-stubs/string.py:38:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%70#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='!' + alpha)))), reusing result: tmp%69#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='!' + alpha)))), reusing result: tmp%69#0
@@ -773,7 +743,6 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-stubs/string.py:26:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:26:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%17#0
 debug: Terminated block@2
 debug: Sealing block@3
@@ -790,7 +759,6 @@ debug: Terminated block@3
 debug: Sealing block@4
 debug: Terminated block@4
 debug: Sealing block@5
-stubs/string.py:27:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:27:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='a')))), reusing result: tmp%21#0
 debug: Terminated block@5
 debug: Sealing block@6
@@ -807,7 +775,6 @@ debug: Terminated block@6
 debug: Sealing block@7
 debug: Terminated block@7
 debug: Sealing block@8
-stubs/string.py:28:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:28:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='ab')))), reusing result: tmp%25#0
 debug: Terminated block@8
 debug: Sealing block@9
@@ -824,7 +791,6 @@ debug: Terminated block@9
 debug: Sealing block@10
 debug: Terminated block@10
 debug: Sealing block@11
-stubs/string.py:29:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:29:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='b')))), reusing result: tmp%29#0
 debug: Terminated block@11
 debug: Sealing block@12
@@ -841,9 +807,7 @@ debug: Terminated block@12
 debug: Sealing block@13
 debug: Terminated block@13
 debug: Sealing block@14
-stubs/string.py:30:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:30:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%34#0
-stubs/string.py:30:33 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 debug: Terminated block@14
 debug: Sealing block@15
 debug: Created Phi assignment: let ternary_result%4#2: bool = undefined while trying to resolve 'ternary_result%4' in block@15
@@ -859,7 +823,6 @@ debug: Terminated block@15
 debug: Sealing block@16
 debug: Terminated block@16
 debug: Sealing block@17
-stubs/string.py:31:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:31:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source=alpha + '!')))), reusing result: tmp%38#0
 debug: Terminated block@17
 debug: Sealing block@18
@@ -876,7 +839,6 @@ debug: Terminated block@18
 debug: Sealing block@19
 debug: Terminated block@19
 debug: Sealing block@20
-stubs/string.py:33:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%44#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%43#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%43#0
@@ -895,7 +857,6 @@ debug: Terminated block@21
 debug: Sealing block@22
 debug: Terminated block@22
 debug: Sealing block@23
-stubs/string.py:34:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%49#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='g')))), reusing result: tmp%48#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='g')))), reusing result: tmp%48#0
@@ -914,7 +875,6 @@ debug: Terminated block@24
 debug: Sealing block@25
 debug: Terminated block@25
 debug: Sealing block@26
-stubs/string.py:35:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%54#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='fg')))), reusing result: tmp%53#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='fg')))), reusing result: tmp%53#0
@@ -933,7 +893,6 @@ debug: Terminated block@27
 debug: Sealing block@28
 debug: Terminated block@28
 debug: Sealing block@29
-stubs/string.py:36:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%59#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='f')))), reusing result: tmp%58#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='f')))), reusing result: tmp%58#0
@@ -952,11 +911,9 @@ debug: Terminated block@30
 debug: Sealing block@31
 debug: Terminated block@31
 debug: Sealing block@32
-stubs/string.py:37:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%65#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%64#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%64#0
-stubs/string.py:37:31 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 debug: Terminated block@32
 debug: Sealing block@33
 debug: Created Phi assignment: let ternary_result%10#2: bool = undefined while trying to resolve 'ternary_result%10' in block@33
@@ -972,7 +929,6 @@ debug: Terminated block@33
 debug: Sealing block@34
 debug: Terminated block@34
 debug: Sealing block@35
-stubs/string.py:38:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%70#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='!' + alpha)))), reusing result: tmp%69#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='!' + alpha)))), reusing result: tmp%69#0
@@ -1069,15 +1025,6 @@ debug: removing unused subroutine test_cases.stubs.string.StringContract.clear_s
 debug: removing unused subroutine algopy._contract.Contract.__init__
 debug: Building IR for function test_cases.stubs.bytes.BytesContract.approval_program
 debug: Sealing block@0
-stubs/bytes.py:38:14 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:40:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:41:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:42:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:43:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:44:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:45:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:46:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:47:17 debug: encountered already materialized expression (false), reusing result: false#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.stubs.bytes.BytesContract.clear_state_program
 debug: Sealing block@0
@@ -1087,15 +1034,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.stubs.bytes.BytesContract.approval_program
 debug: Sealing block@0
-stubs/bytes.py:38:14 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:40:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:41:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:42:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:43:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:44:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:45:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:46:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:47:17 debug: encountered already materialized expression (false), reusing result: false#0
 debug: Terminated block@0
 debug: removing unused subroutine _puya_lib.util.ensure_budget
 debug: removing unused subroutine _puya_lib.bytes_.is_substring

--- a/test_cases/stubs/puya_O2.log
+++ b/test_cases/stubs/puya_O2.log
@@ -433,14 +433,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.stubs.uint64.Uint64Contract.approval_program
 debug: Sealing block@0
-stubs/uint64.py:55:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:56:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:57:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:58:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:59:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:60:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:61:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:62:17 debug: encountered already materialized expression (false), reusing result: false#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.stubs.uint64.Uint64Contract.clear_state_program
 debug: Sealing block@0
@@ -450,14 +442,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.stubs.uint64.Uint64Contract.approval_program
 debug: Sealing block@0
-stubs/uint64.py:55:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:56:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:57:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:58:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:59:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:60:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:61:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:62:17 debug: encountered already materialized expression (false), reusing result: false#0
 debug: Terminated block@0
 debug: removing unused subroutine _puya_lib.util.ensure_budget
 debug: removing unused subroutine _puya_lib.bytes_.is_substring
@@ -542,7 +526,6 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-stubs/string.py:26:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:26:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%17#0
 debug: Terminated block@2
 debug: Sealing block@3
@@ -559,7 +542,6 @@ debug: Terminated block@3
 debug: Sealing block@4
 debug: Terminated block@4
 debug: Sealing block@5
-stubs/string.py:27:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:27:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='a')))), reusing result: tmp%21#0
 debug: Terminated block@5
 debug: Sealing block@6
@@ -576,7 +558,6 @@ debug: Terminated block@6
 debug: Sealing block@7
 debug: Terminated block@7
 debug: Sealing block@8
-stubs/string.py:28:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:28:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='ab')))), reusing result: tmp%25#0
 debug: Terminated block@8
 debug: Sealing block@9
@@ -593,7 +574,6 @@ debug: Terminated block@9
 debug: Sealing block@10
 debug: Terminated block@10
 debug: Sealing block@11
-stubs/string.py:29:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:29:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='b')))), reusing result: tmp%29#0
 debug: Terminated block@11
 debug: Sealing block@12
@@ -610,9 +590,7 @@ debug: Terminated block@12
 debug: Sealing block@13
 debug: Terminated block@13
 debug: Sealing block@14
-stubs/string.py:30:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:30:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%34#0
-stubs/string.py:30:33 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 debug: Terminated block@14
 debug: Sealing block@15
 debug: Created Phi assignment: let ternary_result%4#2: bool = undefined while trying to resolve 'ternary_result%4' in block@15
@@ -628,7 +606,6 @@ debug: Terminated block@15
 debug: Sealing block@16
 debug: Terminated block@16
 debug: Sealing block@17
-stubs/string.py:31:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:31:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source=alpha + '!')))), reusing result: tmp%38#0
 debug: Terminated block@17
 debug: Sealing block@18
@@ -645,7 +622,6 @@ debug: Terminated block@18
 debug: Sealing block@19
 debug: Terminated block@19
 debug: Sealing block@20
-stubs/string.py:33:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%44#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%43#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%43#0
@@ -664,7 +640,6 @@ debug: Terminated block@21
 debug: Sealing block@22
 debug: Terminated block@22
 debug: Sealing block@23
-stubs/string.py:34:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%49#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='g')))), reusing result: tmp%48#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='g')))), reusing result: tmp%48#0
@@ -683,7 +658,6 @@ debug: Terminated block@24
 debug: Sealing block@25
 debug: Terminated block@25
 debug: Sealing block@26
-stubs/string.py:35:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%54#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='fg')))), reusing result: tmp%53#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='fg')))), reusing result: tmp%53#0
@@ -702,7 +676,6 @@ debug: Terminated block@27
 debug: Sealing block@28
 debug: Terminated block@28
 debug: Sealing block@29
-stubs/string.py:36:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%59#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='f')))), reusing result: tmp%58#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='f')))), reusing result: tmp%58#0
@@ -721,11 +694,9 @@ debug: Terminated block@30
 debug: Sealing block@31
 debug: Terminated block@31
 debug: Sealing block@32
-stubs/string.py:37:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%65#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%64#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%64#0
-stubs/string.py:37:31 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 debug: Terminated block@32
 debug: Sealing block@33
 debug: Created Phi assignment: let ternary_result%10#2: bool = undefined while trying to resolve 'ternary_result%10' in block@33
@@ -741,7 +712,6 @@ debug: Terminated block@33
 debug: Sealing block@34
 debug: Terminated block@34
 debug: Sealing block@35
-stubs/string.py:38:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%70#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='!' + alpha)))), reusing result: tmp%69#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='!' + alpha)))), reusing result: tmp%69#0
@@ -772,7 +742,6 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-stubs/string.py:26:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:26:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%17#0
 debug: Terminated block@2
 debug: Sealing block@3
@@ -789,7 +758,6 @@ debug: Terminated block@3
 debug: Sealing block@4
 debug: Terminated block@4
 debug: Sealing block@5
-stubs/string.py:27:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:27:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='a')))), reusing result: tmp%21#0
 debug: Terminated block@5
 debug: Sealing block@6
@@ -806,7 +774,6 @@ debug: Terminated block@6
 debug: Sealing block@7
 debug: Terminated block@7
 debug: Sealing block@8
-stubs/string.py:28:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:28:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='ab')))), reusing result: tmp%25#0
 debug: Terminated block@8
 debug: Sealing block@9
@@ -823,7 +790,6 @@ debug: Terminated block@9
 debug: Sealing block@10
 debug: Terminated block@10
 debug: Sealing block@11
-stubs/string.py:29:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:29:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='b')))), reusing result: tmp%29#0
 debug: Terminated block@11
 debug: Sealing block@12
@@ -840,9 +806,7 @@ debug: Terminated block@12
 debug: Sealing block@13
 debug: Terminated block@13
 debug: Sealing block@14
-stubs/string.py:30:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:30:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%34#0
-stubs/string.py:30:33 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 debug: Terminated block@14
 debug: Sealing block@15
 debug: Created Phi assignment: let ternary_result%4#2: bool = undefined while trying to resolve 'ternary_result%4' in block@15
@@ -858,7 +822,6 @@ debug: Terminated block@15
 debug: Sealing block@16
 debug: Terminated block@16
 debug: Sealing block@17
-stubs/string.py:31:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:31:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source=alpha + '!')))), reusing result: tmp%38#0
 debug: Terminated block@17
 debug: Sealing block@18
@@ -875,7 +838,6 @@ debug: Terminated block@18
 debug: Sealing block@19
 debug: Terminated block@19
 debug: Sealing block@20
-stubs/string.py:33:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%44#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%43#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%43#0
@@ -894,7 +856,6 @@ debug: Terminated block@21
 debug: Sealing block@22
 debug: Terminated block@22
 debug: Sealing block@23
-stubs/string.py:34:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%49#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='g')))), reusing result: tmp%48#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='g')))), reusing result: tmp%48#0
@@ -913,7 +874,6 @@ debug: Terminated block@24
 debug: Sealing block@25
 debug: Terminated block@25
 debug: Sealing block@26
-stubs/string.py:35:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%54#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='fg')))), reusing result: tmp%53#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='fg')))), reusing result: tmp%53#0
@@ -932,7 +892,6 @@ debug: Terminated block@27
 debug: Sealing block@28
 debug: Terminated block@28
 debug: Sealing block@29
-stubs/string.py:36:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%59#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='f')))), reusing result: tmp%58#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='f')))), reusing result: tmp%58#0
@@ -951,11 +910,9 @@ debug: Terminated block@30
 debug: Sealing block@31
 debug: Terminated block@31
 debug: Sealing block@32
-stubs/string.py:37:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%65#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%64#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%64#0
-stubs/string.py:37:31 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 debug: Terminated block@32
 debug: Sealing block@33
 debug: Created Phi assignment: let ternary_result%10#2: bool = undefined while trying to resolve 'ternary_result%10' in block@33
@@ -971,7 +928,6 @@ debug: Terminated block@33
 debug: Sealing block@34
 debug: Terminated block@34
 debug: Sealing block@35
-stubs/string.py:38:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%70#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='!' + alpha)))), reusing result: tmp%69#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='!' + alpha)))), reusing result: tmp%69#0
@@ -1068,15 +1024,6 @@ debug: removing unused subroutine test_cases.stubs.string.StringContract.clear_s
 debug: removing unused subroutine algopy._contract.Contract.__init__
 debug: Building IR for function test_cases.stubs.bytes.BytesContract.approval_program
 debug: Sealing block@0
-stubs/bytes.py:38:14 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:40:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:41:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:42:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:43:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:44:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:45:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:46:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:47:17 debug: encountered already materialized expression (false), reusing result: false#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.stubs.bytes.BytesContract.clear_state_program
 debug: Sealing block@0
@@ -1086,15 +1033,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.stubs.bytes.BytesContract.approval_program
 debug: Sealing block@0
-stubs/bytes.py:38:14 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:40:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:41:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:42:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:43:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:44:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:45:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:46:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:47:17 debug: encountered already materialized expression (false), reusing result: false#0
 debug: Terminated block@0
 debug: removing unused subroutine _puya_lib.util.ensure_budget
 debug: removing unused subroutine _puya_lib.bytes_.is_substring

--- a/test_cases/stubs/puya_unoptimized.log
+++ b/test_cases/stubs/puya_unoptimized.log
@@ -433,14 +433,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.stubs.uint64.Uint64Contract.approval_program
 debug: Sealing block@0
-stubs/uint64.py:55:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:56:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:57:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:58:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:59:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:60:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:61:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:62:17 debug: encountered already materialized expression (false), reusing result: false#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.stubs.uint64.Uint64Contract.clear_state_program
 debug: Sealing block@0
@@ -450,14 +442,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.stubs.uint64.Uint64Contract.approval_program
 debug: Sealing block@0
-stubs/uint64.py:55:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:56:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:57:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:58:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:59:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:60:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/uint64.py:61:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/uint64.py:62:17 debug: encountered already materialized expression (false), reusing result: false#0
 debug: Terminated block@0
 debug: removing unused subroutine _puya_lib.util.ensure_budget
 debug: removing unused subroutine _puya_lib.bytes_.is_substring
@@ -542,7 +526,6 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-stubs/string.py:26:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:26:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%17#0
 debug: Terminated block@2
 debug: Sealing block@3
@@ -559,7 +542,6 @@ debug: Terminated block@3
 debug: Sealing block@4
 debug: Terminated block@4
 debug: Sealing block@5
-stubs/string.py:27:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:27:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='a')))), reusing result: tmp%21#0
 debug: Terminated block@5
 debug: Sealing block@6
@@ -576,7 +558,6 @@ debug: Terminated block@6
 debug: Sealing block@7
 debug: Terminated block@7
 debug: Sealing block@8
-stubs/string.py:28:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:28:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='ab')))), reusing result: tmp%25#0
 debug: Terminated block@8
 debug: Sealing block@9
@@ -593,7 +574,6 @@ debug: Terminated block@9
 debug: Sealing block@10
 debug: Terminated block@10
 debug: Sealing block@11
-stubs/string.py:29:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:29:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='b')))), reusing result: tmp%29#0
 debug: Terminated block@11
 debug: Sealing block@12
@@ -610,9 +590,7 @@ debug: Terminated block@12
 debug: Sealing block@13
 debug: Terminated block@13
 debug: Sealing block@14
-stubs/string.py:30:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:30:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%34#0
-stubs/string.py:30:33 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 debug: Terminated block@14
 debug: Sealing block@15
 debug: Created Phi assignment: let ternary_result%4#2: bool = undefined while trying to resolve 'ternary_result%4' in block@15
@@ -628,7 +606,6 @@ debug: Terminated block@15
 debug: Sealing block@16
 debug: Terminated block@16
 debug: Sealing block@17
-stubs/string.py:31:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:31:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source=alpha + '!')))), reusing result: tmp%38#0
 debug: Terminated block@17
 debug: Sealing block@18
@@ -645,7 +622,6 @@ debug: Terminated block@18
 debug: Sealing block@19
 debug: Terminated block@19
 debug: Sealing block@20
-stubs/string.py:33:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%44#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%43#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%43#0
@@ -664,7 +640,6 @@ debug: Terminated block@21
 debug: Sealing block@22
 debug: Terminated block@22
 debug: Sealing block@23
-stubs/string.py:34:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%49#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='g')))), reusing result: tmp%48#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='g')))), reusing result: tmp%48#0
@@ -683,7 +658,6 @@ debug: Terminated block@24
 debug: Sealing block@25
 debug: Terminated block@25
 debug: Sealing block@26
-stubs/string.py:35:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%54#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='fg')))), reusing result: tmp%53#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='fg')))), reusing result: tmp%53#0
@@ -702,7 +676,6 @@ debug: Terminated block@27
 debug: Sealing block@28
 debug: Terminated block@28
 debug: Sealing block@29
-stubs/string.py:36:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%59#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='f')))), reusing result: tmp%58#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='f')))), reusing result: tmp%58#0
@@ -721,11 +694,9 @@ debug: Terminated block@30
 debug: Sealing block@31
 debug: Terminated block@31
 debug: Sealing block@32
-stubs/string.py:37:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%65#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%64#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%64#0
-stubs/string.py:37:31 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 debug: Terminated block@32
 debug: Sealing block@33
 debug: Created Phi assignment: let ternary_result%10#2: bool = undefined while trying to resolve 'ternary_result%10' in block@33
@@ -741,7 +712,6 @@ debug: Terminated block@33
 debug: Sealing block@34
 debug: Terminated block@34
 debug: Sealing block@35
-stubs/string.py:38:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%70#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='!' + alpha)))), reusing result: tmp%69#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='!' + alpha)))), reusing result: tmp%69#0
@@ -772,7 +742,6 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-stubs/string.py:26:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:26:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%17#0
 debug: Terminated block@2
 debug: Sealing block@3
@@ -789,7 +758,6 @@ debug: Terminated block@3
 debug: Sealing block@4
 debug: Terminated block@4
 debug: Sealing block@5
-stubs/string.py:27:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:27:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='a')))), reusing result: tmp%21#0
 debug: Terminated block@5
 debug: Sealing block@6
@@ -806,7 +774,6 @@ debug: Terminated block@6
 debug: Sealing block@7
 debug: Terminated block@7
 debug: Sealing block@8
-stubs/string.py:28:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:28:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='ab')))), reusing result: tmp%25#0
 debug: Terminated block@8
 debug: Sealing block@9
@@ -823,7 +790,6 @@ debug: Terminated block@9
 debug: Sealing block@10
 debug: Terminated block@10
 debug: Sealing block@11
-stubs/string.py:29:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:29:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='b')))), reusing result: tmp%29#0
 debug: Terminated block@11
 debug: Sealing block@12
@@ -840,9 +806,7 @@ debug: Terminated block@12
 debug: Sealing block@13
 debug: Terminated block@13
 debug: Sealing block@14
-stubs/string.py:30:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:30:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%34#0
-stubs/string.py:30:33 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 debug: Terminated block@14
 debug: Sealing block@15
 debug: Created Phi assignment: let ternary_result%4#2: bool = undefined while trying to resolve 'ternary_result%4' in block@15
@@ -858,7 +822,6 @@ debug: Terminated block@15
 debug: Sealing block@16
 debug: Terminated block@16
 debug: Sealing block@17
-stubs/string.py:31:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:31:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source=alpha + '!')))), reusing result: tmp%38#0
 debug: Terminated block@17
 debug: Sealing block@18
@@ -875,7 +838,6 @@ debug: Terminated block@18
 debug: Sealing block@19
 debug: Terminated block@19
 debug: Sealing block@20
-stubs/string.py:33:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%44#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%43#0
 stubs/string.py:33:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='')))), reusing result: tmp%43#0
@@ -894,7 +856,6 @@ debug: Terminated block@21
 debug: Sealing block@22
 debug: Terminated block@22
 debug: Sealing block@23
-stubs/string.py:34:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%49#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='g')))), reusing result: tmp%48#0
 stubs/string.py:34:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='g')))), reusing result: tmp%48#0
@@ -913,7 +874,6 @@ debug: Terminated block@24
 debug: Sealing block@25
 debug: Terminated block@25
 debug: Sealing block@26
-stubs/string.py:35:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%54#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='fg')))), reusing result: tmp%53#0
 stubs/string.py:35:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='fg')))), reusing result: tmp%53#0
@@ -932,7 +892,6 @@ debug: Terminated block@27
 debug: Sealing block@28
 debug: Terminated block@28
 debug: Sealing block@29
-stubs/string.py:36:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%59#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='f')))), reusing result: tmp%58#0
 stubs/string.py:36:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='f')))), reusing result: tmp%58#0
@@ -951,11 +910,9 @@ debug: Terminated block@30
 debug: Sealing block@31
 debug: Terminated block@31
 debug: Sealing block@32
-stubs/string.py:37:16 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%65#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%64#0
 stubs/string.py:37:16 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%64#0
-stubs/string.py:37:31 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 debug: Terminated block@32
 debug: Sealing block@33
 debug: Created Phi assignment: let ternary_result%10#2: bool = undefined while trying to resolve 'ternary_result%10' in block@33
@@ -971,7 +928,6 @@ debug: Terminated block@33
 debug: Sealing block@34
 debug: Terminated block@34
 debug: Sealing block@35
-stubs/string.py:38:20 debug: encountered already materialized expression (alpha), reusing result: alpha#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(alpha))), reusing result: tmp%70#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='!' + alpha)))), reusing result: tmp%69#0
 stubs/string.py:38:20 debug: encountered already materialized expression (len(reinterpret_cast<bytes>(SINGLE_EVAL(id=0, source='!' + alpha)))), reusing result: tmp%69#0
@@ -1068,15 +1024,6 @@ debug: removing unused subroutine test_cases.stubs.string.StringContract.clear_s
 debug: removing unused subroutine algopy._contract.Contract.__init__
 debug: Building IR for function test_cases.stubs.bytes.BytesContract.approval_program
 debug: Sealing block@0
-stubs/bytes.py:38:14 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:40:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:41:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:42:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:43:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:44:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:45:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:46:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:47:17 debug: encountered already materialized expression (false), reusing result: false#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.stubs.bytes.BytesContract.clear_state_program
 debug: Sealing block@0
@@ -1086,15 +1033,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.stubs.bytes.BytesContract.approval_program
 debug: Sealing block@0
-stubs/bytes.py:38:14 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:40:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:41:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:42:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:43:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:44:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:45:17 debug: encountered already materialized expression (true), reusing result: true#0
-stubs/bytes.py:46:17 debug: encountered already materialized expression (false), reusing result: false#0
-stubs/bytes.py:47:17 debug: encountered already materialized expression (false), reusing result: false#0
 debug: Terminated block@0
 debug: removing unused subroutine _puya_lib.util.ensure_budget
 debug: removing unused subroutine _puya_lib.bytes_.is_substring

--- a/test_cases/tuple_support/puya.log
+++ b/test_cases/tuple_support/puya.log
@@ -428,15 +428,10 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_support.bin_ops
 debug: Sealing block@0
-tuple_support/tuple_support.py:96:10 debug: encountered already materialized expression (1u), reusing result: 1u
-tuple_support/tuple_support.py:96:10 debug: encountered already materialized expression (1u), reusing result: 1u
-tuple_support/tuple_support.py:102:9 debug: encountered already materialized expression (tup), reusing result: (tup.0#0, tup.1#0)
 tuple_support/tuple_support.py:102:9 debug: encountered already materialized expression (tup[0]), reusing result: tup.0#0
 tuple_support/tuple_support.py:102:9 debug: encountered already materialized expression (tup[1]), reusing result: tup.1#0
 tuple_support/tuple_support.py:102:9 debug: encountered already materialized expression (tup[0]), reusing result: tup.0#0
 tuple_support/tuple_support.py:102:9 debug: encountered already materialized expression (tup[1]), reusing result: tup.1#0
-tuple_support/tuple_support.py:115:9 debug: encountered already materialized expression (tup), reusing result: (tup.0#0, tup.1#0)
-tuple_support/tuple_support.py:115:15 debug: encountered already materialized expression (tup), reusing result: (tup.0#0, tup.1#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_support.bytes_combine
 debug: Sealing block@0
@@ -503,8 +498,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_support.slicing
 debug: Sealing block@0
-tuple_support/tuple_support.py:175:12 debug: encountered already materialized expression (one_to_three), reusing result: (one_to_three.0#0, one_to_three.1#0, one_to_three.2#0)
-tuple_support/tuple_support.py:175:12 debug: encountered already materialized expression (one_to_three), reusing result: (one_to_three.0#0, one_to_three.1#0, one_to_three.2#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_support.test_empty
 debug: Sealing block@0
@@ -680,7 +673,6 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-tuple_support/tuple_support.py:18:17 debug: encountered already materialized expression (3u), reusing result: 3u
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -798,7 +790,6 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-tuple_support/tuple_support.py:18:17 debug: encountered already materialized expression (3u), reusing result: 3u
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1061,22 +1052,18 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_storage.NestedTuplesStorage.mutate_tuple
 debug: Sealing block@0
 tuple_support/tuple_storage.py:30:9 debug: encountered already materialized expression (GlobalState['tup']), reusing result: (tmp%0#0, tmp%1#0)
-tuple_support/tuple_storage.py:30:9 debug: encountered already materialized expression ('tup'), reusing result: "tup"
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_storage.NestedTuplesStorage.mutate_box
 debug: Sealing block@0
 tuple_support/tuple_storage.py:34:9 debug: encountered already materialized expression (Box['box']), reusing result: (tmp%0#0, tmp%1#0)
-tuple_support/tuple_storage.py:34:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_storage.NestedTuplesStorage.mutate_global
 debug: Sealing block@0
 tuple_support/tuple_storage.py:38:9 debug: encountered already materialized expression (GlobalState['glob']), reusing result: (tmp%0#0, tmp%1#0)
-tuple_support/tuple_storage.py:38:9 debug: encountered already materialized expression ('glob'), reusing result: "glob"
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_storage.NestedTuplesStorage.mutate_local
 debug: Sealing block@0
 tuple_support/tuple_storage.py:42:9 debug: encountered already materialized expression (LocalState['loc', txn<Sender>()]), reusing result: (tmp%1#0, tmp%2#0)
-tuple_support/tuple_storage.py:42:9 debug: encountered already materialized expression ('loc'), reusing result: "loc"
 tuple_support/tuple_storage.py:42:18 debug: encountered already materialized expression (txn<Sender>()), reusing result: tmp%0#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_storage.NestedTuplesStorage.__algopy_default_create
@@ -1558,7 +1545,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.nested_tuples.NestedTuples.run_tests
 debug: Sealing block@0
-tuple_support/nested_tuples.py:142:24 debug: encountered already materialized expression (y), reusing result: (y.0#0, y.1.0#0, y.1.1#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.nested_tuples.NestedTuples.nested_tuple_params
 debug: Sealing block@0
@@ -1571,7 +1557,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.nested_tuples.NestedTuples.build_nested
 debug: Sealing block@0
-tuple_support/nested_tuples.py:168:9 debug: encountered already materialized expression ('build_nested_call_count'), reusing result: "build_nested_call_count"
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.nested_tuples.NestedTuples.test_single_evaluation_nested
 debug: Sealing block@0

--- a/test_cases/tuple_support/puya_O2.log
+++ b/test_cases/tuple_support/puya_O2.log
@@ -427,15 +427,10 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_support.bin_ops
 debug: Sealing block@0
-tuple_support/tuple_support.py:96:10 debug: encountered already materialized expression (1u), reusing result: 1u
-tuple_support/tuple_support.py:96:10 debug: encountered already materialized expression (1u), reusing result: 1u
-tuple_support/tuple_support.py:102:9 debug: encountered already materialized expression (tup), reusing result: (tup.0#0, tup.1#0)
 tuple_support/tuple_support.py:102:9 debug: encountered already materialized expression (tup[0]), reusing result: tup.0#0
 tuple_support/tuple_support.py:102:9 debug: encountered already materialized expression (tup[1]), reusing result: tup.1#0
 tuple_support/tuple_support.py:102:9 debug: encountered already materialized expression (tup[0]), reusing result: tup.0#0
 tuple_support/tuple_support.py:102:9 debug: encountered already materialized expression (tup[1]), reusing result: tup.1#0
-tuple_support/tuple_support.py:115:9 debug: encountered already materialized expression (tup), reusing result: (tup.0#0, tup.1#0)
-tuple_support/tuple_support.py:115:15 debug: encountered already materialized expression (tup), reusing result: (tup.0#0, tup.1#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_support.bytes_combine
 debug: Sealing block@0
@@ -502,8 +497,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_support.slicing
 debug: Sealing block@0
-tuple_support/tuple_support.py:175:12 debug: encountered already materialized expression (one_to_three), reusing result: (one_to_three.0#0, one_to_three.1#0, one_to_three.2#0)
-tuple_support/tuple_support.py:175:12 debug: encountered already materialized expression (one_to_three), reusing result: (one_to_three.0#0, one_to_three.1#0, one_to_three.2#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_support.test_empty
 debug: Sealing block@0
@@ -679,7 +672,6 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-tuple_support/tuple_support.py:18:17 debug: encountered already materialized expression (3u), reusing result: 3u
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -797,7 +789,6 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-tuple_support/tuple_support.py:18:17 debug: encountered already materialized expression (3u), reusing result: 3u
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1060,22 +1051,18 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_storage.NestedTuplesStorage.mutate_tuple
 debug: Sealing block@0
 tuple_support/tuple_storage.py:30:9 debug: encountered already materialized expression (GlobalState['tup']), reusing result: (tmp%0#0, tmp%1#0)
-tuple_support/tuple_storage.py:30:9 debug: encountered already materialized expression ('tup'), reusing result: "tup"
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_storage.NestedTuplesStorage.mutate_box
 debug: Sealing block@0
 tuple_support/tuple_storage.py:34:9 debug: encountered already materialized expression (Box['box']), reusing result: (tmp%0#0, tmp%1#0)
-tuple_support/tuple_storage.py:34:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_storage.NestedTuplesStorage.mutate_global
 debug: Sealing block@0
 tuple_support/tuple_storage.py:38:9 debug: encountered already materialized expression (GlobalState['glob']), reusing result: (tmp%0#0, tmp%1#0)
-tuple_support/tuple_storage.py:38:9 debug: encountered already materialized expression ('glob'), reusing result: "glob"
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_storage.NestedTuplesStorage.mutate_local
 debug: Sealing block@0
 tuple_support/tuple_storage.py:42:9 debug: encountered already materialized expression (LocalState['loc', txn<Sender>()]), reusing result: (tmp%1#0, tmp%2#0)
-tuple_support/tuple_storage.py:42:9 debug: encountered already materialized expression ('loc'), reusing result: "loc"
 tuple_support/tuple_storage.py:42:18 debug: encountered already materialized expression (txn<Sender>()), reusing result: tmp%0#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_storage.NestedTuplesStorage.__algopy_default_create
@@ -1557,7 +1544,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.nested_tuples.NestedTuples.run_tests
 debug: Sealing block@0
-tuple_support/nested_tuples.py:142:24 debug: encountered already materialized expression (y), reusing result: (y.0#0, y.1.0#0, y.1.1#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.nested_tuples.NestedTuples.nested_tuple_params
 debug: Sealing block@0
@@ -1570,7 +1556,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.nested_tuples.NestedTuples.build_nested
 debug: Sealing block@0
-tuple_support/nested_tuples.py:168:9 debug: encountered already materialized expression ('build_nested_call_count'), reusing result: "build_nested_call_count"
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.nested_tuples.NestedTuples.test_single_evaluation_nested
 debug: Sealing block@0

--- a/test_cases/tuple_support/puya_unoptimized.log
+++ b/test_cases/tuple_support/puya_unoptimized.log
@@ -427,15 +427,10 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_support.bin_ops
 debug: Sealing block@0
-tuple_support/tuple_support.py:96:10 debug: encountered already materialized expression (1u), reusing result: 1u
-tuple_support/tuple_support.py:96:10 debug: encountered already materialized expression (1u), reusing result: 1u
-tuple_support/tuple_support.py:102:9 debug: encountered already materialized expression (tup), reusing result: (tup.0#0, tup.1#0)
 tuple_support/tuple_support.py:102:9 debug: encountered already materialized expression (tup[0]), reusing result: tup.0#0
 tuple_support/tuple_support.py:102:9 debug: encountered already materialized expression (tup[1]), reusing result: tup.1#0
 tuple_support/tuple_support.py:102:9 debug: encountered already materialized expression (tup[0]), reusing result: tup.0#0
 tuple_support/tuple_support.py:102:9 debug: encountered already materialized expression (tup[1]), reusing result: tup.1#0
-tuple_support/tuple_support.py:115:9 debug: encountered already materialized expression (tup), reusing result: (tup.0#0, tup.1#0)
-tuple_support/tuple_support.py:115:15 debug: encountered already materialized expression (tup), reusing result: (tup.0#0, tup.1#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_support.bytes_combine
 debug: Sealing block@0
@@ -502,8 +497,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_support.slicing
 debug: Sealing block@0
-tuple_support/tuple_support.py:175:12 debug: encountered already materialized expression (one_to_three), reusing result: (one_to_three.0#0, one_to_three.1#0, one_to_three.2#0)
-tuple_support/tuple_support.py:175:12 debug: encountered already materialized expression (one_to_three), reusing result: (one_to_three.0#0, one_to_three.1#0, one_to_three.2#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_support.test_empty
 debug: Sealing block@0
@@ -679,7 +672,6 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-tuple_support/tuple_support.py:18:17 debug: encountered already materialized expression (3u), reusing result: 3u
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -797,7 +789,6 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-tuple_support/tuple_support.py:18:17 debug: encountered already materialized expression (3u), reusing result: 3u
 debug: Terminated block@2
 debug: Sealing block@3
 debug: Terminated block@3
@@ -1060,22 +1051,18 @@ debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_storage.NestedTuplesStorage.mutate_tuple
 debug: Sealing block@0
 tuple_support/tuple_storage.py:30:9 debug: encountered already materialized expression (GlobalState['tup']), reusing result: (tmp%0#0, tmp%1#0)
-tuple_support/tuple_storage.py:30:9 debug: encountered already materialized expression ('tup'), reusing result: "tup"
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_storage.NestedTuplesStorage.mutate_box
 debug: Sealing block@0
 tuple_support/tuple_storage.py:34:9 debug: encountered already materialized expression (Box['box']), reusing result: (tmp%0#0, tmp%1#0)
-tuple_support/tuple_storage.py:34:9 debug: encountered already materialized expression ('box'), reusing result: "box"
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_storage.NestedTuplesStorage.mutate_global
 debug: Sealing block@0
 tuple_support/tuple_storage.py:38:9 debug: encountered already materialized expression (GlobalState['glob']), reusing result: (tmp%0#0, tmp%1#0)
-tuple_support/tuple_storage.py:38:9 debug: encountered already materialized expression ('glob'), reusing result: "glob"
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_storage.NestedTuplesStorage.mutate_local
 debug: Sealing block@0
 tuple_support/tuple_storage.py:42:9 debug: encountered already materialized expression (LocalState['loc', txn<Sender>()]), reusing result: (tmp%1#0, tmp%2#0)
-tuple_support/tuple_storage.py:42:9 debug: encountered already materialized expression ('loc'), reusing result: "loc"
 tuple_support/tuple_storage.py:42:18 debug: encountered already materialized expression (txn<Sender>()), reusing result: tmp%0#0
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.tuple_storage.NestedTuplesStorage.__algopy_default_create
@@ -1557,7 +1544,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.nested_tuples.NestedTuples.run_tests
 debug: Sealing block@0
-tuple_support/nested_tuples.py:142:24 debug: encountered already materialized expression (y), reusing result: (y.0#0, y.1.0#0, y.1.1#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.nested_tuples.NestedTuples.nested_tuple_params
 debug: Sealing block@0
@@ -1570,7 +1556,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.nested_tuples.NestedTuples.build_nested
 debug: Sealing block@0
-tuple_support/nested_tuples.py:168:9 debug: encountered already materialized expression ('build_nested_call_count'), reusing result: "build_nested_call_count"
 debug: Terminated block@0
 debug: Building IR for function test_cases.tuple_support.nested_tuples.NestedTuples.test_single_evaluation_nested
 debug: Sealing block@0

--- a/test_cases/typed_abi_call/puya.log
+++ b/test_cases/typed_abi_call/puya.log
@@ -562,7 +562,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_abi_call.logger.Logger.log_asset_account_app
 debug: Sealing block@0
-typed_abi_call/logger.py:67:9 debug: encountered already materialized expression (''), reusing result: ""
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_abi_call.logger.Logger.log_address
 debug: Sealing block@0
@@ -596,8 +595,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_abi_call.logger.Logger.logs_are_equal
 debug: Sealing block@0
-typed_abi_call/logger.py:164:16 debug: encountered already materialized expression (log_1), reusing result: (log_1.level#0, log_1.message#0)
-typed_abi_call/logger.py:164:25 debug: encountered already materialized expression (log_2), reusing result: (log_2.level#0, log_2.message#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_abi_call.logger.Logger.echo_log_struct
 debug: Sealing block@0
@@ -944,28 +941,10 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-typed_abi_call/typed_c2c.py:276:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_abi_call/typed_c2c.py:276:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:276:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_abi_call/typed_c2c.py:276:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:276:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_abi_call/typed_c2c.py:276:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@2
 debug: Sealing block@3
-typed_abi_call/typed_c2c.py:287:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_abi_call/typed_c2c.py:287:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:287:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_abi_call/typed_c2c.py:287:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:287:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_abi_call/typed_c2c.py:287:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@3
 debug: Sealing block@4
-typed_abi_call/typed_c2c.py:298:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_abi_call/typed_c2c.py:298:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:298:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_abi_call/typed_c2c.py:298:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:298:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_abi_call/typed_c2c.py:298:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@4
 debug: Building IR for function test_cases.typed_abi_call.typed_c2c.Greeter.test_nested_tuples
 debug: Sealing block@0
@@ -1001,28 +980,16 @@ debug: Building IR for function test_cases.typed_abi_call.typed_c2c.Greeter.test
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-typed_abi_call/typed_c2c.py:392:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0)
-typed_abi_call/typed_c2c.py:392:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0)
 debug: Terminated block@1
 debug: Sealing block@2
-typed_abi_call/typed_c2c.py:397:16 debug: encountered already materialized expression (result), reusing result: (result.0#1, result.1#1, result.2#1)
-typed_abi_call/typed_c2c.py:397:16 debug: encountered already materialized expression (result), reusing result: (result.0#1, result.1#1, result.2#1)
 debug: Terminated block@2
 debug: Sealing block@3
-typed_abi_call/typed_c2c.py:402:16 debug: encountered already materialized expression (result), reusing result: (result.0#2, result.1#2, result.2#2)
-typed_abi_call/typed_c2c.py:402:16 debug: encountered already materialized expression (result), reusing result: (result.0#2, result.1#2, result.2#2)
 debug: Terminated block@3
 debug: Sealing block@4
-typed_abi_call/typed_c2c.py:407:16 debug: encountered already materialized expression (result), reusing result: (result.0#3, result.1#3, result.2#3)
-typed_abi_call/typed_c2c.py:407:16 debug: encountered already materialized expression (result), reusing result: (result.0#3, result.1#3, result.2#3)
 debug: Terminated block@4
 debug: Sealing block@5
-typed_abi_call/typed_c2c.py:416:16 debug: encountered already materialized expression (result), reusing result: (result.0#4, result.1#4, result.2#4)
-typed_abi_call/typed_c2c.py:416:16 debug: encountered already materialized expression (result), reusing result: (result.0#4, result.1#4, result.2#4)
 debug: Terminated block@5
 debug: Sealing block@6
-typed_abi_call/typed_c2c.py:425:16 debug: encountered already materialized expression (result), reusing result: (result.0#5, result.1#5, result.2#5)
-typed_abi_call/typed_c2c.py:425:16 debug: encountered already materialized expression (result), reusing result: (result.0#5, result.1#5, result.2#5)
 debug: Terminated block@6
 debug: Building IR for function test_cases.typed_abi_call.typed_c2c.Greeter.__algopy_default_create
 debug: Sealing block@0

--- a/test_cases/typed_abi_call/puya_O2.log
+++ b/test_cases/typed_abi_call/puya_O2.log
@@ -561,7 +561,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_abi_call.logger.Logger.log_asset_account_app
 debug: Sealing block@0
-typed_abi_call/logger.py:67:9 debug: encountered already materialized expression (''), reusing result: ""
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_abi_call.logger.Logger.log_address
 debug: Sealing block@0
@@ -595,8 +594,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_abi_call.logger.Logger.logs_are_equal
 debug: Sealing block@0
-typed_abi_call/logger.py:164:16 debug: encountered already materialized expression (log_1), reusing result: (log_1.level#0, log_1.message#0)
-typed_abi_call/logger.py:164:25 debug: encountered already materialized expression (log_2), reusing result: (log_2.level#0, log_2.message#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_abi_call.logger.Logger.echo_log_struct
 debug: Sealing block@0
@@ -943,28 +940,10 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-typed_abi_call/typed_c2c.py:276:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_abi_call/typed_c2c.py:276:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:276:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_abi_call/typed_c2c.py:276:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:276:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_abi_call/typed_c2c.py:276:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@2
 debug: Sealing block@3
-typed_abi_call/typed_c2c.py:287:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_abi_call/typed_c2c.py:287:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:287:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_abi_call/typed_c2c.py:287:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:287:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_abi_call/typed_c2c.py:287:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@3
 debug: Sealing block@4
-typed_abi_call/typed_c2c.py:298:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_abi_call/typed_c2c.py:298:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:298:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_abi_call/typed_c2c.py:298:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:298:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_abi_call/typed_c2c.py:298:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@4
 debug: Building IR for function test_cases.typed_abi_call.typed_c2c.Greeter.test_nested_tuples
 debug: Sealing block@0
@@ -1000,28 +979,16 @@ debug: Building IR for function test_cases.typed_abi_call.typed_c2c.Greeter.test
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-typed_abi_call/typed_c2c.py:392:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0)
-typed_abi_call/typed_c2c.py:392:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0)
 debug: Terminated block@1
 debug: Sealing block@2
-typed_abi_call/typed_c2c.py:397:16 debug: encountered already materialized expression (result), reusing result: (result.0#1, result.1#1, result.2#1)
-typed_abi_call/typed_c2c.py:397:16 debug: encountered already materialized expression (result), reusing result: (result.0#1, result.1#1, result.2#1)
 debug: Terminated block@2
 debug: Sealing block@3
-typed_abi_call/typed_c2c.py:402:16 debug: encountered already materialized expression (result), reusing result: (result.0#2, result.1#2, result.2#2)
-typed_abi_call/typed_c2c.py:402:16 debug: encountered already materialized expression (result), reusing result: (result.0#2, result.1#2, result.2#2)
 debug: Terminated block@3
 debug: Sealing block@4
-typed_abi_call/typed_c2c.py:407:16 debug: encountered already materialized expression (result), reusing result: (result.0#3, result.1#3, result.2#3)
-typed_abi_call/typed_c2c.py:407:16 debug: encountered already materialized expression (result), reusing result: (result.0#3, result.1#3, result.2#3)
 debug: Terminated block@4
 debug: Sealing block@5
-typed_abi_call/typed_c2c.py:416:16 debug: encountered already materialized expression (result), reusing result: (result.0#4, result.1#4, result.2#4)
-typed_abi_call/typed_c2c.py:416:16 debug: encountered already materialized expression (result), reusing result: (result.0#4, result.1#4, result.2#4)
 debug: Terminated block@5
 debug: Sealing block@6
-typed_abi_call/typed_c2c.py:425:16 debug: encountered already materialized expression (result), reusing result: (result.0#5, result.1#5, result.2#5)
-typed_abi_call/typed_c2c.py:425:16 debug: encountered already materialized expression (result), reusing result: (result.0#5, result.1#5, result.2#5)
 debug: Terminated block@6
 debug: Building IR for function test_cases.typed_abi_call.typed_c2c.Greeter.__algopy_default_create
 debug: Sealing block@0

--- a/test_cases/typed_abi_call/puya_unoptimized.log
+++ b/test_cases/typed_abi_call/puya_unoptimized.log
@@ -561,7 +561,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_abi_call.logger.Logger.log_asset_account_app
 debug: Sealing block@0
-typed_abi_call/logger.py:67:9 debug: encountered already materialized expression (''), reusing result: ""
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_abi_call.logger.Logger.log_address
 debug: Sealing block@0
@@ -595,8 +594,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_abi_call.logger.Logger.logs_are_equal
 debug: Sealing block@0
-typed_abi_call/logger.py:164:16 debug: encountered already materialized expression (log_1), reusing result: (log_1.level#0, log_1.message#0)
-typed_abi_call/logger.py:164:25 debug: encountered already materialized expression (log_2), reusing result: (log_2.level#0, log_2.message#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_abi_call.logger.Logger.echo_log_struct
 debug: Sealing block@0
@@ -943,28 +940,10 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-typed_abi_call/typed_c2c.py:276:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_abi_call/typed_c2c.py:276:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:276:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_abi_call/typed_c2c.py:276:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:276:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_abi_call/typed_c2c.py:276:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@2
 debug: Sealing block@3
-typed_abi_call/typed_c2c.py:287:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_abi_call/typed_c2c.py:287:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:287:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_abi_call/typed_c2c.py:287:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:287:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_abi_call/typed_c2c.py:287:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@3
 debug: Sealing block@4
-typed_abi_call/typed_c2c.py:298:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_abi_call/typed_c2c.py:298:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:298:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_abi_call/typed_c2c.py:298:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_abi_call/typed_c2c.py:298:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_abi_call/typed_c2c.py:298:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@4
 debug: Building IR for function test_cases.typed_abi_call.typed_c2c.Greeter.test_nested_tuples
 debug: Sealing block@0
@@ -1000,28 +979,16 @@ debug: Building IR for function test_cases.typed_abi_call.typed_c2c.Greeter.test
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-typed_abi_call/typed_c2c.py:392:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0)
-typed_abi_call/typed_c2c.py:392:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0)
 debug: Terminated block@1
 debug: Sealing block@2
-typed_abi_call/typed_c2c.py:397:16 debug: encountered already materialized expression (result), reusing result: (result.0#1, result.1#1, result.2#1)
-typed_abi_call/typed_c2c.py:397:16 debug: encountered already materialized expression (result), reusing result: (result.0#1, result.1#1, result.2#1)
 debug: Terminated block@2
 debug: Sealing block@3
-typed_abi_call/typed_c2c.py:402:16 debug: encountered already materialized expression (result), reusing result: (result.0#2, result.1#2, result.2#2)
-typed_abi_call/typed_c2c.py:402:16 debug: encountered already materialized expression (result), reusing result: (result.0#2, result.1#2, result.2#2)
 debug: Terminated block@3
 debug: Sealing block@4
-typed_abi_call/typed_c2c.py:407:16 debug: encountered already materialized expression (result), reusing result: (result.0#3, result.1#3, result.2#3)
-typed_abi_call/typed_c2c.py:407:16 debug: encountered already materialized expression (result), reusing result: (result.0#3, result.1#3, result.2#3)
 debug: Terminated block@4
 debug: Sealing block@5
-typed_abi_call/typed_c2c.py:416:16 debug: encountered already materialized expression (result), reusing result: (result.0#4, result.1#4, result.2#4)
-typed_abi_call/typed_c2c.py:416:16 debug: encountered already materialized expression (result), reusing result: (result.0#4, result.1#4, result.2#4)
 debug: Terminated block@5
 debug: Sealing block@6
-typed_abi_call/typed_c2c.py:425:16 debug: encountered already materialized expression (result), reusing result: (result.0#5, result.1#5, result.2#5)
-typed_abi_call/typed_c2c.py:425:16 debug: encountered already materialized expression (result), reusing result: (result.0#5, result.1#5, result.2#5)
 debug: Terminated block@6
 debug: Building IR for function test_cases.typed_abi_call.typed_c2c.Greeter.__algopy_default_create
 debug: Sealing block@0

--- a/test_cases/typed_itxn_abi_call/puya.log
+++ b/test_cases/typed_itxn_abi_call/puya.log
@@ -562,7 +562,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_itxn_abi_call.logger.Logger.log_asset_account_app
 debug: Sealing block@0
-typed_itxn_abi_call/logger.py:67:9 debug: encountered already materialized expression (''), reusing result: ""
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_itxn_abi_call.logger.Logger.log_address
 debug: Sealing block@0
@@ -596,8 +595,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_itxn_abi_call.logger.Logger.logs_are_equal
 debug: Sealing block@0
-typed_itxn_abi_call/logger.py:164:16 debug: encountered already materialized expression (log_1), reusing result: (log_1.level#0, log_1.message#0)
-typed_itxn_abi_call/logger.py:164:25 debug: encountered already materialized expression (log_2), reusing result: (log_2.level#0, log_2.message#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_itxn_abi_call.logger.Logger.echo_log_struct
 debug: Sealing block@0
@@ -950,28 +947,10 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-typed_itxn_abi_call/typed_c2c.py:334:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_itxn_abi_call/typed_c2c.py:334:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:334:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_itxn_abi_call/typed_c2c.py:334:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:334:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_itxn_abi_call/typed_c2c.py:334:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@2
 debug: Sealing block@3
-typed_itxn_abi_call/typed_c2c.py:349:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_itxn_abi_call/typed_c2c.py:349:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:349:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_itxn_abi_call/typed_c2c.py:349:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:349:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_itxn_abi_call/typed_c2c.py:349:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@3
 debug: Sealing block@4
-typed_itxn_abi_call/typed_c2c.py:364:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_itxn_abi_call/typed_c2c.py:364:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:364:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_itxn_abi_call/typed_c2c.py:364:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:364:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_itxn_abi_call/typed_c2c.py:364:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@4
 debug: Building IR for function test_cases.typed_itxn_abi_call.typed_c2c.Greeter.test_nested_tuples
 debug: Sealing block@0
@@ -1007,28 +986,16 @@ debug: Building IR for function test_cases.typed_itxn_abi_call.typed_c2c.Greeter
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-typed_itxn_abi_call/typed_c2c.py:480:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0)
-typed_itxn_abi_call/typed_c2c.py:480:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0)
 debug: Terminated block@1
 debug: Sealing block@2
-typed_itxn_abi_call/typed_c2c.py:487:16 debug: encountered already materialized expression (result), reusing result: (result.0#1, result.1#1, result.2#1)
-typed_itxn_abi_call/typed_c2c.py:487:16 debug: encountered already materialized expression (result), reusing result: (result.0#1, result.1#1, result.2#1)
 debug: Terminated block@2
 debug: Sealing block@3
-typed_itxn_abi_call/typed_c2c.py:494:16 debug: encountered already materialized expression (result), reusing result: (result.0#2, result.1#2, result.2#2)
-typed_itxn_abi_call/typed_c2c.py:494:16 debug: encountered already materialized expression (result), reusing result: (result.0#2, result.1#2, result.2#2)
 debug: Terminated block@3
 debug: Sealing block@4
-typed_itxn_abi_call/typed_c2c.py:501:16 debug: encountered already materialized expression (result), reusing result: (result.0#3, result.1#3, result.2#3)
-typed_itxn_abi_call/typed_c2c.py:501:16 debug: encountered already materialized expression (result), reusing result: (result.0#3, result.1#3, result.2#3)
 debug: Terminated block@4
 debug: Sealing block@5
-typed_itxn_abi_call/typed_c2c.py:514:16 debug: encountered already materialized expression (result), reusing result: (result.0#4, result.1#4, result.2#4)
-typed_itxn_abi_call/typed_c2c.py:514:16 debug: encountered already materialized expression (result), reusing result: (result.0#4, result.1#4, result.2#4)
 debug: Terminated block@5
 debug: Sealing block@6
-typed_itxn_abi_call/typed_c2c.py:527:16 debug: encountered already materialized expression (result), reusing result: (result.0#5, result.1#5, result.2#5)
-typed_itxn_abi_call/typed_c2c.py:527:16 debug: encountered already materialized expression (result), reusing result: (result.0#5, result.1#5, result.2#5)
 debug: Terminated block@6
 debug: Building IR for function test_cases.typed_itxn_abi_call.typed_c2c.Greeter.__algopy_default_create
 debug: Sealing block@0

--- a/test_cases/typed_itxn_abi_call/puya_O2.log
+++ b/test_cases/typed_itxn_abi_call/puya_O2.log
@@ -561,7 +561,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_itxn_abi_call.logger.Logger.log_asset_account_app
 debug: Sealing block@0
-typed_itxn_abi_call/logger.py:67:9 debug: encountered already materialized expression (''), reusing result: ""
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_itxn_abi_call.logger.Logger.log_address
 debug: Sealing block@0
@@ -595,8 +594,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_itxn_abi_call.logger.Logger.logs_are_equal
 debug: Sealing block@0
-typed_itxn_abi_call/logger.py:164:16 debug: encountered already materialized expression (log_1), reusing result: (log_1.level#0, log_1.message#0)
-typed_itxn_abi_call/logger.py:164:25 debug: encountered already materialized expression (log_2), reusing result: (log_2.level#0, log_2.message#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_itxn_abi_call.logger.Logger.echo_log_struct
 debug: Sealing block@0
@@ -949,28 +946,10 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-typed_itxn_abi_call/typed_c2c.py:334:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_itxn_abi_call/typed_c2c.py:334:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:334:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_itxn_abi_call/typed_c2c.py:334:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:334:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_itxn_abi_call/typed_c2c.py:334:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@2
 debug: Sealing block@3
-typed_itxn_abi_call/typed_c2c.py:349:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_itxn_abi_call/typed_c2c.py:349:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:349:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_itxn_abi_call/typed_c2c.py:349:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:349:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_itxn_abi_call/typed_c2c.py:349:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@3
 debug: Sealing block@4
-typed_itxn_abi_call/typed_c2c.py:364:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_itxn_abi_call/typed_c2c.py:364:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:364:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_itxn_abi_call/typed_c2c.py:364:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:364:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_itxn_abi_call/typed_c2c.py:364:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@4
 debug: Building IR for function test_cases.typed_itxn_abi_call.typed_c2c.Greeter.test_nested_tuples
 debug: Sealing block@0
@@ -1006,28 +985,16 @@ debug: Building IR for function test_cases.typed_itxn_abi_call.typed_c2c.Greeter
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-typed_itxn_abi_call/typed_c2c.py:480:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0)
-typed_itxn_abi_call/typed_c2c.py:480:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0)
 debug: Terminated block@1
 debug: Sealing block@2
-typed_itxn_abi_call/typed_c2c.py:487:16 debug: encountered already materialized expression (result), reusing result: (result.0#1, result.1#1, result.2#1)
-typed_itxn_abi_call/typed_c2c.py:487:16 debug: encountered already materialized expression (result), reusing result: (result.0#1, result.1#1, result.2#1)
 debug: Terminated block@2
 debug: Sealing block@3
-typed_itxn_abi_call/typed_c2c.py:494:16 debug: encountered already materialized expression (result), reusing result: (result.0#2, result.1#2, result.2#2)
-typed_itxn_abi_call/typed_c2c.py:494:16 debug: encountered already materialized expression (result), reusing result: (result.0#2, result.1#2, result.2#2)
 debug: Terminated block@3
 debug: Sealing block@4
-typed_itxn_abi_call/typed_c2c.py:501:16 debug: encountered already materialized expression (result), reusing result: (result.0#3, result.1#3, result.2#3)
-typed_itxn_abi_call/typed_c2c.py:501:16 debug: encountered already materialized expression (result), reusing result: (result.0#3, result.1#3, result.2#3)
 debug: Terminated block@4
 debug: Sealing block@5
-typed_itxn_abi_call/typed_c2c.py:514:16 debug: encountered already materialized expression (result), reusing result: (result.0#4, result.1#4, result.2#4)
-typed_itxn_abi_call/typed_c2c.py:514:16 debug: encountered already materialized expression (result), reusing result: (result.0#4, result.1#4, result.2#4)
 debug: Terminated block@5
 debug: Sealing block@6
-typed_itxn_abi_call/typed_c2c.py:527:16 debug: encountered already materialized expression (result), reusing result: (result.0#5, result.1#5, result.2#5)
-typed_itxn_abi_call/typed_c2c.py:527:16 debug: encountered already materialized expression (result), reusing result: (result.0#5, result.1#5, result.2#5)
 debug: Terminated block@6
 debug: Building IR for function test_cases.typed_itxn_abi_call.typed_c2c.Greeter.__algopy_default_create
 debug: Sealing block@0

--- a/test_cases/typed_itxn_abi_call/puya_unoptimized.log
+++ b/test_cases/typed_itxn_abi_call/puya_unoptimized.log
@@ -561,7 +561,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_itxn_abi_call.logger.Logger.log_asset_account_app
 debug: Sealing block@0
-typed_itxn_abi_call/logger.py:67:9 debug: encountered already materialized expression (''), reusing result: ""
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_itxn_abi_call.logger.Logger.log_address
 debug: Sealing block@0
@@ -595,8 +594,6 @@ debug: Sealing block@0
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_itxn_abi_call.logger.Logger.logs_are_equal
 debug: Sealing block@0
-typed_itxn_abi_call/logger.py:164:16 debug: encountered already materialized expression (log_1), reusing result: (log_1.level#0, log_1.message#0)
-typed_itxn_abi_call/logger.py:164:25 debug: encountered already materialized expression (log_2), reusing result: (log_2.level#0, log_2.message#0)
 debug: Terminated block@0
 debug: Building IR for function test_cases.typed_itxn_abi_call.logger.Logger.echo_log_struct
 debug: Sealing block@0
@@ -949,28 +946,10 @@ debug: Terminated block@0
 debug: Sealing block@1
 debug: Terminated block@1
 debug: Sealing block@2
-typed_itxn_abi_call/typed_c2c.py:334:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_itxn_abi_call/typed_c2c.py:334:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:334:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_itxn_abi_call/typed_c2c.py:334:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:334:16 debug: encountered already materialized expression (result_2), reusing result: (result_2.0#0, result_2.1#0, result_2.2#0, result_2.3#0)
-typed_itxn_abi_call/typed_c2c.py:334:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@2
 debug: Sealing block@3
-typed_itxn_abi_call/typed_c2c.py:349:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_itxn_abi_call/typed_c2c.py:349:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:349:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_itxn_abi_call/typed_c2c.py:349:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:349:16 debug: encountered already materialized expression (result_3), reusing result: (result_3.0#0, result_3.1#0, result_3.2#0, result_3.3#0)
-typed_itxn_abi_call/typed_c2c.py:349:28 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@3
 debug: Sealing block@4
-typed_itxn_abi_call/typed_c2c.py:364:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_itxn_abi_call/typed_c2c.py:364:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:364:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_itxn_abi_call/typed_c2c.py:364:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
-typed_itxn_abi_call/typed_c2c.py:364:16 debug: encountered already materialized expression (result_native), reusing result: (result_native.0#0, result_native.1#0, result_native.2#0, result_native.3#0)
-typed_itxn_abi_call/typed_c2c.py:364:33 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0, result.3#0)
 debug: Terminated block@4
 debug: Building IR for function test_cases.typed_itxn_abi_call.typed_c2c.Greeter.test_nested_tuples
 debug: Sealing block@0
@@ -1006,28 +985,16 @@ debug: Building IR for function test_cases.typed_itxn_abi_call.typed_c2c.Greeter
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-typed_itxn_abi_call/typed_c2c.py:480:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0)
-typed_itxn_abi_call/typed_c2c.py:480:16 debug: encountered already materialized expression (result), reusing result: (result.0#0, result.1#0, result.2#0)
 debug: Terminated block@1
 debug: Sealing block@2
-typed_itxn_abi_call/typed_c2c.py:487:16 debug: encountered already materialized expression (result), reusing result: (result.0#1, result.1#1, result.2#1)
-typed_itxn_abi_call/typed_c2c.py:487:16 debug: encountered already materialized expression (result), reusing result: (result.0#1, result.1#1, result.2#1)
 debug: Terminated block@2
 debug: Sealing block@3
-typed_itxn_abi_call/typed_c2c.py:494:16 debug: encountered already materialized expression (result), reusing result: (result.0#2, result.1#2, result.2#2)
-typed_itxn_abi_call/typed_c2c.py:494:16 debug: encountered already materialized expression (result), reusing result: (result.0#2, result.1#2, result.2#2)
 debug: Terminated block@3
 debug: Sealing block@4
-typed_itxn_abi_call/typed_c2c.py:501:16 debug: encountered already materialized expression (result), reusing result: (result.0#3, result.1#3, result.2#3)
-typed_itxn_abi_call/typed_c2c.py:501:16 debug: encountered already materialized expression (result), reusing result: (result.0#3, result.1#3, result.2#3)
 debug: Terminated block@4
 debug: Sealing block@5
-typed_itxn_abi_call/typed_c2c.py:514:16 debug: encountered already materialized expression (result), reusing result: (result.0#4, result.1#4, result.2#4)
-typed_itxn_abi_call/typed_c2c.py:514:16 debug: encountered already materialized expression (result), reusing result: (result.0#4, result.1#4, result.2#4)
 debug: Terminated block@5
 debug: Sealing block@6
-typed_itxn_abi_call/typed_c2c.py:527:16 debug: encountered already materialized expression (result), reusing result: (result.0#5, result.1#5, result.2#5)
-typed_itxn_abi_call/typed_c2c.py:527:16 debug: encountered already materialized expression (result), reusing result: (result.0#5, result.1#5, result.2#5)
 debug: Terminated block@6
 debug: Building IR for function test_cases.typed_itxn_abi_call.typed_c2c.Greeter.__algopy_default_create
 debug: Sealing block@0

--- a/test_cases/unssa/puya.log
+++ b/test_cases/unssa/puya.log
@@ -802,7 +802,6 @@ debug: Building IR for function test_cases.unssa.no_inlining.UnSSAContractNoInli
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-unssa/no_inlining.py:13:21 debug: encountered already materialized expression (result1), reusing result: result1#0
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -814,7 +813,6 @@ debug: Added and_result%0#0 to Phi node: let and_result%0#2: bool = φ(and_resul
 debug: Added and_result%0#1 to Phi node: let and_result%0#2: bool = φ(and_result%0#0 <- block@2, and_result%0#1 <- block@3) in block@3
 debug: Terminated block@4
 debug: Sealing block@5
-unssa/no_inlining.py:16:21 debug: encountered already materialized expression (result2), reusing result: result2#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Terminated block@6
@@ -835,7 +833,6 @@ debug: Building IR for function test_cases.unssa.no_inlining.UnSSAContractNoInli
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-unssa/no_inlining.py:13:21 debug: encountered already materialized expression (result1), reusing result: result1#0
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -847,7 +844,6 @@ debug: Added and_result%0#0 to Phi node: let and_result%0#2: bool = φ(and_resul
 debug: Added and_result%0#1 to Phi node: let and_result%0#2: bool = φ(and_result%0#0 <- block@2, and_result%0#1 <- block@3) in block@3
 debug: Terminated block@4
 debug: Sealing block@5
-unssa/no_inlining.py:16:21 debug: encountered already materialized expression (result2), reusing result: result2#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Terminated block@6
@@ -957,7 +953,6 @@ debug: Building IR for function test_cases.unssa.contract.UnSSAContract.approval
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-unssa/contract.py:9:21 debug: encountered already materialized expression (result1), reusing result: result1#0
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -969,7 +964,6 @@ debug: Added and_result%0#0 to Phi node: let and_result%0#2: bool = φ(and_resul
 debug: Added and_result%0#1 to Phi node: let and_result%0#2: bool = φ(and_result%0#0 <- block@2, and_result%0#1 <- block@3) in block@3
 debug: Terminated block@4
 debug: Sealing block@5
-unssa/contract.py:12:21 debug: encountered already materialized expression (result2), reusing result: result2#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Terminated block@6
@@ -990,7 +984,6 @@ debug: Building IR for function test_cases.unssa.contract.UnSSAContract.approval
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-unssa/contract.py:9:21 debug: encountered already materialized expression (result1), reusing result: result1#0
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -1002,7 +995,6 @@ debug: Added and_result%0#0 to Phi node: let and_result%0#2: bool = φ(and_resul
 debug: Added and_result%0#1 to Phi node: let and_result%0#2: bool = φ(and_result%0#0 <- block@2, and_result%0#1 <- block@3) in block@3
 debug: Terminated block@4
 debug: Sealing block@5
-unssa/contract.py:12:21 debug: encountered already materialized expression (result2), reusing result: result2#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Terminated block@6

--- a/test_cases/unssa/puya_O2.log
+++ b/test_cases/unssa/puya_O2.log
@@ -801,7 +801,6 @@ debug: Building IR for function test_cases.unssa.no_inlining.UnSSAContractNoInli
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-unssa/no_inlining.py:13:21 debug: encountered already materialized expression (result1), reusing result: result1#0
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -813,7 +812,6 @@ debug: Added and_result%0#0 to Phi node: let and_result%0#2: bool = φ(and_resul
 debug: Added and_result%0#1 to Phi node: let and_result%0#2: bool = φ(and_result%0#0 <- block@2, and_result%0#1 <- block@3) in block@3
 debug: Terminated block@4
 debug: Sealing block@5
-unssa/no_inlining.py:16:21 debug: encountered already materialized expression (result2), reusing result: result2#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Terminated block@6
@@ -834,7 +832,6 @@ debug: Building IR for function test_cases.unssa.no_inlining.UnSSAContractNoInli
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-unssa/no_inlining.py:13:21 debug: encountered already materialized expression (result1), reusing result: result1#0
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -846,7 +843,6 @@ debug: Added and_result%0#0 to Phi node: let and_result%0#2: bool = φ(and_resul
 debug: Added and_result%0#1 to Phi node: let and_result%0#2: bool = φ(and_result%0#0 <- block@2, and_result%0#1 <- block@3) in block@3
 debug: Terminated block@4
 debug: Sealing block@5
-unssa/no_inlining.py:16:21 debug: encountered already materialized expression (result2), reusing result: result2#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Terminated block@6
@@ -956,7 +952,6 @@ debug: Building IR for function test_cases.unssa.contract.UnSSAContract.approval
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-unssa/contract.py:9:21 debug: encountered already materialized expression (result1), reusing result: result1#0
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -968,7 +963,6 @@ debug: Added and_result%0#0 to Phi node: let and_result%0#2: bool = φ(and_resul
 debug: Added and_result%0#1 to Phi node: let and_result%0#2: bool = φ(and_result%0#0 <- block@2, and_result%0#1 <- block@3) in block@3
 debug: Terminated block@4
 debug: Sealing block@5
-unssa/contract.py:12:21 debug: encountered already materialized expression (result2), reusing result: result2#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Terminated block@6
@@ -989,7 +983,6 @@ debug: Building IR for function test_cases.unssa.contract.UnSSAContract.approval
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-unssa/contract.py:9:21 debug: encountered already materialized expression (result1), reusing result: result1#0
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -1001,7 +994,6 @@ debug: Added and_result%0#0 to Phi node: let and_result%0#2: bool = φ(and_resul
 debug: Added and_result%0#1 to Phi node: let and_result%0#2: bool = φ(and_result%0#0 <- block@2, and_result%0#1 <- block@3) in block@3
 debug: Terminated block@4
 debug: Sealing block@5
-unssa/contract.py:12:21 debug: encountered already materialized expression (result2), reusing result: result2#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Terminated block@6

--- a/test_cases/unssa/puya_unoptimized.log
+++ b/test_cases/unssa/puya_unoptimized.log
@@ -801,7 +801,6 @@ debug: Building IR for function test_cases.unssa.no_inlining.UnSSAContractNoInli
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-unssa/no_inlining.py:13:21 debug: encountered already materialized expression (result1), reusing result: result1#0
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -813,7 +812,6 @@ debug: Added and_result%0#0 to Phi node: let and_result%0#2: bool = φ(and_resul
 debug: Added and_result%0#1 to Phi node: let and_result%0#2: bool = φ(and_result%0#0 <- block@2, and_result%0#1 <- block@3) in block@3
 debug: Terminated block@4
 debug: Sealing block@5
-unssa/no_inlining.py:16:21 debug: encountered already materialized expression (result2), reusing result: result2#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Terminated block@6
@@ -834,7 +832,6 @@ debug: Building IR for function test_cases.unssa.no_inlining.UnSSAContractNoInli
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-unssa/no_inlining.py:13:21 debug: encountered already materialized expression (result1), reusing result: result1#0
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -846,7 +843,6 @@ debug: Added and_result%0#0 to Phi node: let and_result%0#2: bool = φ(and_resul
 debug: Added and_result%0#1 to Phi node: let and_result%0#2: bool = φ(and_result%0#0 <- block@2, and_result%0#1 <- block@3) in block@3
 debug: Terminated block@4
 debug: Sealing block@5
-unssa/no_inlining.py:16:21 debug: encountered already materialized expression (result2), reusing result: result2#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Terminated block@6
@@ -956,7 +952,6 @@ debug: Building IR for function test_cases.unssa.contract.UnSSAContract.approval
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-unssa/contract.py:9:21 debug: encountered already materialized expression (result1), reusing result: result1#0
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -968,7 +963,6 @@ debug: Added and_result%0#0 to Phi node: let and_result%0#2: bool = φ(and_resul
 debug: Added and_result%0#1 to Phi node: let and_result%0#2: bool = φ(and_result%0#0 <- block@2, and_result%0#1 <- block@3) in block@3
 debug: Terminated block@4
 debug: Sealing block@5
-unssa/contract.py:12:21 debug: encountered already materialized expression (result2), reusing result: result2#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Terminated block@6
@@ -989,7 +983,6 @@ debug: Building IR for function test_cases.unssa.contract.UnSSAContract.approval
 debug: Sealing block@0
 debug: Terminated block@0
 debug: Sealing block@1
-unssa/contract.py:9:21 debug: encountered already materialized expression (result1), reusing result: result1#0
 debug: Terminated block@1
 debug: Sealing block@2
 debug: Terminated block@2
@@ -1001,7 +994,6 @@ debug: Added and_result%0#0 to Phi node: let and_result%0#2: bool = φ(and_resul
 debug: Added and_result%0#1 to Phi node: let and_result%0#2: bool = φ(and_result%0#0 <- block@2, and_result%0#1 <- block@3) in block@3
 debug: Terminated block@4
 debug: Sealing block@5
-unssa/contract.py:12:21 debug: encountered already materialized expression (result2), reusing result: result2#0
 debug: Terminated block@5
 debug: Sealing block@6
 debug: Terminated block@6


### PR DESCRIPTION
In the same way that PuyaPy doesn't construct unnecessary `SingleEvaluation` nodes to wrap nodes that can never have side-effects, the IR doesn't need to guard these against double-evaluation.

Note this only impacts PuyaPy due to our JSON serialisation lacking references.