### PR TITLE
fix: warn/error when OCA incompatible with creation option

### DIFF
--- a/changelog.d/20260625_034652_argimirodelpozo_arc56_create_error.md
+++ b/changelog.d/20260625_034652_argimirodelpozo_arc56_create_error.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- A bug when OCA is one of (UpdateApplication, CloseOut) and creation is required or allowed in an abi or bare method, silently leaving those options out of arc56 clients. We now emit warning/s and/or error when this happens, according to the severity of the OCA+create combination (e.g. 'CloseOut' only on a creation required method will always fail potentially compiling an undeployable contract)
+
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/puya/awst/validation/arc4_create_actions.py
+++ b/src/puya/awst/validation/arc4_create_actions.py
@@ -1,0 +1,101 @@
+import typing
+
+from puya import log
+from puya.avm import OnCompletionAction
+from puya.awst import nodes as awst_nodes
+from puya.awst.awst_traverser import AWSTTraverser
+
+logger = log.get_logger(__name__)
+
+# In arc56, `Create` only supports `NoOp`, `OptIn` and `DeleteApplication` as OCA
+# - `UpdateApplication` would technically work but do nothing
+#   (save for increasing the update version number)
+# - `CloseOut` would fail as the account is not opted into the application
+# See the arc56 implementation in utils:
+# https://github.com/algorandfoundation/algokit-utils-py/blob/68e139d52e13db2afa3fe815dcfd44bcfa1eebea/src/algokit_abi/arc56.py#L92
+_INVALID_CREATE_OCA = (
+    OnCompletionAction.UpdateApplication,
+    OnCompletionAction.CloseOut,
+)
+
+
+class ARC4CreateActionsValidator(AWSTTraverser):
+    """
+    Validates the create/OCA combinations on a contract's ARC-4 methods.
+    """
+
+    @classmethod
+    def validate(cls, module: awst_nodes.AWST) -> None:
+        for module_statement in module:
+            validator = cls()
+            module_statement.accept(validator)
+
+    @typing.override
+    def visit_contract(self, contract: awst_nodes.Contract) -> None:
+        creation_configs = [
+            config
+            for method in contract.all_methods
+            if (config := method.arc4_method_config) is not None
+            and config.create != awst_nodes.ARC4CreateOption.disallow
+        ]
+        # creation methods whose allowed OCAs aren't all representable in arc56
+        problematic_configs = [
+            config for config in creation_configs if _invalid_create_ocas(config)
+        ]
+        for config in problematic_configs:
+            _validate_create_config(config)
+
+
+def _invalid_create_ocas(config: awst_nodes.ARC4MethodConfig) -> list[OnCompletionAction]:
+    return [oca for oca in config.allowed_completion_types if oca in _INVALID_CREATE_OCA]
+
+
+def _is_closeout_only(config: awst_nodes.ARC4MethodConfig) -> bool:
+    return config.allowed_completion_types == (OnCompletionAction.CloseOut,)
+
+
+def _validate_create_config(config: awst_nodes.ARC4MethodConfig) -> None:
+    location = config.source_location
+    allowed_completion_types = config.allowed_completion_types
+    names = ", ".join(oca.name for oca in _invalid_create_ocas(config))
+    has_valid_create_oca = any(oca not in _INVALID_CREATE_OCA for oca in allowed_completion_types)
+    has_closeout = OnCompletionAction.CloseOut in allowed_completion_types
+
+    if config.create == awst_nodes.ARC4CreateOption.require:
+        # a create-only method with CloseOut as its only OCA can never be invoked:
+        # a create + CloseOut always fails, as the account is never opted in at creation time
+        if _is_closeout_only(config):
+            logger.error(
+                'required creation method with "CloseOut" as only allowed OCA will always fail, '
+                "rendering the contract undeployable through this method",
+                location=location,
+            )
+            return
+        # create-only methods have no `call` list, so any non-representable OCA
+        # is silently dropped from the arc56 spec
+        logger.warning(
+            f"arc56 clients will drop {names} on completion actions for creation method",
+            location=location,
+        )
+        if has_closeout:
+            logger.warning(
+                "CloseOut on creation will always fail; consider removing it from allow_actions",
+                location=location,
+            )
+    elif config.create == awst_nodes.ARC4CreateOption.allow:
+        # with a valid create OCA the non-representable ones just go on the `call` list
+        if has_valid_create_oca:
+            return
+        # CloseOut as the sole OCA is a dead create path: create + CloseOut always fails
+        if _is_closeout_only(config):
+            logger.error(
+                'create="allow" with "CloseOut" as only OCA is a dead create path, '
+                'consider switching to create="disallow"',
+                location=location,
+            )
+            return
+        # an update-only create capability (optionally with CloseOut) isn't arc56-representable
+        logger.warning(
+            f"arc56 clients will drop {names} on completion actions for creation method",
+            location=location,
+        )

--- a/src/puya/awst/validation/main.py
+++ b/src/puya/awst/validation/main.py
@@ -1,5 +1,6 @@
 from puya.awst import nodes as awst_nodes
 from puya.awst.validation.abi_method_name import AbiMethodNameValidator
+from puya.awst.validation.arc4_create_actions import ARC4CreateActionsValidator
 from puya.awst.validation.base_invoker import BaseInvokerValidator
 from puya.awst.validation.immutable import ImmutableValidator
 from puya.awst.validation.inner_transactions import (
@@ -21,4 +22,5 @@ def validate_awst(module: awst_nodes.AWST) -> None:
     LabelsValidator.validate(module)
     ImmutableValidator.validate(module)
     AbiMethodNameValidator.validate(module)
+    ARC4CreateActionsValidator.validate(module)
     LoggedErrorsValidator.validate(module)

--- a/test_cases/abi_routing/puya.log
+++ b/test_cases/abi_routing/puya.log
@@ -1,5 +1,7 @@
 debug: PuyaPyOptions(output_teal=True, output_source_map=True, output_assembly_report=True, output_arc32=False, output_arc56=True, output_ssa_ir=True, output_optimization_ir=True, output_destructured_ir=True, output_memory_ir=True, output_bytecode=True, output_teal_intermediates=False, output_op_statistics=True, debug_level=1, optimization_level=1, treat_warnings_as_errors=False, target_avm_version=11, cli_template_definitions={}, template_vars_prefix='TMPL_', locals_coalescing_strategy=<LocalsCoalescingStrategy.root_operand: 'root_operand'>, optimizations_override=immutabledict({}), expand_all_bytes=False, validate_abi_args=True, validate_abi_return=True, paths=['abi_routing'], resource_encoding='value', output_awst=True, output_awst_json=False, output_source_annotations_json=False, output_client=True)
 info: writing abi_routing/out/module.awst
+abi_routing/contract.py:79:6 warning: arc56 clients will drop CloseOut, UpdateApplication on completion actions for creation method
+abi_routing/contract.py:79:6 warning: CloseOut on creation will always fail; consider removing it from allow_actions
 debug: Building IR for function _puya_lib.util.ensure_budget
 debug: Sealing block@0
 debug: Terminated block@0

--- a/test_cases/abi_routing/puya_O2.log
+++ b/test_cases/abi_routing/puya_O2.log
@@ -1,4 +1,6 @@
 debug: PuyaPyOptions(output_teal=True, output_source_map=False, output_assembly_report=True, output_arc32=False, output_arc56=False, output_ssa_ir=False, output_optimization_ir=False, output_destructured_ir=True, output_memory_ir=False, output_bytecode=True, output_teal_intermediates=False, output_op_statistics=True, debug_level=0, optimization_level=2, treat_warnings_as_errors=False, target_avm_version=11, cli_template_definitions={}, template_vars_prefix='TMPL_', locals_coalescing_strategy=<LocalsCoalescingStrategy.root_operand: 'root_operand'>, optimizations_override=immutabledict({}), expand_all_bytes=False, validate_abi_args=True, validate_abi_return=True, paths=['abi_routing'], resource_encoding='value', output_awst=False, output_awst_json=False, output_source_annotations_json=False, output_client=False)
+abi_routing/contract.py:79:6 warning: arc56 clients will drop CloseOut, UpdateApplication on completion actions for creation method
+abi_routing/contract.py:79:6 warning: CloseOut on creation will always fail; consider removing it from allow_actions
 debug: Building IR for function _puya_lib.util.ensure_budget
 debug: Sealing block@0
 debug: Terminated block@0

--- a/test_cases/abi_routing/puya_unoptimized.log
+++ b/test_cases/abi_routing/puya_unoptimized.log
@@ -1,4 +1,6 @@
 debug: PuyaPyOptions(output_teal=True, output_source_map=False, output_assembly_report=True, output_arc32=False, output_arc56=False, output_ssa_ir=False, output_optimization_ir=False, output_destructured_ir=True, output_memory_ir=False, output_bytecode=True, output_teal_intermediates=False, output_op_statistics=True, debug_level=1, optimization_level=0, treat_warnings_as_errors=False, target_avm_version=11, cli_template_definitions={}, template_vars_prefix='TMPL_', locals_coalescing_strategy=<LocalsCoalescingStrategy.root_operand: 'root_operand'>, optimizations_override=immutabledict({}), expand_all_bytes=False, validate_abi_args=True, validate_abi_return=True, paths=['abi_routing'], resource_encoding='value', output_awst=False, output_awst_json=False, output_source_annotations_json=False, output_client=False)
+abi_routing/contract.py:79:6 warning: arc56 clients will drop CloseOut, UpdateApplication on completion actions for creation method
+abi_routing/contract.py:79:6 warning: CloseOut on creation will always fail; consider removing it from allow_actions
 debug: Building IR for function _puya_lib.util.ensure_budget
 debug: Sealing block@0
 debug: Terminated block@0

--- a/tests/test_expected_output/arc4.test
+++ b/tests/test_expected_output/arc4.test
@@ -601,6 +601,106 @@ class MyContract(ARC4Contract):
     def d(self, arg: Bytes) -> BoxRef: 
         return BoxRef(key=arg)
 
+## case: create_without_valid_create_action
+from algopy import *
+
+class RequireUpdateOnly(ARC4Contract):
+    @arc4.abimethod(create="require", allow_actions=["UpdateApplication"]) ## W: arc56 clients will drop UpdateApplication on completion actions for creation method
+    def create_update(self) -> None:
+        pass
+
+class RequireUpdateAndDelete(ARC4Contract):
+    @arc4.abimethod(create="require", allow_actions=["UpdateApplication", "DeleteApplication"]) ## W: arc56 clients will drop UpdateApplication on completion actions for creation method
+    def create_update_or_delete(self) -> None:
+        pass
+
+class RequireCloseOutAndDelete(ARC4Contract):
+    # CloseOut is dropped from the spec and is also a dead create path, so warn about both
+    @arc4.abimethod(create="require", allow_actions=["CloseOut", "DeleteApplication"]) ## W: arc56 clients will drop CloseOut on completion actions for creation method \
+                                                                                       ## W: CloseOut on creation will always fail; consider removing it from allow_actions
+    def create_closeout_or_delete(self) -> None:
+        pass
+
+class RequireCloseOutAndUpdate(ARC4Contract):
+    # the only other option is Update, so warn about both the dropped
+    # OCAs and the dead CloseOut path
+    @arc4.abimethod(create="require", allow_actions=["UpdateApplication", "CloseOut"]) ## W: arc56 clients will drop UpdateApplication, CloseOut on completion actions for creation method \
+                                                                                      ## W: CloseOut on creation will always fail; consider removing it from allow_actions
+    def create_update_or_closeout(self) -> None:
+        pass
+
+class RequireCloseOutOnly(ARC4Contract):
+    @arc4.baremethod(create="require", allow_actions=["CloseOut"]) ## E: required creation method with "CloseOut" as only allowed OCA will always fail, rendering the contract undeployable through this method
+    def bare_create_closeout(self) -> None:
+        pass
+
+class AllowUpdateOnly(ARC4Contract):
+    @arc4.abimethod(create="allow", allow_actions=["UpdateApplication"]) ## W: arc56 clients will drop UpdateApplication on completion actions for creation method
+    def maybe_create_update(self) -> None:
+        pass
+
+class AllowUpdateAndDelete(ARC4Contract):
+    @arc4.abimethod(create="allow", allow_actions=["UpdateApplication", "DeleteApplication"])
+    def maybe_create_update_or_delete(self) -> None:
+        pass
+
+class AllowCloseOutAndDelete(ARC4Contract):
+    # DeleteApplication creates and CloseOut goes on the `call` list, so nothing to report
+    @arc4.abimethod(create="allow", allow_actions=["CloseOut", "DeleteApplication"])
+    def maybe_create_closeout_or_delete(self) -> None:
+        pass
+
+class AllowCloseOutAndUpdate(ARC4Contract):
+    @arc4.abimethod(create="allow", allow_actions=["UpdateApplication", "CloseOut"]) ## W: arc56 clients will drop UpdateApplication, CloseOut on completion actions for creation method
+    def maybe_create_update_or_closeout(self) -> None:
+        pass
+
+class AllowCloseOutOnly(ARC4Contract):
+    # create="allow" with only CloseOut is a dead create path: create + CloseOut always fails,
+    # so allowing creation for this method makes no sense
+    @arc4.baremethod(create="allow", allow_actions=["CloseOut"]) ## E: create="allow" with "CloseOut" as only OCA is a dead create path, consider switching to create="disallow"
+    def maybe_create_closeout(self) -> None:
+        pass
+
+class CloseOutCreateWithValidSibling(ARC4Contract):
+    # even though the contract is creatable via the NoOp create below,
+    # this method can never be invoked, so it errors regardless
+    @arc4.baremethod(create="require", allow_actions=["CloseOut"]) ## E: required creation method with "CloseOut" as only allowed OCA will always fail, rendering the contract undeployable through this method
+    def bare_create_closeout(self) -> None:
+        pass
+
+    @arc4.abimethod(create="require")
+    def create_noop(self) -> None:
+        pass
+
+class BareRequireUpdateOnly(ARC4Contract):
+    @arc4.baremethod(create="require", allow_actions=["UpdateApplication"]) ## W: arc56 clients will drop UpdateApplication on completion actions for creation method
+    def bare_create_update(self) -> None:
+        pass
+
+class BareRequireCloseOutAndDelete(ARC4Contract):
+    @arc4.baremethod(create="require", allow_actions=["CloseOut", "DeleteApplication"]) ## W: arc56 clients will drop CloseOut on completion actions for creation method \
+                                                                                        ## W: CloseOut on creation will always fail; consider removing it from allow_actions
+    def bare_create_closeout_or_delete(self) -> None:
+        pass
+
+class BareRequireCloseOutAndUpdate(ARC4Contract):
+    @arc4.baremethod(create="require", allow_actions=["UpdateApplication", "CloseOut"]) ## W: arc56 clients will drop UpdateApplication, CloseOut on completion actions for creation method \
+                                                                                       ## W: CloseOut on creation will always fail; consider removing it from allow_actions
+    def bare_create_update_or_closeout(self) -> None:
+        pass
+
+class BareAllowUpdateOnly(ARC4Contract):
+    @arc4.baremethod(create="allow", allow_actions=["UpdateApplication"]) ## W: arc56 clients will drop UpdateApplication on completion actions for creation method
+    def bare_maybe_create_update(self) -> None:
+        pass
+
+class BareAllowCloseOutAndUpdate(ARC4Contract):
+    @arc4.baremethod(create="allow", allow_actions=["UpdateApplication", "CloseOut"]) ## W: arc56 clients will drop UpdateApplication, CloseOut on completion actions for creation method
+    def bare_maybe_create_update_or_closeout(self) -> None:
+        pass
+
+
 ## case: test_string
 from algopy import arc4, subroutine
 


### PR DESCRIPTION
This PR solves some silent or potentially unexpected behaviors for developers on interactions between OCA and create options (specifically create="allow" | "require" with Update and CloseOut OCAs).
The problem is that arc56 disallows update and closeout actions on creation, leaving those options out of the create array for the method (even if the code still allows them).
There is an additional problem in the fact that on creation, CloseOut will always fail as the account can't be opted into the app before it is created (updates, tho pointless -save for some strange use case where one would like to increase the app version right away?- would work).

The cases considered are as follows:

### ABI method, creation = "allow":
- an update OCA will be pointless for the creation path, however wont fail. 
    - if by itself or with a single other which is closeout, we warn (arc56 client warning)
    - If with other valid ones, we don't do anything.
- a closeout OCA will fail (dead path):
    - if there are other valid options we don't do anything
    - if the only other option is update, we warn (arc56 client warning)
    - if there are no other options in this method, we error (it makes no sense to allow creation for this method as it will be a dead path)

### ABI method, creation = "require"
- an update OCA earns a warning, by itself or with other valid ones (arc56 ocas warning)
- a closeout OCA will fail, but this time:
    - if there are other valid options in this method, we warn (we recommend the developer consider removing it from oca)
    - if the only other option is update, we warn (arc56 client warning) _and_ the closeout warning
    - if there are no other valid options, we error (closeout will always fail!)

(For bare methods same rules as above)