### PR TITLE
chore: fold devportal examples into Puya to keep them updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ examples/**/*.trace
 /examples/**/out*/*.bin
 /test_cases/**/out*/*.bin
 /test_cases_awst/**/out*/*.bin
+# on-chain (localnet) test compilation output for examples
+/examples/**/out_tests/
 # wheel output
 /dist
 /stubs/dist

--- a/examples/devportal/abimethod_options/contract.py
+++ b/examples/devportal/abimethod_options/contract.py
@@ -1,0 +1,167 @@
+from algopy import (
+    Account,
+    Application,
+    ARC4Contract,
+    Asset,
+    Global,
+    GlobalState,
+    LocalState,
+    OnCompleteAction,
+    Txn,
+    UInt64,
+    arc4,
+    public,
+)
+
+
+class AbiMethodOptions(ARC4Contract):
+    """
+    A tour of `@arc4.abimethod` options. Each method here is annotated with a
+    different combination so it's easy to see their use cases.
+    """
+
+    def __init__(self) -> None:
+        self.governor = GlobalState(Account)
+        self.fee_asset = GlobalState(Asset)
+        self.join_event_count = GlobalState(UInt64(0))
+        self.leave_event_count = GlobalState(UInt64(0))
+        self.joined_round = LocalState(UInt64)
+
+    @arc4.abimethod(create="require")
+    def create(self, governor: Account, fee_asset: Asset) -> None:
+        """
+        By default, an `ARC4Contract` can be created via any bare or `NoOp` call.
+        Marking a method `create="require"` forces creation to go through that
+        method instead, allowing constructor-style initialization with parameters.
+        """
+        self.governor.value = governor
+        self.fee_asset.value = fee_asset
+
+    # public is an alias for arc4.abimethod
+    @public
+    def public_governor_getter(self) -> Account:
+        return self.governor.value
+
+    # example: ABIMETHOD_NAME
+    @arc4.abimethod(name="ping")
+    def long_internal_name(self) -> arc4.String:
+        """
+        `name=` decouples the on-chain ABI method name from the Python
+        function name. Useful for keeping the ABI surface stable while
+        renaming the implementation, or for shortening selector signatures.
+        """
+        return arc4.String("ping")
+
+    # example: ABIMETHOD_NAME
+
+    # example: ABIMETHOD_READONLY
+    @arc4.abimethod(readonly=True)
+    def get_join_event_count(self) -> UInt64:
+        """
+        `readonly=True` marks the method as side-effect-free. Clients can run
+        it via `simulate` without sending a real transaction. Puya does not
+        enforce read-only at the bytecode level; it constitutes a promise to the
+        caller.
+        """
+        return self.join_event_count.value
+
+    # example: ABIMETHOD_READONLY
+
+    # example: ABIMETHOD_DEFAULT_ARGS
+    @arc4.abimethod(
+        default_args={
+            "fee_asset": "fee_asset",  # name of a state member
+            "expected_join_event_count": get_join_event_count,  # a readonly method
+        }
+    )
+    def admin_action(self, fee_asset: Asset, expected_join_event_count: UInt64) -> None:
+        """
+        `default_args=` lets a client fill arguments automatically from the
+        contract's own state or readonly methods. Each value is either:
+          * a string naming a storage member (state default), or
+          * a reference to a `readonly=True` method (dynamic default).
+        Clients that read the ABI metadata can supply the defaults on the
+        user's behalf: here that means attaching the configured `fee_asset`
+        resource without a separate state read, and pre-filling
+        `expected_join_event_count` as an optimistic-concurrency check.
+        """
+        assert Txn.sender == self.governor.value, "only governor"
+
+        # the arg is caller-supplied, so check it against the configured asset
+        # before acting on it — here a mismatch is tolerated with an early
+        # return rather than a failed transaction
+        if fee_asset != self.fee_asset.value:
+            # do some specific handling for this case
+            return
+
+        # compare-and-swap guard: reject if membership changed since observed
+        assert expected_join_event_count == self.join_event_count.value, "stale join event count"
+        # privileged work acting on `fee_asset` would go here
+
+    # example: ABIMETHOD_DEFAULT_ARGS
+
+    # example: ABIMETHOD_RESOURCE_ENCODING
+    @arc4.abimethod(resource_encoding="index")
+    def eligible_balance(self, asset: Asset, app: Application, account: Account) -> UInt64:
+        """
+        `resource_encoding="index"` (the pre-PuyaPy-5.0 behavior) tells the
+        ABI router to expect resource references as a `UInt8` index into the
+        foreign-array slots populated by the caller. This saves calldata when
+        the same resources are reused across calls in a group.
+
+        Without this option, the default in PuyaPy 5+ is `"value"`; the
+        client passes the full Asset id / app id / account address directly,
+        which is simpler and reflected in the published ABI signature.
+        """
+        assert account.is_opted_in(app), "account not opted in to app"
+        # note: opting in creates a zero-balance holding, so this only proves the
+        # account *can* hold the asset
+        # use `asset.balance(account) > 0` to require an actual balance
+        assert account.is_opted_in(asset), "account is not opted in to the asset"
+        return asset.balance(account)
+
+    # example: ABIMETHOD_RESOURCE_ENCODING
+
+    # example: ABIMETHOD_ALLOW_ACTIONS
+    @arc4.abimethod(allow_actions=["NoOp", "OptIn"])
+    def join(self) -> None:
+        """
+        `allow_actions=` declares which OnComplete actions can dispatch to
+        this method. The default is `["NoOp"]`. Listing `"OptIn"` here lets
+        the same logic run during a NoOp call *or* an opt-in call, which is
+        a handy way to bundle "first-time setup" with regular use: new
+        members come in via OptIn (the network opens their local state in
+        the same transaction), returning members hit the NoOp path.
+        Inspect `Txn.on_completion` to branch on which one actually ran.
+        """
+        # Common path: every join (first or repeat) must be opted in to the fee asset
+        # Even though the asset comes from state, this holding lookup still
+        # requires it to be an *available resource* on the call — the AlgoKit
+        # client discovers and attaches the reference automatically (via
+        # simulate); a hand-rolled caller must add it to the asset references.
+        assert Txn.sender.is_opted_in(self.fee_asset.value), "must be opted in to fee asset"
+
+        # One-time setup runs only on the OptIn variant, where the sender's
+        # local state has just been allocated.
+        if Txn.on_completion == OnCompleteAction.OptIn:
+            self.join_event_count.value += 1  # record this account's join
+            self.joined_round[Txn.sender] = Global.round
+
+    @arc4.abimethod(allow_actions=["CloseOut"])
+    def opt_out(self) -> None:
+        """A CloseOut handler: a member voluntarily leaving releases their
+        local state, and the leave event is counted so the pair of counters
+        keeps a best-effort registry: active members are approximately
+        `join_event_count - leave_event_count`.
+
+        Note: an account can always leave via a ClearState transaction, which
+        cannot be blocked and bypasses this handler, so a ClearState leave is
+        never recorded and the difference can overcount active members."""
+        self.leave_event_count.value += 1
+
+    @arc4.abimethod(allow_actions=["DeleteApplication"])
+    def shut_down(self) -> None:
+        """A delete handler. Only routable from a DeleteApplication action."""
+        assert Txn.sender == self.governor.value, "only governor can delete"
+
+    # example: ABIMETHOD_ALLOW_ACTIONS

--- a/examples/devportal/arc4_client/contract.py
+++ b/examples/devportal/arc4_client/contract.py
@@ -1,0 +1,79 @@
+import typing
+
+from algopy import Application, ARC4Contract, String, UInt64, arc4
+
+
+# example: ARC4_CLIENT_PROTOCOL
+class HelloWorldClient(arc4.ARC4Client, typing.Protocol):
+    """
+    A typed client for an *external* ARC-4 contract.
+    It subclasses both `arc4.ARC4Client` and `typing.Protocol` and describes
+    the methods we want to call by their signatures with stubbed bodies
+    (`...`).
+
+    A client like this can be generated from a compiled contract by
+    passing the `--output-client` option to the PuyaPy compiler.
+
+    The signatures match the on-chain contract's published ABI; puya
+    uses them to:
+      * derive the correct ABI selector for each call,
+      * type-check the args we pass,
+      * type the return value.
+
+    A typed client is preferable to passing a method-name string to
+    `arc4.abi_call` because mistakes (wrong arg type, missing arg, etc.)
+    are caught at compile time rather than as on-chain failures.
+    """
+
+    @arc4.abimethod
+    def hello(self, name: String) -> String: ...
+
+    @arc4.abimethod
+    def add(self, a: UInt64, b: UInt64) -> UInt64: ...
+
+
+# example: ARC4_CLIENT_PROTOCOL
+
+
+# example: ARC4_ABI_CALL_CLIENT
+class ClientConsumer(ARC4Contract):
+    """
+    Calls into an external contract via the typed `HelloWorldClient`. Each
+    `arc4.abi_call(HelloWorldClient.method, ...)` returns a
+    `(result, inner_txn)` tuple where `result` has the type declared in
+    the protocol.
+    """
+
+    @arc4.abimethod
+    def call_hello(self, app: Application, name: String) -> String:
+        """Call `hello(string)string` on the target app. The return type is
+        inferred as `String` from the client protocol."""
+        result, _txn = arc4.abi_call(
+            HelloWorldClient.hello,
+            name,
+            app_id=app,
+            # fee=0 means the outer transaction must cover the inner fee
+            fee=0,
+        )
+        return result
+
+    @arc4.abimethod
+    def call_add(self, app: Application, a: UInt64, b: UInt64) -> UInt64:
+        """Call `add(uint64,uint64)uint64`. Arg types are checked against
+        the protocol method signature at compile time.
+
+        The second tuple element is the inner transaction handle.
+        It's useful when you want to inspect the call after the fact (e.g.
+        confirm which app id was hit, read emitted logs, etc.)."""
+        result, txn = arc4.abi_call(
+            HelloWorldClient.add,
+            a,
+            b,
+            app_id=app,
+            fee=0,
+        )
+        assert txn.num_logs == 1, "only the return log was emitted by the app"
+        return result
+
+
+# example: ARC4_ABI_CALL_CLIENT

--- a/examples/devportal/arc4_types/contract.py
+++ b/examples/devportal/arc4_types/contract.py
@@ -1,0 +1,292 @@
+import typing
+
+from algopy import ARC4Contract, Bytes, GlobalState, String, UInt64, arc4, op, urange
+
+
+class Arc4Types(ARC4Contract):
+    # example: ARC4_UINT64
+    @arc4.abimethod
+    def add_arc4_uint64(self, a: arc4.UInt64, b: arc4.UInt64) -> arc4.UInt64:
+        """
+        Arithmetic operators are not defined directly on ARC-4 integer types
+        because they are stored as fixed-width byte arrays in the AVM.
+        Use `.as_uint64()` (or `.as_biguint()` for big integers) to obtain the
+        native value, perform the math, then wrap the result back into the
+        ARC-4 type for ABI compatibility.
+        """
+        c = a.as_uint64() + b.as_uint64()
+        return arc4.UInt64(c)
+
+    # example: ARC4_UINT64
+
+    # example: ARC4_UINTN
+    @arc4.abimethod
+    def add_arc4_uint_n(
+        self, a: arc4.UInt8, b: arc4.UInt16, c: arc4.UInt32, d: arc4.UInt64
+    ) -> arc4.UInt64:
+        """
+        The encoding of ARC-4 integers uses fewer bytes for smaller bit widths.
+        All `UIntN` variants up to 64 bits decode to the native `UInt64` via
+        `.as_uint64()`.
+        """
+        assert a.bytes.length == 1, "UInt8 is encoded in 1 byte"
+        assert b.bytes.length == 2, "UInt16 is encoded in 2 bytes"
+        assert c.bytes.length == 4, "UInt32 is encoded in 4 bytes"
+        assert d.bytes.length == 8, "UInt64 is encoded in 8 bytes"
+
+        total = a.as_uint64() + b.as_uint64() + c.as_uint64() + d.as_uint64()
+        return arc4.UInt64(total)
+
+    # example: ARC4_UINTN
+
+    # example: ARC4_BIGUINT
+    @arc4.abimethod
+    def add_arc4_biguint_n(
+        self, a: arc4.UInt128, b: arc4.UInt256, c: arc4.UInt512
+    ) -> arc4.UInt512:
+        """
+        Larger bit widths up to 512 bits are supported via `UIntN`.
+        Their native representation is `BigUInt`, obtained via `.as_biguint()`.
+        """
+        assert a.bytes.length == 16, "UInt128 is encoded in 16 bytes"
+        assert b.bytes.length == 32, "UInt256 is encoded in 32 bytes"
+        assert c.bytes.length == 64, "UInt512 is encoded in 64 bytes"
+
+        total = a.as_biguint() + b.as_biguint() + c.as_biguint()
+        return arc4.UInt512(total)
+
+    # example: ARC4_BIGUINT
+
+    # example: ARC4_BYTES
+    @arc4.abimethod
+    def arc4_byte(self, a: arc4.Byte) -> arc4.Byte:
+        """
+        `arc4.Byte` is an alias for `arc4.UInt8`. As with other UIntN types,
+        arithmetic goes through the native representation.
+        """
+        return arc4.Byte(a.as_uint64() + 1)
+
+    # example: ARC4_BYTES
+
+    # example: ARC4_ADDRESS
+    @arc4.abimethod
+    def arc4_address_balance(self, address: arc4.Address) -> UInt64:
+        # The underlying 32 bytes of the address.
+        _underlying_bytes = address.bytes
+
+        # Decode into the native `Account` reference type.
+        account = address.native
+        return account.balance
+
+    @arc4.abimethod
+    def arc4_address_roundtrip(self, address: arc4.Address) -> arc4.Address:
+        # `address.native` returns an `Account`, which is a reference type and
+        # therefore can't be returned directly from an ABI method.
+        # Wrap it back into `arc4.Address` for the return value.
+        converted_address = arc4.Address(address.native)
+        assert converted_address == address
+        return converted_address
+
+    # example: ARC4_ADDRESS
+
+
+# example: ARC4_STATIC_ARRAY
+AliasedStaticArray: typing.TypeAlias = arc4.StaticArray[arc4.UInt8, typing.Literal[1]]
+
+
+class Arc4StaticArray(ARC4Contract):
+    @arc4.abimethod
+    def arc4_static_array(self) -> None:
+        # A static array has a fixed, compile-time length.
+        static_uint32_array = arc4.StaticArray(
+            arc4.UInt32(1), arc4.UInt32(10), arc4.UInt32(2048), arc4.UInt32(128)
+        )
+
+        total = UInt64(0)
+        for item in static_uint32_array:
+            total += item.as_uint64()
+        assert total == 1 + 10 + 2048 + 128
+
+        # A type alias makes the element type and length explicit at the use site.
+        aliased_static = AliasedStaticArray(arc4.UInt8(101))
+        index = UInt64(0)
+        assert (aliased_static[0].as_uint64() + aliased_static[index].as_uint64()) == 202
+
+        aliased_static[0] = arc4.UInt8(202)
+        assert aliased_static[0] == 202
+
+        # Static arrays are fixed-size: `.pop()` or `.append(...)` would not compile.
+
+
+# example: ARC4_STATIC_ARRAY
+
+
+# example: ARC4_DYNAMIC_ARRAY
+Goodbye: typing.TypeAlias = arc4.DynamicArray[arc4.String]
+
+
+class Arc4DynamicArray(ARC4Contract):
+    @arc4.abimethod
+    def goodbye(self, name: arc4.String) -> Goodbye:
+        return Goodbye(arc4.String("Good bye "), name)
+
+    @arc4.abimethod
+    def hello(self, name: arc4.String) -> String:
+        """
+        Dynamic arrays have variable size and capacity. They support
+        `append`, `extend`, `pop`, and concatenation via `+`.
+        """
+        dynamic_string_array = arc4.DynamicArray[arc4.String](arc4.String("Hello "))
+
+        extension = arc4.DynamicArray[arc4.String](name, arc4.String("!"))
+        dynamic_string_array.extend(extension)
+
+        copied = dynamic_string_array.copy()
+        # `pop()` removes and returns the last element
+        last = copied.pop()
+        assert last == "!", "last element should be the exclamation mark"
+        second_last = copied.pop()
+        assert second_last == name, "second last element should be the name"
+        copied.append(arc4.String("world!"))
+        assert copied.length == 2, "copied is now ['Hello ', 'world!']"
+
+        greeting = String()
+        for x in dynamic_string_array:
+            greeting += x.native
+        return greeting
+
+    # example: ARC4_DYNAMIC_ARRAY
+
+    # example: ARC4_DYNAMIC_BYTES
+    @arc4.abimethod
+    def arc4_dynamic_bytes(self) -> arc4.DynamicBytes:
+        """
+        `arc4.DynamicBytes` is `arc4.DynamicArray[arc4.Byte]` with extra
+        convenience: it can be constructed from a `bytes` literal and
+        decoded to native `Bytes` via `.native`.
+        """
+        dynamic_bytes = arc4.DynamicBytes(b"\xff\xff\xff")
+
+        # Unlike a generic `DynamicArray`, `DynamicBytes` exposes `.native`
+        # so the whole sequence can be decoded in one step.
+        native_dynamic_bytes = dynamic_bytes.native
+        assert native_dynamic_bytes.length == 3
+
+        dynamic_bytes[0] = arc4.Byte(0)
+        dynamic_bytes.extend(arc4.DynamicBytes(b"\xaa\xbb\xcc"))
+        _popped = dynamic_bytes.pop()
+        dynamic_bytes.append(arc4.Byte(255))
+
+        return dynamic_bytes
+
+    # example: ARC4_DYNAMIC_BYTES
+
+
+# example: ARC4_STRUCT
+class Todo(arc4.Struct, kw_only=True):
+    """
+    `arc4.Struct` declares a named, ARC-4-encoded record type. Subclass options:
+      - `kw_only=True` forces keyword construction, which keeps call sites
+        readable when fields are added or reordered.
+      - `frozen=True` (not used here) makes the struct immutable;
+        mutations must go through `_replace(...)`.
+    """
+
+    task: arc4.String
+    completed: arc4.Bool
+
+
+Todos: typing.TypeAlias = arc4.DynamicArray[Todo]
+
+
+class Arc4Struct(ARC4Contract):
+    def __init__(self) -> None:
+        self.todos = Todos()
+
+    @arc4.abimethod
+    def add_todo(self, task: arc4.String) -> Todos:
+        todo = Todo(task=task, completed=arc4.Bool(False))
+        self.todos.append(todo.copy())
+        return self.todos
+
+    @arc4.abimethod
+    def complete_todo(self, task: arc4.String) -> None:
+        for index in urange(self.todos.length):
+            if self.todos[index].task == task:
+                self.todos[index].completed = arc4.Bool(True)
+                break
+
+    @arc4.abimethod
+    def return_todo(self, task: arc4.String) -> Todo:
+        for index in urange(self.todos.length):
+            if self.todos[index].task == task:
+                return self.todos[index].copy()
+        op.err("todo not found")
+
+
+# example: ARC4_STRUCT
+
+
+# example: ARC4_TUPLE
+ContactInfo: typing.TypeAlias = arc4.Tuple[arc4.String, arc4.String, arc4.UInt64]
+
+
+class Arc4Tuple(ARC4Contract):
+    def __init__(self) -> None:
+        self.contact_info = GlobalState(
+            ContactInfo((arc4.String(""), arc4.String(""), arc4.UInt64(0)))
+        )
+
+    @arc4.abimethod
+    def add_contact_info(self, contact: ContactInfo) -> UInt64:
+        """An `arc4.Tuple` is a heterogeneous, ARC-4-encoded collection.
+        `.native` unpacks it into a regular Python tuple of the element types."""
+        name, email, phone = contact.native
+        assert name.native == "Alice", "unexpected name"
+        assert email.native == "alice@something.com", "unexpected email"
+        assert phone == 555_555_555, "unexpected phone number"
+
+        self.contact_info.value = contact
+        return phone.as_uint64()
+
+    @arc4.abimethod
+    def return_contact(self) -> ContactInfo:
+        return self.contact_info.value
+
+
+# example: ARC4_TUPLE
+
+
+# example: ARC4_ENCODE_DECODE
+class Arc4Codec(ARC4Contract):
+    """
+    Demonstrates `arc4.encode` and `arc4.decode`, the general-purpose
+    ARC-4 codec. Use these when you need to:
+      * Build or parse ARC-4 bytes by hand (e.g. constructing event
+        payloads, decoding bytes received off-chain).
+      * Round-trip a value through bytes for hashing, signing, or storage.
+    """
+
+    @arc4.abimethod
+    def encode_decode(self, value: UInt64) -> UInt64:
+        """`arc4.encode(value)` returns the ARC-4 encoded bytes; passing
+        the bytes plus a target type to `arc4.decode` reverses it."""
+        encoded: Bytes = arc4.encode(value)
+        assert encoded.length == 8, "UInt64 encodes to 8 big-endian bytes"
+
+        decoded: UInt64 = arc4.decode(UInt64, encoded)
+        assert decoded == value, "round-trip through bytes preserves the value"
+        return decoded
+
+    @arc4.abimethod
+    def decode_unvalidated(self, raw: Bytes) -> arc4.UInt64:
+        """
+        `decode(..., validate=False)` skips the ARC-4 encoding check on the
+        input bytes. Smaller bytecode, faster — but only safe when you
+        already trust the source of the bytes (e.g. you wrote them in the
+        same program). Defaults to `validate=True`.
+        """
+        return arc4.decode(arc4.UInt64, raw, validate=False)
+
+
+# example: ARC4_ENCODE_DECODE

--- a/examples/devportal/box_storage/contract.py
+++ b/examples/devportal/box_storage/contract.py
@@ -1,0 +1,324 @@
+import typing
+
+from algopy import (
+    ARC4Contract,
+    Array,
+    Box,
+    BoxMap,
+    Bytes,
+    Global,
+    String,
+    Struct,
+    Txn,
+    UInt64,
+    arc4,
+    subroutine,
+    urange,
+)
+
+StaticInts: typing.TypeAlias = arc4.StaticArray[arc4.UInt8, typing.Literal[4]]
+
+
+# example: INIT_BOX_STORAGE_STRUCT
+class UserStruct(arc4.Struct):
+    """An ARC-4 struct stored as the value type of a BoxMap."""
+
+    name: arc4.String
+    id: arc4.UInt64
+    asset: arc4.UInt64
+
+
+# example: INIT_BOX_STORAGE_STRUCT
+
+
+class InnerStruct(Struct):
+    """A nested algopy Struct with a dynamic array inside it."""
+
+    c: UInt64
+    arr: Array[UInt64]
+    d: UInt64
+
+
+class NestedStruct(Struct):
+    """Composition of Structs, including an Array of Structs."""
+
+    a: UInt64
+    inner: InnerStruct
+    siblings: Array[InnerStruct]
+    b: UInt64
+
+
+class BoxStorage(ARC4Contract):
+    # example: INIT_BOX_STORAGE
+    def __init__(self) -> None:
+        # Box[T] holds a single value of type T. The key defaults to the attribute name.
+        self.box_int = Box(UInt64)
+        # An explicit `key` overrides the attribute-derived default.
+        self.box_dynamic_bytes = Box(arc4.DynamicBytes, key="b")
+        self.box_string = Box(arc4.String, key=b"BOX_STRING")
+        self.box_bytes = Box(Bytes, key=b"BOX_BYTES")
+        # BoxMap[K, V] is a family of boxes keyed by K with values of type V.
+        self.box_map = BoxMap(UInt64, String, key_prefix="")
+        # A BoxMap whose value is a Struct.
+        self.box_map_struct = BoxMap(arc4.UInt64, UserStruct, key_prefix="users")
+        # Boxes can also hold a non-ARC-4 Struct, including nested ones with
+        # dynamic arrays inside.
+        self.box_nested = Box(NestedStruct)
+
+    # example: INIT_BOX_STORAGE
+
+    # example: GET_BOX_STORAGE
+    @arc4.abimethod
+    def get_box(self) -> UInt64:
+        # `.value` reads the current contents; fails if the box does not exist.
+        return self.box_int.value
+
+    @arc4.abimethod
+    def get_item_box_map(self, key: UInt64) -> String:
+        # Indexing reads the box for `key`; fails if it does not exist.
+        return self.box_map[key]
+
+    @arc4.abimethod
+    def get_box_map(self) -> String:
+        # `.get(key, default=...)` returns the default when the box does not exist.
+        return self.box_map.get(UInt64(1), default=String("default"))
+
+    @arc4.abimethod
+    def maybe_box(self) -> tuple[UInt64, bool]:
+        # `.maybe()` returns `(value, exists)`; `value` is undefined when False.
+        return self.box_int.maybe()
+
+    @arc4.abimethod
+    def maybe_box_map(self) -> tuple[String, bool]:
+        value, exists = self.box_map.maybe(UInt64(1))
+        if not exists:
+            value = String("")
+        return value, exists
+
+    # example: GET_BOX_STORAGE
+
+    # example: GET_BOX_STORAGE_EXAMPLE
+    @arc4.abimethod
+    def get_box_example(self) -> tuple[UInt64, Bytes, arc4.String]:
+        return (
+            self.box_int.value,
+            self.box_dynamic_bytes.value.native,
+            self.box_string.value,
+        )
+
+    @arc4.abimethod
+    def get_box_map_struct(self, key: arc4.UInt64) -> UserStruct:
+        return self.box_map_struct[key]
+
+    @arc4.abimethod
+    def read_box_passed_to_subroutine(self, key: UInt64) -> String:
+        # Box and BoxMap proxies can be passed to subroutines.
+        return get_box_map_value_from_key_plus_1(self.box_map, key)
+
+    # example: GET_BOX_STORAGE_EXAMPLE
+
+    # example: SET_BOX_STORAGE
+    @arc4.abimethod
+    def set_box(self, value: UInt64) -> None:
+        self.box_int.value = value
+
+    @arc4.abimethod
+    def set_box_map(self, key: UInt64, value: String) -> None:
+        self.box_map[key] = value
+
+    @arc4.abimethod
+    def set_box_map_struct(self, key: arc4.UInt64, value: UserStruct) -> bool:
+        # ARC-4 Structs are reference-like; `.copy()` is required when assigning
+        # to storage so the box owns its own bytes.
+        self.box_map_struct[key] = value.copy()
+        assert self.box_map_struct[key] == value, "stored struct must round-trip"
+        return True
+
+    # example: SET_BOX_STORAGE
+
+    # example: SET_BOX_STORAGE_EXAMPLE
+    @arc4.abimethod
+    def set_box_example(
+        self,
+        value_int: UInt64,
+        value_dbytes: arc4.DynamicBytes,
+        value_string: arc4.String,
+    ) -> None:
+        self.box_int.value = value_int
+        self.box_dynamic_bytes.value = value_dbytes.copy()
+        self.box_string.value = value_string
+        self.box_bytes.value = value_dbytes.native
+
+        # Boxes support in-place mutation via augmented assignment.
+        self.box_int.value += 3
+
+    # example: SET_BOX_STORAGE_EXAMPLE
+
+    # example: DELETE_BOX_STORAGE
+    @arc4.abimethod
+    def delete_box(self) -> None:
+        # `del box.value` removes the box entirely.
+        del self.box_int.value
+        del self.box_dynamic_bytes.value
+        del self.box_string.value
+
+        # After deletion, `.get(default=...)` returns the default.
+        assert self.box_int.get(default=UInt64(42)) == 42, "box_int must be deleted"
+        assert (
+            self.box_dynamic_bytes.get(default=arc4.DynamicBytes(b"42")).native == b"42"
+        ), "box_dynamic_bytes must be deleted"
+        assert self.box_string.get(default=arc4.String("42")) == "42", "box_string must be deleted"
+
+    @arc4.abimethod
+    def delete_box_map(self, key: UInt64) -> None:
+        del self.box_map[key]
+
+    # example: DELETE_BOX_STORAGE
+
+    # example: LENGTH_BOX_STORAGE
+    @arc4.abimethod
+    def box_int_length(self) -> UInt64:
+        # `.length` is the size in bytes of the stored value.
+        return self.box_int.length
+
+    @arc4.abimethod
+    def box_map_length(self, key: UInt64) -> UInt64:
+        if key not in self.box_map:
+            return UInt64(0)
+        return self.box_map.length(key)
+
+    @arc4.abimethod
+    def box_map_struct_length(self) -> bool:
+        key = arc4.UInt64(0)
+        value = UserStruct(name=arc4.String("testName"), id=arc4.UInt64(70), asset=arc4.UInt64(2))
+
+        self.box_map_struct[key] = value.copy()
+        # The on-chain length matches the encoded byte length of the struct.
+        assert (
+            self.box_map_struct[key].bytes.length == value.bytes.length
+        ), "stored struct must have the same encoded length"
+        assert (
+            self.box_map_struct.length(key) == value.bytes.length
+        ), "box length must match the encoded length"
+        return True
+
+    # example: LENGTH_BOX_STORAGE
+
+    # example: EXTRACT_BOX
+    @arc4.abimethod
+    def extract_box(self) -> None:
+        # An ad-hoc Box[Bytes] is useful for low-level byte slicing.
+        box = Box(Bytes, key=String("blob"))
+        # `.create(size=n)` allocates a zero-filled box; True means newly created.
+        assert box.create(size=UInt64(32)), "box must not exist yet"
+
+        # Addresses are 32 bytes long.
+        sender_bytes = Txn.sender.bytes
+        app_address = Global.current_application_address.bytes
+        value_3 = Bytes(b"hello")
+        # `.replace(offset, value)` overwrites bytes in place.
+        box.replace(0, sender_bytes)
+        # `.resize(size)` grows (zero-padding the end) or shrinks the box;
+        # `.splice` cannot grow a box, so resize first to make room.
+        box.resize(32 * 2 + value_3.length)
+        # `.splice(offset, drop, value)` shifts bytes within the fixed-size
+        # box: here it inserts `app_address` at the front, pushing the
+        # existing content right; bytes past the box length are dropped.
+        box.splice(0, 0, app_address)
+        box.replace(64, value_3)
+        # `.extract(offset, length)` returns a slice without mutation.
+        prefix = box.extract(0, 32 * 2 + value_3.length)
+        assert prefix == app_address + sender_bytes + value_3, "unexpected box contents"
+        del box.value
+
+    # example: EXTRACT_BOX
+
+    # example: OTHER_OPS_BOX
+    @arc4.abimethod
+    def exist_box(self) -> tuple[bool, bool, bool, bool]:
+        # `bool(box)` is True if the box exists.
+        return (
+            bool(self.box_int),
+            bool(self.box_dynamic_bytes),
+            bool(self.box_string),
+            bool(self.box_bytes),
+        )
+
+    @arc4.abimethod
+    def slice_box(self) -> None:
+        box_0 = Box(Bytes, key=String("scratch"))
+        box_0.value = Bytes(b"Testing testing 123")
+        assert box_0.value[0:7] == b"Testing", "box value must support slicing"
+
+        self.box_string.value = arc4.String("Hello")
+        # `.value.bytes` exposes the raw encoded bytes of an ARC-4 value
+        # (an arc4.String is prefixed with its 2-byte length).
+        assert self.box_string.value.bytes[2:10] == b"Hello", "unexpected string contents"
+        del box_0.value
+
+    @arc4.abimethod
+    def arc4_box(self) -> None:
+        box_d = Box(StaticInts, key=Bytes(b"d"))
+        box_d.value = StaticInts(arc4.UInt8(0), arc4.UInt8(1), arc4.UInt8(2), arc4.UInt8(3))
+
+        assert box_d.value[0] == 0, "first element must be 0"
+        assert box_d.value[3] == 3, "last element must be 3"
+        del box_d.value
+
+    @arc4.abimethod
+    def key_box(self) -> Bytes:
+        return self.box_int.key
+
+    @arc4.abimethod
+    def key_box_example(self) -> None:
+        assert self.box_dynamic_bytes.key == b"b", "key must match the explicit str key"
+        assert self.box_string.key == b"BOX_STRING", "key must match the explicit bytes key"
+        assert self.box_bytes.key == b"BOX_BYTES", "key must match the explicit bytes key"
+
+    # example: OTHER_OPS_BOX
+
+    # example: OTHER_OPS_BOX_MAP
+    @arc4.abimethod
+    def box_map_exists(self, key: UInt64) -> bool:
+        # `key in box_map` is True if the box for `key` exists.
+        return key in self.box_map
+
+    @arc4.abimethod
+    def box_map_struct_exists(self, key: arc4.UInt64) -> bool:
+        return key in self.box_map_struct
+
+    @arc4.abimethod
+    def key_prefix_box_map(self) -> Bytes:
+        return self.box_map.key_prefix
+
+    # example: OTHER_OPS_BOX_MAP
+
+    # example: NESTED_STRUCT_BOX
+    @arc4.abimethod
+    def nested_struct_write(self, value: UInt64) -> None:
+        # Boxes can hold Structs whose fields are themselves Structs or Arrays.
+        # Field assignment writes through to the underlying box bytes.
+        self.box_nested.value = NestedStruct(
+            a=value,
+            inner=InnerStruct(c=value + 1, arr=Array[UInt64](), d=value + 2),
+            siblings=Array[InnerStruct](),
+            b=value + 3,
+        )
+        for i in urange(3):
+            self.box_nested.value.inner.arr.append(i)
+
+    @arc4.abimethod
+    def nested_struct_sum(self) -> UInt64:
+        total = self.box_nested.value.a + self.box_nested.value.b
+        total += self.box_nested.value.inner.c + self.box_nested.value.inner.d
+        for v in self.box_nested.value.inner.arr:
+            total += v
+        return total
+
+    # example: NESTED_STRUCT_BOX
+
+
+@subroutine
+def get_box_map_value_from_key_plus_1(box_map: BoxMap[UInt64, String], key: UInt64) -> String:
+    """BoxMap proxies are first-class values and can be passed to subroutines."""
+    return box_map[key + 1]

--- a/examples/devportal/contract_options/contract.py
+++ b/examples/devportal/contract_options/contract.py
@@ -1,0 +1,111 @@
+from algopy import (
+    ARC4Contract,
+    Bytes,
+    GlobalState,
+    StateTotals,
+    Txn,
+    UInt64,
+    arc4,
+    op,
+    urange,
+)
+
+
+# example: CONTRACT_NAME
+class ContractWithCustomName(ARC4Contract, name="OnChainName"):
+    """
+    `name=` on the class kwargs serves two purposes:
+      * It overrides the output TEAL file name when multiple non-abstract
+        contracts share a source file.
+      * For `ARC4Contract` subclasses, it sets the contract name in the
+        published ARC-32 application.json (and ARC-56), decoupling the
+        on-chain identity from the Python class name.
+
+    Useful for renaming the implementation class without breaking client
+    code that pins to the published name.
+    """
+
+    @arc4.abimethod
+    def hello(self) -> arc4.String:
+        return arc4.String("hello")
+
+
+# example: CONTRACT_NAME
+
+
+# example: CONTRACT_STATE_TOTALS
+class ContractWithStateReservation(
+    ARC4Contract,
+    state_totals=StateTotals(global_uints=16, global_bytes=8, local_uints=4),
+):
+    """
+    `state_totals=` declares the total state slots the application requires,
+    overriding the automatic calculation from `self.` declarations.
+
+    Required when:
+      * The contract reads or writes state via dynamic keys (`op.AppGlobal.put(...)`
+        etc.) that puya can't see by inspecting `self.` assignments.
+      * You want to reserve extra slots for future upgrades. However, the AVM
+        now does allow updates to state totals after creation.
+    """
+
+    def __init__(self) -> None:
+        # Puya sees these two `self.` assignments and would auto-compute
+        # `global_uints=1`, `global_bytes=1`. The explicit `state_totals=`
+        # above reserves 16 + 8 instead, leaving room for upgrades.
+        self.counter = GlobalState(UInt64(0))
+        self.label = GlobalState(Bytes(b""))
+
+    @arc4.abimethod
+    def increment(self) -> UInt64:
+        self.counter.value += 1
+        return self.counter.value
+
+
+# example: CONTRACT_STATE_TOTALS
+
+
+# example: CONTRACT_SCRATCH_SLOTS
+class ContractWithScratchReservation(
+    ARC4Contract,
+    # `urange(200, 256)` reserves slots 200..255 for non-puya use (e.g.
+    # `op.Scratch.store`, `op.Scratch.load`, and ReferenceArray usage).
+    scratch_slots=urange(200, 256),
+):
+    """
+    `scratch_slots=` reserves AVM scratch slots so puya won't try to use
+    them for compiler-managed values. Pass a `urange`, a tuple of ints, or
+    a list of ints/uranges.
+    """
+
+    @arc4.abimethod
+    def echo(self, x: UInt64) -> UInt64:
+        # write to the reserved slots 200..255 directly; puya will avoid
+        # internally placing any values there under any circumstance
+        for i in urange(200, 256):
+            op.Scratch.store(i, x)
+        return x
+
+
+# example: CONTRACT_SCRATCH_SLOTS
+
+
+# example: CONTRACT_AVM_VERSION
+class ContractWithAvmVersion(ARC4Contract, avm_version=12):
+    """
+    `avm_version=` pins the contract to a specific AVM version. The compiler
+    allows opcodes available in that version, rejects ones introduced later,
+    and the produced bytecode declares the version at the top.
+    Using the default (latest) version is recommended, use this only if needed.
+    """
+
+    @arc4.abimethod
+    def caller_pin(self) -> UInt64:
+        """`Txn.reject_version` is a transaction field introduced in
+        AVM 12, so reading it compiles because of the `avm_version=12`
+        declaration above; on an older target version the compiler rejects
+        it."""
+        return Txn.reject_version
+
+
+# example: CONTRACT_AVM_VERSION

--- a/examples/devportal/control_flow/contract.py
+++ b/examples/devportal/control_flow/contract.py
@@ -1,0 +1,110 @@
+import typing
+
+from algopy import ARC4Contract, String, UInt64, arc4, uenumerate, urange
+
+
+class IfElseExample(ARC4Contract):
+    # example: IF_ELSE
+    @arc4.abimethod
+    def is_rich(self, account_balance: UInt64) -> String:
+        """`if`/`elif`/`else` statements work just like in standard Python."""
+        if account_balance > 1000:
+            return String("This account is rich!")
+        elif account_balance > 100:
+            return String("This account is doing well.")
+        else:
+            return String("This account is poor :(")
+
+    # example: IF_ELSE
+
+    # example: TERNARY
+    @arc4.abimethod
+    def is_even(self, number: UInt64) -> String:
+        """Conditional (ternary) expressions are supported too."""
+        return String("Even") if number % 2 == 0 else String("Odd")
+
+    # example: TERNARY
+
+
+# example: FOR_LOOP
+FourArray: typing.TypeAlias = arc4.StaticArray[arc4.UInt8, typing.Literal[4]]
+
+
+class ForLoopsExample(ARC4Contract):
+    @arc4.abimethod
+    def for_loop(self) -> FourArray:
+        """`urange` iterates over a sequence of `UInt64` values, and composes
+        with `reversed` and `uenumerate` (the `UInt64` counterpart of
+        `enumerate`) just like in standard Python."""
+        array = FourArray(arc4.UInt8(0), arc4.UInt8(0), arc4.UInt8(0), arc4.UInt8(0))
+
+        # reversed items, forward index: item takes 3, 2, 1, 0 at index 0..3
+        for index, item in uenumerate(reversed(urange(4))):
+            array[index] = arc4.UInt8(item)
+
+        x = UInt64(0)
+
+        for item in urange(1, 5):  # [1, 2, 3, 4]
+            x += item
+
+        assert x == 10, "expected sum of 1 + 2 + 3 + 4"
+
+        return array
+
+
+# example: FOR_LOOP
+
+
+# example: MATCH
+class MatchStatements(ARC4Contract):
+    @arc4.abimethod
+    def get_day(self, day: UInt64) -> String:
+        """`match` statements support `UInt64` subjects; the wildcard `_`
+        case catches any value the other cases do not."""
+        match day:
+            case UInt64(0):
+                return String("Monday")
+            case UInt64(1):
+                return String("Tuesday")
+            case UInt64(2):
+                return String("Wednesday")
+            case UInt64(3):
+                return String("Thursday")
+            case UInt64(4):
+                return String("Friday")
+            case UInt64(5):
+                return String("Saturday")
+            case UInt64(6):
+                return String("Sunday")
+            case _:
+                return String("Invalid day")
+
+
+# example: MATCH
+
+
+# example: WHILE_LOOP
+class WhileLoopExample(ARC4Contract):
+    @arc4.abimethod
+    def loop(self) -> UInt64:
+        """`while` loops, including `continue` and `break`, behave just like
+        in standard Python."""
+        num = UInt64(10)
+        loop_count = UInt64(0)
+
+        while num > 0:
+            if num > 5:
+                num -= 1
+                loop_count += 1
+                continue
+
+            num -= 2
+            loop_count += 1
+
+            if num == 1:
+                break
+
+        return loop_count
+
+
+# example: WHILE_LOOP

--- a/examples/devportal/crypto_ops/contract.py
+++ b/examples/devportal/crypto_ops/contract.py
@@ -1,0 +1,118 @@
+from algopy import ARC4Contract, Bytes, UInt64, arc4, op
+
+
+class CryptoOps(ARC4Contract):
+    """
+    A tour of the cryptographic opcodes exposed via `algopy.op`.
+
+    All hash and verify opcodes accept `BytesBacked` inputs: `Bytes`,
+    `String`, `arc4` values, account addresses; basically any type that is
+    represented as a byte array in the TEAL code (including plain `bytes`
+    literals).
+
+    Most of these opcodes are expensive: they cost far more than the 700
+    opcode-budget units a single application call provides, so callers
+    typically pool budget by grouping the call with extra app calls, or the
+    contract raises its own budget with `algopy.ensure_budget` (see the
+    op_budget example).
+
+    As many of these constitute some sort of cryptographic verification,
+    many times they can also be used in conjunction with logic signatures,
+    which are stateless programs executed at transaction signature verification
+    time but have a budget separate to app calls in a group.
+    """
+
+    # example: SHA_HASHES
+    @arc4.abimethod
+    def hashes(self, data: Bytes) -> tuple[Bytes, Bytes, Bytes, Bytes]:
+        """
+        Most common hashing algorithms.
+        All return `Bytes`. Always remember that the input arguments
+        are visible in the AVM, and thus the preimage of the hash
+        is easily reconstructible for anything being hashed on-chain.
+        """
+        return (
+            op.sha256(data),
+            op.sha3_256(data),
+            op.sha512_256(data),
+            op.keccak256(data),
+        )
+
+    # example: SHA_HASHES
+
+    # example: ED25519_VERIFY
+    @arc4.abimethod
+    def ed25519(self, data: Bytes, signature: Bytes, public_key: Bytes) -> tuple[bool, bool]:
+        """
+        Two ed25519 verify variants:
+          * `ed25519verify` given some data, a signature and a public key,
+            it verifies the signature over `"ProgData" || program_hash || data`
+            (where `program_hash` is the hash of the current program and "ProgData"
+            is just a string used as domain separator).
+          * `ed25519verify_bare` given the same 3 parameters, it verifies
+            the signature over the raw data.
+        """
+        bound = op.ed25519verify(data, signature, public_key)
+        bare = op.ed25519verify_bare(data, signature, public_key)
+        return bound, bare
+
+    # example: ED25519_VERIFY
+
+    # example: ECDSA_VERIFY
+    @arc4.abimethod
+    def ecdsa(
+        self,
+        data: Bytes,
+        sig_r: Bytes,
+        sig_s: Bytes,
+        pubkey_x: Bytes,
+        pubkey_y: Bytes,
+    ) -> tuple[bool, bool]:
+        """
+        ECDSA verify over either Secp256k1 (Bitcoin-compatible) or
+        Secp256r1 (used by passkeys / WebAuthn). `data` must be a 32-byte
+        digest of the signed message (hash it before calling); the signature
+        is supplied as (R, S) — in canonical low-S form — and the public key
+        as (X, Y), both decompressed.
+        """
+        k1 = op.ecdsa_verify(op.ECDSA.Secp256k1, data, sig_r, sig_s, pubkey_x, pubkey_y)
+        r1 = op.ecdsa_verify(op.ECDSA.Secp256r1, data, sig_r, sig_s, pubkey_x, pubkey_y)
+        return k1, r1
+
+    @arc4.abimethod
+    def ecdsa_decompress(self, compressed_pubkey: Bytes) -> tuple[Bytes, Bytes]:
+        """
+        `ecdsa_pk_decompress` expands a compressed (33-byte) Secp256k1 or
+        Secp256r1 public key into its (X, Y) components. Useful for
+        accepting compressed keys on the wire while feeding `ecdsa_verify`.
+        """
+        return op.ecdsa_pk_decompress(op.ECDSA.Secp256k1, compressed_pubkey)
+
+    @arc4.abimethod
+    def ecdsa_recover(
+        self, digest: Bytes, recovery_id: UInt64, sig_r: Bytes, sig_s: Bytes
+    ) -> tuple[Bytes, Bytes]:
+        """
+        `ecdsa_pk_recover` recovers the signer's public key (X, Y) from a
+        32-byte digest, a signature and its recovery id — Bitcoin/Ethereum
+        style "ecrecover". Only supported for Secp256k1.
+        """
+        return op.ecdsa_pk_recover(op.ECDSA.Secp256k1, digest, recovery_id, sig_r, sig_s)
+
+    # example: ECDSA_VERIFY
+
+    # example: VRF_VERIFY
+    @arc4.abimethod
+    def vrf(self, message: Bytes, proof: Bytes, public_key: Bytes) -> tuple[Bytes, bool]:
+        """
+        VRF (Verifiable Random Function) verification using the
+        `VrfAlgorand` parameter set (ECVRF-ED25519-SHA512-Elligator2).
+
+        Returns a `(vrf_output, verified)` tuple: the output is the random
+        bytes derived from the message, and `verified` is True only if the
+        proof checks against `public_key`. The output is meaningful only
+        when `verified` is True.
+        """
+        return op.vrf_verify(op.VrfVerify.VrfAlgorand, message, proof, public_key)
+
+    # example: VRF_VERIFY

--- a/examples/devportal/events/contract.py
+++ b/examples/devportal/events/contract.py
@@ -1,0 +1,89 @@
+from algopy import Account, ARC4Contract, String, Struct, UInt64, arc4
+
+
+# example: ARC28_EVENT_STRUCT
+class Swapped(arc4.Struct):
+    """
+    A typed ARC-28 event. The signature emitted on-chain is derived from the
+    class name and field types: `Swapped(address,address,uint64,uint64)`.
+
+    The first 4 bytes of the SHA-512/256 of that signature form the event's
+    selector; the rest of the log payload is the ARC-4 encoding of the fields.
+    Indexers can subscribe to the selector to pick up only this event.
+    """
+
+    sender: arc4.Address
+    receiver: arc4.Address
+    in_amount: arc4.UInt64
+    out_amount: arc4.UInt64
+
+
+class NativeStruct(Struct):
+    """
+    Native structs can also be directly emitted.
+    In this case the equivalent arc4 representation
+    of the native types will be used.
+    """
+
+    count: UInt64
+    message: String
+
+
+class SwapContract(ARC4Contract):
+    @arc4.abimethod
+    def swap_emit_struct(
+        self, sender: Account, receiver: Account, in_amount: UInt64, out_amount: UInt64
+    ) -> None:
+        """Emit by passing the Struct instance (recommended form)."""
+        event = Swapped(
+            sender=arc4.Address(sender),
+            receiver=arc4.Address(receiver),
+            in_amount=arc4.UInt64(in_amount),
+            out_amount=arc4.UInt64(out_amount),
+        )
+        arc4.emit(event)
+
+        native_event = NativeStruct(count=in_amount, message=String("payment received"))
+        arc4.emit(native_event)
+
+
+# example: ARC28_EVENT_STRUCT
+
+
+# example: ARC28_EVENT_BY_SIGNATURE
+class TransferContract(ARC4Contract):
+    @arc4.abimethod
+    def transfer_emit_signature(self, sender: Account, receiver: Account, amount: UInt64) -> None:
+        """
+        Emit using an explicit ARC-28 signature string. The signature must
+        match the runtime arg types; puya type-checks the args against it.
+        """
+        arc4.emit(
+            "Transfer(address,address,uint64)",
+            arc4.Address(sender),
+            arc4.Address(receiver),
+            arc4.UInt64(amount),
+        )
+
+
+# example: ARC28_EVENT_BY_SIGNATURE
+
+
+# example: ARC28_EVENT_BY_NAME
+class MintContract(ARC4Contract):
+    @arc4.abimethod
+    def mint_emit_by_name(self, recipient: Account, amount: UInt64) -> None:
+        """
+        Emit using only an event *name*; the signature is inferred from the
+        types of the following args. Equivalent to the by-signature form when
+        the inferred shape matches what off-chain consumers expect.
+
+        Be aware that the inferred ARC-4 types are picked from the runtime arg
+        types, so passing native types (e.g. `UInt64`) results in a different
+        signature than passing the ARC-4 equivalent (`arc4.UInt64`). Prefer
+        the explicit signature form when the shape must be exact.
+        """
+        arc4.emit("Mint", arc4.Address(recipient), arc4.UInt64(amount))
+
+
+# example: ARC28_EVENT_BY_NAME

--- a/examples/devportal/global_state/contract.py
+++ b/examples/devportal/global_state/contract.py
@@ -1,0 +1,288 @@
+from algopy import (
+    Account,
+    Application,
+    ARC4Contract,
+    Asset,
+    Bytes,
+    GlobalMap,
+    GlobalState,
+    StateTotals,
+    String,
+    UInt64,
+    arc4,
+    subroutine,
+)
+
+
+# example: GLOBAL_MAP_STRUCT
+class Profile(arc4.Struct):
+    """An ARC-4 struct stored as the value type of a GlobalMap."""
+
+    name: arc4.String
+    score: arc4.UInt64
+
+
+# example: GLOBAL_MAP_STRUCT
+
+
+class GlobalStorage(ARC4Contract):
+    # example: INIT_GLOBAL_STORAGE
+    def __init__(self) -> None:
+        # The full form `GlobalState(UInt64(50))` declares a typed proxy and an
+        # initial value. The proxy exposes `.value`, `.get(default=...)`, and
+        # `.maybe()` for richer read patterns.
+        self.global_int_full = GlobalState(UInt64(50))
+        # The short form binds the attribute to a value directly. Reads use the
+        # attribute name itself (no `.value`); there is no proxy API.
+        self.global_int_simplified = UInt64(10)
+        # `GlobalState(UInt64)` declares the type but leaves the slot empty
+        # until it is written. Reads must go through `.maybe()` or `.get(...)`.
+        self.global_int_no_default = GlobalState(UInt64)
+
+        # example: INIT_BYTES
+        self.global_bytes_full = GlobalState(Bytes(b"Hello"))
+        self.global_bytes_simplified = Bytes(b"Hello")
+        self.global_bytes_no_default = GlobalState(Bytes)
+        # example: INIT_BYTES
+
+        self.global_bool_simplified = True
+        self.global_bool_no_default = GlobalState(bool)
+
+        # Reference types are declared without defaults; they are populated by
+        # later writes from method bodies.
+        self.global_asset = GlobalState(Asset)
+        self.global_application = GlobalState(Application)
+        self.global_account = GlobalState(Account)
+
+    # example: INIT_GLOBAL_STORAGE
+
+    # example: READ_GLOBAL_STATE
+    @arc4.abimethod
+    def get_global_state(self) -> UInt64:
+        # `.get(default=...)` returns the default when the slot is empty.
+        return self.global_int_no_default.get(default=UInt64(0))
+
+    @arc4.abimethod
+    def maybe_global_state(self) -> tuple[UInt64, bool]:
+        # `.maybe()` returns `(value, exists)`; when `exists` is False, `value`
+        # is the type's zero value and should not be relied upon.
+        value, exists = self.global_int_no_default.maybe()
+        if not exists:
+            value = UInt64(0)
+        return value, exists
+
+    @arc4.abimethod
+    def get_global_state_example(self) -> bool:
+        # The full form supports `.get(default=...)` and `.value`.
+        assert self.global_int_full.get(default=UInt64(0)) == 50, "expected initial value 50"
+        # The simplified form is the value itself; no proxy methods apply.
+        assert self.global_int_simplified == UInt64(10), "expected initial value 10"
+        assert self.global_int_no_default.get(default=UInt64(0)) == 0, "expected default 0"
+        assert (
+            self.global_bytes_full.get(default=Bytes(b"default")) == b"Hello"
+        ), "expected initial value Hello"
+        return True
+
+    # example: READ_GLOBAL_STATE
+
+    # example: READ_GLOBAL_STATE_EXAMPLES
+    @arc4.abimethod
+    def maybe_global_state_example(self) -> bool:
+        int_value, int_exists = self.global_int_full.maybe()
+        assert int_exists, "global_int_full should have a value"
+        assert int_value == UInt64(50), "expected initial value 50"
+
+        bytes_value, bytes_exists = self.global_bytes_full.maybe()
+        assert bytes_exists, "global_bytes_full should have a value"
+        assert bytes_value == b"Hello", "expected initial value Hello"
+
+        # `no_default` slots start empty, so `.maybe()` returns False.
+        _asset, asset_exists = self.global_asset.maybe()
+        assert not asset_exists, "global_asset should start empty"
+        return True
+
+    # example: READ_GLOBAL_STATE_EXAMPLES
+
+    # example: VALUE_PROPERTY_GLOBAL_STATE_EXAMPLES
+    @arc4.abimethod
+    def check_global_state_example(self) -> bool:
+        # `.value` on a populated proxy returns the stored value directly.
+        assert self.global_int_full.value == 50, "expected initial value 50"
+        assert self.global_bytes_full.value == Bytes(b"Hello"), "expected initial value Hello"
+
+        # Simplified-form attributes are just the value.
+        assert self.global_int_simplified == 10, "expected initial value 10"
+        assert self.global_bytes_simplified == b"Hello", "expected initial value Hello"
+        assert bool(self.global_bool_simplified), "expected initial value True"
+
+        # Truthiness on a proxy is "does the slot have a value".
+        assert not self.global_int_no_default, "global_int_no_default should start empty"
+        assert not self.global_bytes_no_default, "global_bytes_no_default should start empty"
+        assert not self.global_bool_no_default, "global_bool_no_default should start empty"
+        return True
+
+    # example: VALUE_PROPERTY_GLOBAL_STATE_EXAMPLES
+
+    # example: WRITE_GLOBAL_STATE
+    @arc4.abimethod
+    def set_global_state(self, value: Bytes) -> None:
+        # `.value = ...` writes through the proxy.
+        self.global_bytes_full.value = value
+
+    # example: WRITE_GLOBAL_STATE
+
+    # example: WRITE_GLOBAL_STATE_EXAMPLES
+    @arc4.abimethod
+    def set_global_state_example(
+        self,
+        value_bytes: Bytes,
+        value_asset: Asset,
+        value_app: Application,
+        value_account: Account,
+        *,
+        value_bool: bool,
+    ) -> None:
+        self.global_bytes_no_default.value = value_bytes
+        assert self.global_bytes_no_default.value == value_bytes, "bytes value should be stored"
+
+        self.global_bool_no_default.value = value_bool
+        assert self.global_bool_no_default.value == value_bool, "bool value should be stored"
+
+        self.global_asset.value = value_asset
+        self.global_application.value = value_app
+        self.global_account.value = value_account
+
+        # The simplified form is mutated via plain attribute assignment.
+        self.global_int_simplified = UInt64(99)
+        assert self.global_int_simplified == 99, "int value should be stored"
+
+    # example: WRITE_GLOBAL_STATE_EXAMPLES
+
+    # example: DELETE_GLOBAL_STATE
+    @arc4.abimethod
+    def del_global_state(self) -> bool:
+        del self.global_int_full.value
+        # After deletion, `.maybe()` reports the slot as empty again.
+        _value, exists = self.global_int_full.maybe()
+        assert not exists, "global_int_full should be empty after deletion"
+        return True
+
+    # example: DELETE_GLOBAL_STATE
+
+    # example: DELETE_GLOBAL_STATE_EXAMPLES
+    @arc4.abimethod
+    def del_global_state_example(self) -> bool:
+        # Deleting is idempotent: it succeeds even if the slot is already empty.
+        del self.global_bytes_no_default.value
+        del self.global_bool_no_default.value
+        del self.global_asset.value
+        return True
+
+    # example: DELETE_GLOBAL_STATE_EXAMPLES
+
+    @arc4.abimethod
+    def pass_proxy_to_subroutine(self) -> UInt64:
+        # GlobalState proxies can be passed to subroutines like any value.
+        self.global_int_no_default.value = UInt64(44)
+        return get_global_state_plus_1(self.global_int_no_default)
+
+    @arc4.abimethod
+    def dynamic_key_access(self) -> tuple[UInt64, Bytes]:
+        # A GlobalState constructed inside a method shares the underlying
+        # storage slot named by `key`. This is useful for dynamic key lookups.
+        self.global_int_no_default.value = UInt64(7)
+        self.global_bytes_no_default.value = Bytes(b"hi")
+        return (
+            read_global_uint64(Bytes(b"global_int_no_default")),
+            read_global_bytes(String("global_bytes_no_default")),
+        )
+
+
+@subroutine
+def get_global_state_plus_1(state: GlobalState[UInt64]) -> UInt64:
+    """A GlobalState[T] proxy can be passed to and read from a subroutine."""
+    return state.value + 1
+
+
+@subroutine
+def read_global_uint64(key: Bytes) -> UInt64:
+    """Re-create the proxy from a dynamic key to read the underlying slot."""
+    return GlobalState(UInt64, key=key).value
+
+
+@subroutine
+def read_global_bytes(key: String) -> Bytes:
+    return GlobalState(Bytes, key=key).value
+
+
+class GlobalStorageMap(
+    ARC4Contract,
+    state_totals=StateTotals(global_uints=16, global_bytes=16),
+):
+    """
+    Demonstrates `GlobalMap`, a typed key→value collection backed by global
+    state. Each key consumes one global-state slot, so capacity must be sized
+    on the application via `algopy.StateTotals` at creation time, although
+    it may be expanded throughout the app's lifecycle. The numbers
+    here are the per-app maximums reserved for `scores` (uint) and `profiles`
+    (bytes).
+    """
+
+    # example: INIT_GLOBAL_MAP
+    def __init__(self) -> None:
+        # `GlobalMap[K, V]` stores `V` keyed by `K` in global state.
+        # `key_prefix` is prepended to every stored key; it defaults to the
+        # attribute name when omitted.
+        self.scores = GlobalMap(arc4.String, UInt64)
+        self.profiles = GlobalMap(UInt64, Profile, key_prefix="profile")
+
+    # example: INIT_GLOBAL_MAP
+
+    # example: READ_GLOBAL_MAP
+    @arc4.abimethod
+    def get_score(self, name: arc4.String) -> UInt64:
+        # Indexing reads the slot for `name`; fails if not present.
+        return self.scores[name]
+
+    @arc4.abimethod
+    def get_score_or_default(self, name: arc4.String) -> UInt64:
+        # `.get(key, default=...)` returns the default if the key is missing.
+        return self.scores.get(name, default=UInt64(0))
+
+    @arc4.abimethod
+    def maybe_score(self, name: arc4.String) -> tuple[UInt64, bool]:
+        # `.maybe(key)` returns `(value, exists)`.
+        return self.scores.maybe(name)
+
+    @arc4.abimethod
+    def has_profile(self, user_id: UInt64) -> bool:
+        # `key in map` is True if the key has a stored value.
+        return user_id in self.profiles
+
+    # example: READ_GLOBAL_MAP
+
+    # example: WRITE_GLOBAL_MAP
+    @arc4.abimethod
+    def set_score(self, name: arc4.String, score: UInt64) -> None:
+        self.scores[name] = score
+
+    @arc4.abimethod
+    def set_profile(self, user_id: UInt64, profile: Profile) -> None:
+        # ARC-4 Structs are reference-like; `.copy()` ensures the map owns its bytes.
+        self.profiles[user_id] = profile.copy()
+
+    # example: WRITE_GLOBAL_MAP
+
+    # example: DELETE_GLOBAL_MAP
+    @arc4.abimethod
+    def delete_score(self, name: arc4.String) -> None:
+        del self.scores[name]
+
+    # example: DELETE_GLOBAL_MAP
+
+    @arc4.abimethod
+    def get_slot_proxy(self, name: arc4.String) -> UInt64:
+        # `.state(key)` returns a `GlobalState[V]` proxy for a single slot,
+        # which can be passed to subroutines or used with `.value`, `.maybe()`, etc.
+        slot = self.scores.state(name)
+        return slot.value

--- a/examples/devportal/group_transactions/contract.py
+++ b/examples/devportal/group_transactions/contract.py
@@ -1,0 +1,142 @@
+from algopy import ARC4Contract, Asset, Global, Txn, UInt64, arc4, gtxn, itxn
+
+
+class GroupTransactions(ARC4Contract):
+    """
+    Demonstrates two complementary ways to read sibling transactions from
+    the current atomic group:
+
+    1. **Index lookup** (`gtxn.*Transaction(index)`): a runtime assertion +
+       typed view. Fails the txn unless the transaction at `index` is of
+       that type. Useful when the shape can't be encoded in the ABI
+       signature, and may assert facts about transactions coming later
+       in the group as well as before.
+
+    2. **Typed ABI argument**: declare a `gtxn.*Transaction` directly as a
+       method parameter. Transaction parameters are purely *positional*:
+       they consume no space in the application args array, and the router
+       binds them to the transactions immediately preceding this call, in
+       declaration order, asserting each one's type before the body runs.
+    """
+
+    # example: GTXN_PAYMENT
+    @arc4.abimethod
+    def expect_payment(self, expected_amount: UInt64) -> UInt64:
+        """
+        Expects a Payment transaction immediately before this app call.
+        The `gtxn.PaymentTransaction(index)` form fails if the txn at
+        `index` is not a Payment (or is not present), eliminating the
+        need for an explicit `Txn.type_enum` check.
+        """
+        pay_txn = gtxn.PaymentTransaction(Txn.group_index - 1)
+        assert pay_txn.receiver == Global.current_application_address, "payment must be to app"
+        assert pay_txn.amount == expected_amount, "wrong payment amount"
+        return pay_txn.amount
+
+    # example: GTXN_PAYMENT
+
+    # example: GTXN_ASSET_TRANSFER
+    @arc4.abimethod
+    def expect_asset_transfer(self, asset: Asset) -> UInt64:
+        """
+        Expects an AssetTransfer transaction immediately before this call.
+        Validates the asset id, sender, and that we (the app account) are
+        the recipient.
+        """
+        axfer = gtxn.AssetTransferTransaction(Txn.group_index - 1)
+        assert axfer.xfer_asset == asset, "wrong asset"
+        assert (
+            axfer.asset_receiver == Global.current_application_address
+        ), "transfer must be to app"
+        assert axfer.sender == Txn.sender, "transfer must come from caller"
+        return axfer.asset_amount
+
+    # example: GTXN_ASSET_TRANSFER
+
+    @arc4.abimethod
+    def opt_in_to_asset(self, asset: Asset) -> None:
+        """
+        Opt the application account into `asset` via an inner zero-amount
+        transfer, so it can be the recipient in the `expect_asset_transfer`
+        and `receive_asset_transfer` patterns above.
+        """
+        itxn.AssetTransfer(
+            xfer_asset=asset,
+            asset_receiver=Global.current_application_address,
+            asset_amount=0,
+        ).submit()
+
+    # example: GTXN_APP_CALL
+    @arc4.abimethod
+    def chained_app_call(self) -> UInt64:
+        """
+        Expects an ApplicationCall transaction immediately before this call.
+        `last_log` exposes the previous app's last log entry, which lets
+        chained app calls observe each other's output.
+        """
+        prev = gtxn.ApplicationCallTransaction(Txn.group_index - 1)
+        # `arc4.UInt64.from_log(...)` decodes a typed value off the log.
+        prev_count = arc4.UInt64.from_log(prev.last_log)
+        return prev_count.as_uint64()
+
+    # example: GTXN_APP_CALL
+
+    # example: GTXN_TYPED_ARGS
+    @arc4.abimethod
+    def receive_funding(
+        self,
+        pay: gtxn.PaymentTransaction,
+        axfer: gtxn.AssetTransferTransaction,
+        asset: Asset,
+        expected_amount: UInt64,
+    ) -> UInt64:
+        """
+        Typed-arg form of the `expect_*` lookups, with two transaction
+        parameters to show the binding rule: declaration order is group
+        order, ending at this call: the group must look like
+        `[..., pay, axfer, this call, ...]`, so `pay` is bound to
+        `Txn.group_index - 2` and `axfer` to `Txn.group_index - 1`.
+        The positions are fixed by that rule (the caller cannot choose
+        them), and each position's transaction type is asserted before the
+        body runs, so only the *fields* still need validating here.
+        """
+        assert pay.receiver == Global.current_application_address, "payment must be to app"
+        assert pay.amount == expected_amount, "wrong payment amount"
+        assert axfer.xfer_asset == asset, "wrong asset"
+        assert (
+            axfer.asset_receiver == Global.current_application_address
+        ), "transfer must be to app"
+        assert axfer.sender == Txn.sender, "transfer must come from caller"
+        return pay.amount + axfer.asset_amount
+
+    @arc4.abimethod
+    def observe_app_call(self, prev: gtxn.ApplicationCallTransaction) -> UInt64:
+        """Typed-arg form of `chained_app_call`: a single transaction
+        parameter always binds to the transaction immediately preceding
+        this call (`Txn.group_index - 1`), with its type asserted by the
+        router. Reading `last_log` works the same as via index lookup."""
+        prev_count = arc4.UInt64.from_log(prev.last_log)
+        return prev_count.as_uint64()
+
+    # example: GTXN_TYPED_ARGS
+
+    # example: GROUP_POSITION_GUARDS
+    @arc4.abimethod
+    def strict_position(self, expected_size: UInt64) -> None:
+        """
+        Group-position guards: the `Global.group_size` and `Txn.group_index`
+        properties let a contract verify its place in the group exactly.
+        Useful for atomic patterns that depend on a fixed shape, e.g.
+        `[Payment, AppCall, AssetTransfer]`.
+        """
+        assert Global.group_size == expected_size, "wrong group size"
+        # This contract expects to sit at index 1 in a 3-txn group.
+        assert Txn.group_index == 1, "must be index 1"
+
+        # Reading the surrounding txns by absolute position rather than
+        # relative to `group_index` is sometimes clearer.
+        pay = gtxn.PaymentTransaction(0)
+        axfer = gtxn.AssetTransferTransaction(2)
+        assert pay.sender == axfer.asset_receiver, "sender must receive axfer"
+
+    # example: GROUP_POSITION_GUARDS

--- a/examples/devportal/inner_transactions/contract.py
+++ b/examples/devportal/inner_transactions/contract.py
@@ -1,0 +1,221 @@
+from algopy import (
+    Account,
+    Application,
+    ARC4Contract,
+    Asset,
+    Global,
+    String,
+    Txn,
+    UInt64,
+    arc4,
+    compile_contract,
+    itxn,
+)
+
+
+class HelloWorldContract(ARC4Contract):
+    """
+    A minimal callee used by `InnerTransactions.deploy_app` and friends.
+    Kept in this file so the example is self-contained.
+    """
+
+    @arc4.abimethod
+    def hello(self, name: String) -> String:
+        return "Hello, " + name
+
+
+class InnerTransactions(ARC4Contract):
+    # example: PAYMENT
+    @arc4.abimethod
+    def payment(self) -> UInt64:
+        """
+        The inner transaction `fee` defaults to 0, so the outer transaction must cover
+        it; it is only set explicitly here for demonstration purposes.
+        The sender is implied to be `Global.current_application_address`.
+
+        If a different sender is needed, it'd have to be an account that has been
+        rekeyed to the application address.
+        """
+        result = itxn.Payment(amount=5000, receiver=Txn.sender, fee=0).submit()
+        return result.amount
+
+    # example: PAYMENT
+
+    # example: ASSET_CREATE
+    @arc4.abimethod
+    def fungible_asset_create(self) -> UInt64:
+        itxn_result = itxn.AssetConfig(
+            total=100_000_000_000,
+            decimals=2,
+            unit_name="RP",
+            asset_name="Royalty Points",
+        ).submit()
+        return itxn_result.created_asset.id
+
+    @arc4.abimethod
+    def non_fungible_asset_create(self) -> UInt64:
+        """
+        Following the ARC3 standard, a non-fungible asset must have an on-chain total
+        supply of exactly 1 whole unit. For fractional NFTs that means
+        `total` must equal 10^`decimals`.
+        Example: total=100, decimals=2 -> 100 * 0.01 = 1 whole unit
+        """
+        itxn_result = itxn.AssetConfig(
+            total=100,
+            decimals=2,
+            unit_name="ML",
+            asset_name="Mona Lisa",
+            url="https://link_to_ipfs/Mona_Lisa",
+            manager=Global.current_application_address,
+            reserve=Global.current_application_address,
+            freeze=Global.current_application_address,
+            clawback=Global.current_application_address,
+        ).submit()
+        return itxn_result.created_asset.id
+
+    # example: ASSET_CREATE
+
+    # example: ASSET_OPT_IN
+    @arc4.abimethod
+    def asset_opt_in(self, asset: Asset) -> None:
+        """
+        A zero amount asset transfer to one's self is a special type of asset transfer
+        that is used to opt-in to an asset.
+
+        To send an asset transfer, the asset must be an available resource.
+        Refer to the Resource Availability section for more information.
+        """
+        itxn.AssetTransfer(
+            asset_receiver=Global.current_application_address,
+            xfer_asset=asset,
+            asset_amount=0,
+        ).submit()
+
+    # example: ASSET_OPT_IN
+
+    # example: ASSET_TRANSFER
+    @arc4.abimethod
+    def asset_transfer(self, asset: Asset, receiver: Account, amount: UInt64) -> None:
+        """
+        For a smart contract to transfer an asset, the app account must be opted into it,
+        and be holding a non zero amount of said asset.
+
+        To send an asset transfer, the asset must be an available resource.
+        Refer to the Resource Availability section for more information.
+        """
+        itxn.AssetTransfer(
+            asset_receiver=receiver,
+            xfer_asset=asset,
+            asset_amount=amount,
+        ).submit()
+
+    # example: ASSET_TRANSFER
+
+    # example: ASSET_FREEZE
+    @arc4.abimethod
+    def asset_freeze(self, acct_to_be_frozen: Account, asset: Asset) -> None:
+        """The asset must have an account with freeze authority."""
+        itxn.AssetFreeze(
+            freeze_account=acct_to_be_frozen,
+            freeze_asset=asset,
+            frozen=True,
+        ).submit()
+
+    # example: ASSET_FREEZE
+
+    # example: ASSET_REVOKE
+    @arc4.abimethod
+    def asset_revoke(self, asset: Asset, account_to_be_revoked: Account, amount: UInt64) -> None:
+        """
+        To revoke an asset, the asset must be a revocable asset
+        by having an account with clawback authority.
+
+        Sender is implied to be current_application_address.
+        """
+        itxn.AssetTransfer(
+            asset_receiver=Global.current_application_address,
+            xfer_asset=asset,
+            asset_sender=account_to_be_revoked,
+            asset_amount=amount,
+        ).submit()
+
+    # example: ASSET_REVOKE
+
+    # example: ASSET_CONFIG
+    @arc4.abimethod
+    def asset_config(self, asset: Asset) -> None:
+        itxn.AssetConfig(
+            config_asset=asset,
+            manager=Global.current_application_address,
+            reserve=Global.current_application_address,
+            freeze=Txn.sender,
+            clawback=Txn.sender,
+        ).submit()
+
+    # example: ASSET_CONFIG
+
+    # example: ASSET_DELETE
+    @arc4.abimethod
+    def asset_delete(self, asset: Asset) -> None:
+        itxn.AssetConfig(config_asset=asset).submit()
+
+    # example: ASSET_DELETE
+
+    # example: GROUPED_INNER_TXNS
+    @arc4.abimethod
+    def multi_inner_txns(self, app_id: Application) -> tuple[UInt64, String]:
+        payment_params = itxn.Payment(amount=5000, receiver=Txn.sender)
+        app_call_params = itxn.ApplicationCall(
+            app_id=app_id,
+            app_args=(arc4.arc4_signature("hello(string)string"), arc4.String("World")),
+        )
+
+        pay_txn, app_call_txn = itxn.submit_txns(payment_params, app_call_params)
+
+        # `arc4.String.from_log(...)` decodes a typed value off the log;
+        # `.native` converts it to the native `String` type.
+        hello_world_result = arc4.String.from_log(app_call_txn.last_log)
+        return pay_txn.amount, hello_world_result.native
+
+    # example: GROUPED_INNER_TXNS
+
+    # example: DEPLOY_APP
+    @arc4.abimethod
+    def deploy_app(self) -> UInt64:
+        """Deploy `HelloWorldContract` via a low-level `itxn.ApplicationCall`."""
+        compiled = compile_contract(HelloWorldContract)
+        app_txn = itxn.ApplicationCall(
+            approval_program=compiled.approval_program,
+            clear_state_program=compiled.clear_state_program,
+        ).submit()
+        return app_txn.created_app.id
+
+    @arc4.abimethod
+    def arc4_deploy_app(self) -> UInt64:
+        """Deploy `HelloWorldContract` via the higher-level `arc4.arc4_create`."""
+        app_txn = arc4.arc4_create(HelloWorldContract)
+        return app_txn.created_app.id
+
+    # example: DEPLOY_APP
+
+    # example: NOOP_APP_CALL
+    @arc4.abimethod
+    def noop_app_call(self, app_id: Application) -> tuple[String, String]:
+        # Manually-constructed app call: caller must encode args and decode logs.
+        call_txn = itxn.ApplicationCall(
+            app_id=app_id,
+            app_args=(arc4.arc4_signature("hello(string)string"), arc4.String("World")),
+        ).submit()
+        first_hello_world_result = arc4.String.from_log(call_txn.last_log).native
+
+        # `arc4.abi_call` infers the signature from the typed method reference
+        # and handles argument encoding and return decoding automatically.
+        second_hello_world_result, _txn = arc4.abi_call(
+            HelloWorldContract.hello,
+            "again",
+            app_id=app_id,
+        )
+
+        return first_hello_world_result, second_hello_world_result
+
+    # example: NOOP_APP_CALL

--- a/examples/devportal/local_state/contract.py
+++ b/examples/devportal/local_state/contract.py
@@ -1,0 +1,271 @@
+from algopy import (
+    Account,
+    Application,
+    ARC4Contract,
+    Asset,
+    Bytes,
+    Global,
+    LocalMap,
+    LocalState,
+    StateTotals,
+    Txn,
+    UInt64,
+    arc4,
+    subroutine,
+)
+
+
+class LocalStorage(ARC4Contract):
+    # example: INIT_LOCAL_STORAGE
+    def __init__(self) -> None:
+        # `LocalState(T)` declares a per-account storage slot of type T.
+        # Each opted-in account gets an independent value at this key.
+        self.local_int = LocalState(UInt64)
+        self.local_bytes = LocalState(Bytes)
+        self.local_bool = LocalState(bool)
+        self.local_asset = LocalState(Asset)
+        self.local_application = LocalState(Application)
+        self.local_account = LocalState(Account)
+
+    # example: INIT_LOCAL_STORAGE
+
+    @arc4.abimethod(allow_actions=["OptIn"])
+    def opt_in(self) -> None:
+        """Accounts must opt in before their local state slots can be written."""
+        self.local_int[Txn.sender] = UInt64(10)
+        self.local_bytes[Txn.sender] = Bytes(b"Hello")
+        self.local_bool[Txn.sender] = True
+        self.local_asset[Txn.sender] = Asset(10)
+        self.local_application[Txn.sender] = Application(10)
+        self.local_account[Txn.sender] = Global.zero_address
+
+    # example: CONTAIN_PROPERTY_LOCAL_STATE
+    @arc4.abimethod
+    def contains_local_data(self, for_account: Account) -> bool:
+        # `account in state` is True if the account has a value at this slot.
+        return for_account in self.local_int
+
+    # example: CONTAIN_PROPERTY_LOCAL_STATE
+
+    # example: CONTAIN_PROPERTY_LOCAL_STATE_EXAMPLES
+    @arc4.abimethod
+    def contains_local_data_example(self, for_account: Account) -> bool:
+        assert for_account in self.local_int, "no local_int for account"
+        assert for_account in self.local_bytes, "no local_bytes for account"
+        assert for_account in self.local_bool, "no local_bool for account"
+        assert for_account in self.local_asset, "no local_asset for account"
+        assert for_account in self.local_application, "no local_application for account"
+        assert for_account in self.local_account, "no local_account for account"
+        return True
+
+    # example: CONTAIN_PROPERTY_LOCAL_STATE_EXAMPLES
+
+    # example: READ_LOCAL_STATE
+    @arc4.abimethod
+    def get_item_local_data(self, for_account: Account) -> UInt64:
+        # `state[account]` returns the stored value; fails if the account has none.
+        return self.local_int[for_account]
+
+    @arc4.abimethod
+    def get_local_data_with_default_int(self, for_account: Account) -> UInt64:
+        # `.get(account, default=...)` returns the default if no value exists.
+        return self.local_int.get(for_account, default=UInt64(0))
+
+    @arc4.abimethod
+    def maybe_local_data(self, for_account: Account) -> tuple[UInt64, bool]:
+        # `.maybe(account)` returns `(value, exists)`; when `exists` is False,
+        # `value` is the type's zero value and should not be relied upon.
+        result, exists = self.local_int.maybe(for_account)
+        if not exists:
+            result = UInt64(0)
+        return result, exists
+
+    # example: READ_LOCAL_STATE
+
+    # example: READ_LOCAL_STATE_EXAMPLES
+    @arc4.abimethod
+    def get_item_local_data_example(self, for_account: Account) -> bool:
+        assert self.local_int[for_account] == UInt64(10), "expected opt-in value 10"
+        assert self.local_bytes[for_account] == b"Hello", "expected opt-in value Hello"
+        assert bool(self.local_bool[for_account]), "expected opt-in value True"
+        assert self.local_asset[for_account] == Asset(10), "expected opt-in asset 10"
+        assert self.local_application[for_account] == Application(10), "expected opt-in app 10"
+        assert (
+            self.local_account[for_account] == Global.zero_address
+        ), "expected opt-in zero address"
+        return True
+
+    @arc4.abimethod
+    def get_local_data_with_default(self, for_account: Account) -> bool:
+        assert self.local_int.get(for_account, default=UInt64(0)) == UInt64(
+            10
+        ), "expected opt-in value 10"
+        assert self.local_bytes.get(for_account, default=Bytes(b"Default Value")) == Bytes(
+            b"Hello"
+        ), "expected opt-in value Hello"
+        assert bool(self.local_bool.get(for_account, default=False)), "expected opt-in value True"
+        assert self.local_asset.get(for_account, default=Asset(0)) == Asset(
+            10
+        ), "expected opt-in asset 10"
+        assert self.local_application.get(for_account, default=Application(0)) == Application(
+            10
+        ), "expected opt-in app 10"
+        assert (
+            self.local_account.get(for_account, default=Global.zero_address) == Global.zero_address
+        ), "expected opt-in zero address"
+        return True
+
+    @arc4.abimethod
+    def maybe_local_data_example(self, for_account: Account) -> bool:
+        result, exists = self.local_int.maybe(for_account)
+        assert exists, "no data for account"
+        assert result == UInt64(10), "expected opt-in value 10"
+        return True
+
+    # example: READ_LOCAL_STATE_EXAMPLES
+
+    # example: WRITE_LOCAL_STATE
+    @arc4.abimethod
+    def set_local_int(self, for_account: Account, value: UInt64) -> None:
+        # `state[account] = value` writes the per-account slot.
+        self.local_int[for_account] = value
+
+    # example: WRITE_LOCAL_STATE
+
+    # example: WRITE_LOCAL_STATE_EXAMPLES
+    @arc4.abimethod
+    def set_local_data_example(
+        self,
+        for_account: Account,
+        value_asset: Asset,
+        value_account: Account,
+        value_app: Application,
+        value_bytes: Bytes,
+        *,
+        value_bool: bool,
+    ) -> bool:
+        self.local_bytes[for_account] = value_bytes
+        assert self.local_bytes[for_account] == value_bytes, "bytes value should be stored"
+
+        self.local_bool[for_account] = value_bool
+        assert self.local_bool[for_account] == value_bool, "bool value should be stored"
+
+        self.local_asset[for_account] = value_asset
+        assert self.local_asset[for_account] == value_asset, "asset value should be stored"
+
+        self.local_application[for_account] = value_app
+        assert self.local_application[for_account] == value_app, "app value should be stored"
+
+        self.local_account[for_account] = value_account
+        assert self.local_account[for_account] == value_account, "account value should be stored"
+        return True
+
+    # example: WRITE_LOCAL_STATE_EXAMPLES
+
+    # example: DELETE_LOCAL_STATE
+    @arc4.abimethod
+    def delete_local_data(self, for_account: Account) -> None:
+        # `del state[account]` removes the per-account value.
+        del self.local_int[for_account]
+
+    # example: DELETE_LOCAL_STATE
+
+    # example: DELETE_LOCAL_STATE_EXAMPLES
+    @arc4.abimethod
+    def delete_local_data_example(self, for_account: Account) -> bool:
+        # Deleting is idempotent: it succeeds even if the slot is already empty.
+        del self.local_int[for_account]
+        del self.local_bytes[for_account]
+        del self.local_bool[for_account]
+        del self.local_asset[for_account]
+        del self.local_application[for_account]
+        del self.local_account[for_account]
+        return True
+
+    # example: DELETE_LOCAL_STATE_EXAMPLES
+
+    @arc4.abimethod
+    def pass_proxy_to_subroutine(self, for_account: Account) -> UInt64:
+        # LocalState proxies can be passed to subroutines like any value.
+        return read_local_int_plus_1(self.local_int, for_account)
+
+
+@subroutine
+def read_local_int_plus_1(state: LocalState[UInt64], account: Account) -> UInt64:
+    """A LocalState[T] proxy can be passed to and read from a subroutine."""
+    return state[account] + 1
+
+
+class LocalStorageMap(ARC4Contract, state_totals=StateTotals(local_uints=16)):
+    """
+    Demonstrates `LocalMap`, a typed key→value collection in each opted-in
+    account's local state. Capacity may be sized on the application via
+    `algopy.StateTotals` at creation time, and it may be decreased or increased
+    throughout the application's lifecycle. The number here is the per-account
+    maximum reserved for `balances` and `flags` combined.
+
+    `LocalMap` lookups are indexed by a `(account, key)` tuple: one logical
+    map shared by all accounts, with values partitioned by account.
+    """
+
+    # example: INIT_LOCAL_MAP
+    def __init__(self) -> None:
+        # `LocalMap[K, V]` stores `V` keyed by `K` in each account's local state.
+        # The `key_prefix` defaults to the attribute name when omitted.
+        self.balances = LocalMap(arc4.String, UInt64)
+        self.flags = LocalMap(UInt64, bool, key_prefix="flag")
+
+    # example: INIT_LOCAL_MAP
+
+    @arc4.abimethod(allow_actions=["OptIn"])
+    def opt_in(self) -> None:
+        # Accounts must opt in before any per-account slot is writable.
+        self.balances[Txn.sender, arc4.String("USD")] = UInt64(100)
+        self.flags[Txn.sender, UInt64(0)] = True
+
+    # example: READ_LOCAL_MAP
+    @arc4.abimethod
+    def get_balance(self, account: Account, currency: arc4.String) -> UInt64:
+        # Indexing reads the slot for `(account, key)`; fails if not present.
+        return self.balances[account, currency]
+
+    @arc4.abimethod
+    def get_balance_or_default(self, account: Account, currency: arc4.String) -> UInt64:
+        # `.get(account, key, default=...)` returns the default if missing.
+        return self.balances.get(account, currency, default=UInt64(0))
+
+    @arc4.abimethod
+    def maybe_balance(self, account: Account, currency: arc4.String) -> tuple[UInt64, bool]:
+        return self.balances.maybe(account, currency)
+
+    @arc4.abimethod
+    def has_flag(self, account: Account, key: UInt64) -> bool:
+        # `(account, key) in map` is True if the slot has a stored value.
+        return (account, key) in self.flags
+
+    # example: READ_LOCAL_MAP
+
+    # example: WRITE_LOCAL_MAP
+    @arc4.abimethod
+    def set_balance(self, account: Account, currency: arc4.String, value: UInt64) -> None:
+        self.balances[account, currency] = value
+
+    @arc4.abimethod
+    def set_flag(self, account: Account, key: UInt64, *, value: bool) -> None:
+        self.flags[account, key] = value
+
+    # example: WRITE_LOCAL_MAP
+
+    # example: DELETE_LOCAL_MAP
+    @arc4.abimethod
+    def delete_balance(self, account: Account, currency: arc4.String) -> None:
+        del self.balances[account, currency]
+
+    # example: DELETE_LOCAL_MAP
+
+    @arc4.abimethod
+    def get_slot_proxy(self, account: Account, currency: arc4.String) -> UInt64:
+        # `.state(key)` returns a `LocalState[V]` proxy for that key,
+        # which still requires an account to dereference.
+        slot = self.balances.state(currency)
+        return slot[account]

--- a/examples/devportal/logged_errors/contract.py
+++ b/examples/devportal/logged_errors/contract.py
@@ -1,0 +1,70 @@
+from algopy import ARC4Contract, UInt64, arc4, logged_assert, logged_err
+
+
+class LoggedErrors(ARC4Contract):
+    """
+    Demonstrates `logged_assert` and `logged_err`: ARC-65-compliant error
+    helpers that log a structured `ERR:{error_code}:{error_message}`
+    string before failing the transaction.
+
+    ARC-65 suggests error codes be camel case and alphanumeric (the compiler
+    emits a warning when a code does not follow this format).
+    Furthermore, code and message may not contain ':', as this character
+    is the domain separator for ARC-65 (the compiler will error if code
+    or message contain ':').
+
+    Compared to a plain `assert ..., "msg"` this:
+      * Always logs the error, so failed transactions in algod carry it
+        in their response.
+      * Uses an explicit short code clients can match against.
+
+    The trade-off is bytecode size: every distinct code + message becomes a
+    byte string in the program, so keep both as short as possible.
+    """
+
+    def __init__(self) -> None:
+        self.balance = UInt64(0)
+
+    @arc4.abimethod
+    def deposit(self, amount: UInt64) -> UInt64:
+        self.balance += amount
+        return self.balance
+
+    # example: LOGGED_ASSERT
+    @arc4.abimethod
+    def withdraw(self, amount: UInt64) -> UInt64:
+        # `logged_assert(condition, error_code, error_message=..., prefix=...)`
+        # logs `ERR:amountError01:amount must be positive` and aborts when the
+        # condition is false. `desc=` additionally sets a plain description in
+        # the ARC-56 source info — the human-readable error typed clients
+        # surface — without changing the logged output.
+        logged_assert(
+            amount > 0,
+            "amountError01",
+            "amount must be positive",
+            desc="Withdrawal amount must be greater than zero",
+        )
+        logged_assert(
+            amount <= self.balance,
+            "amountError02",
+            "insufficient balance",
+        )
+
+        self.balance -= amount
+        return self.balance
+
+    # example: LOGGED_ASSERT
+
+    # example: LOGGED_ERR
+    @arc4.abimethod
+    def reject(self, code: UInt64) -> UInt64:
+        # `logged_err` is the unconditional version of `logged_assert`; it is
+        # equivalent to `logged_assert(False, ...)`. Useful inside branches
+        # where the failure decision has already been made.
+        if code == 0:
+            logged_err("codeRange00", "code zero is reserved")
+        if code > 100:
+            logged_err("codeRange01", "code out of range")
+        return code
+
+    # example: LOGGED_ERR

--- a/examples/devportal/lsig_with_args/contract.py
+++ b/examples/devportal/lsig_with_args/contract.py
@@ -1,0 +1,155 @@
+from algopy import (
+    Account,
+    Global,
+    TemplateVar,
+    TransactionType,
+    Txn,
+    UInt64,
+    arc4,
+    logicsig,
+    op,
+)
+
+
+# example: LSIG_SIMPLE_ARGS
+@logicsig
+def escrow_release(amount: UInt64) -> bool:
+    """
+    A typed lsig for a contract account (escrow): `amount` is auto-decoded
+    from `op.arg(0)`, and the default `validate_encoding="args"` verifies
+    the encoded bytes against the declared type (see `escrow_release_to`
+    for opting out). The beneficiary is baked in via a `TemplateVar`.
+
+    A contract account must constrain every abusable field: `rekey_to` and
+    `close_remainder_to` are pinned, and `fee` is bounded — but only per
+    transaction, so repeated approved payments can still drain fees. See
+    `voucher_redeem` below for the lease-based replay guard.
+    """
+    beneficiary = TemplateVar[Account]("BENEFICIARY")
+    return (
+        Txn.type_enum == TransactionType.Payment
+        and Txn.receiver == beneficiary
+        and Txn.amount == amount
+        and Txn.fee <= Global.min_txn_fee
+        and Txn.rekey_to == Global.zero_address
+        and Txn.close_remainder_to == Global.zero_address
+    )
+
+
+# example: LSIG_SIMPLE_ARGS
+
+
+# example: LSIG_STRUCT_ARGS
+class Voucher(arc4.Struct):
+    """A signed payload describing a single permitted payment."""
+
+    recipient: arc4.Address
+    max_amount: arc4.UInt64
+    expires_at: arc4.UInt64
+
+
+@logicsig
+def voucher_redeem(voucher: Voucher) -> bool:
+    """
+    Compound argument types work too. `voucher` is an `arc4.Struct` whose
+    fields are decoded and made available as `voucher.recipient`,
+    `voucher.max_amount`, `voucher.expires_at`.
+
+    Use case: a holder receives the voucher bytes off-chain and supplies
+    them as the lsig arg at redemption time. The lsig verifies that the
+    actual payment transaction matches the voucher's constraints.
+
+    Single-use is enforced with a lease: the payment's `lease` must commit
+    to the voucher bytes, and `last_valid` is pinned to `expires_at`, so
+    once a redemption confirms, the ledger blocks any other transaction
+    with the same (sender, lease) pair until `expires_at` has passed — at
+    which point the voucher can no longer be valid at all. Without this,
+    "max_amount" would only cap each redemption, not the total outflow.
+
+    Note that lsig args are not authenticated by the network — whoever
+    submits the transaction chooses them. A production voucher scheme could
+    also verify a signature over the encoded voucher bytes (e.g. with
+    `op.ed25519verify_bare`) so that only vouchers issued by a trusted key
+    can release funds; this example focuses on the struct decoding itself.
+    """
+    return (
+        Txn.type_enum == TransactionType.Payment
+        and Txn.receiver == voucher.recipient.native
+        and Txn.amount <= voucher.max_amount.as_uint64()
+        # pin the validity window's end to the voucher expiry...
+        and Txn.last_valid == voucher.expires_at.as_uint64()
+        # ...and hold the (sender, lease) slot until then: one redemption only
+        and Txn.lease == op.sha256(voucher.bytes)
+        and Txn.fee <= Global.min_txn_fee
+        and Txn.rekey_to == Global.zero_address
+        and Txn.close_remainder_to == Global.zero_address
+    )
+
+
+# example: LSIG_STRUCT_ARGS
+
+
+# example: LSIG_MIXED_ARGS
+@logicsig(name="MixedArgsLsig", avm_version=11)
+def mixed_args(
+    amount: UInt64,
+    recipient: arc4.Address,
+    note: arc4.DynamicBytes,
+) -> UInt64:
+    """
+    A logic signature can return `UInt64` instead of `bool`; a non-zero value
+    is treated as success. Native (`UInt64`) and ARC-4 (`arc4.Address`,
+    `arc4.DynamicBytes`) argument types can be mixed freely. `op.arg(N)`
+    remains callable inside the body for raw access to the encoded bytes.
+
+    Decorator options like `name=` and `avm_version=` configure how puya
+    compiles the lsig itself; they do not become function parameters.
+    """
+    assert Txn.type_enum == TransactionType.Payment
+    assert Txn.receiver == recipient.native
+    assert Txn.amount >= amount
+    assert Txn.note == note.native
+    assert Txn.fee <= Global.min_txn_fee
+    assert Txn.rekey_to == Global.zero_address
+    assert Txn.close_remainder_to == Global.zero_address
+
+    # raw access via op.arg(N): require the payment's lease to commit to the
+    # hash of all three encoded arguments, so no other transaction can reuse
+    # the same (sender, lease) slot during this transaction's validity window
+    digest = op.sha256(op.arg(0) + op.arg(1) + op.arg(2))
+    assert Txn.lease == digest
+    return UInt64(1)
+
+
+# example: LSIG_MIXED_ARGS
+
+
+# example: LSIG_UNSAFE_ARGS
+@logicsig(validate_encoding="unsafe_disabled")
+def escrow_release_to(payee: arc4.Address) -> bool:
+    """
+    `validate_encoding="unsafe_disabled"` skips the ARC-4 encoding checks on
+    decode, trading a small amount of safety for smaller bytecode. It is safe
+    here because any 32-byte sequence is a valid `arc4.Address` encoding, so
+    there is nothing for the check to reject.
+
+    This escrow releases funds to either of two beneficiaries baked in at
+    compile time; the caller selects which one via the `payee` argument.
+    Disabling the *encoding* check does not weaken the *authorization* check —
+    the chosen payee is still verified against the baked-in allow-list and the
+    transaction is fully constrained below.
+    """
+    payee_a = TemplateVar[Account]("PAYEE_A")
+    payee_b = TemplateVar[Account]("PAYEE_B")
+    recipient = payee.native
+    return (
+        Txn.type_enum == TransactionType.Payment
+        and recipient in (payee_a, payee_b)
+        and Txn.receiver == recipient
+        and Txn.fee <= Global.min_txn_fee
+        and Txn.rekey_to == Global.zero_address
+        and Txn.close_remainder_to == Global.zero_address
+    )
+
+
+# example: LSIG_UNSAFE_ARGS

--- a/examples/devportal/op_budget/contract.py
+++ b/examples/devportal/op_budget/contract.py
@@ -1,0 +1,90 @@
+from algopy import (
+    ARC4Contract,
+    Bytes,
+    OpUpFeeSource,
+    UInt64,
+    arc4,
+    ensure_budget,
+    op,
+    urange,
+)
+
+
+class OpBudget(ARC4Contract):
+    """
+    Demonstrates `ensure_budget`: the standard way to extend the AVM opcode
+    budget for operations that exceed the default 700-op-per-txn cap (besides
+    group pooling).
+
+    Under the hood `ensure_budget` issues inner application calls to a no-op
+    `OpUp` app, each of which carries its own 700-op budget that this txn
+    can consume. The `OpUpFeeSource` argument controls how the inner txn fees
+    are paid.
+    """
+
+    # example: ENSURE_BUDGET_BASIC
+    @arc4.abimethod
+    def many_hashes(self, seed: Bytes, rounds: UInt64) -> Bytes:
+        """
+        Each `op.sha256` costs 35 ops, so chaining many of them consumes
+        budget quickly. `ensure_budget(required)` requests enough
+        additional budget to cover `required` ops.
+
+        The argument is the *total* op budget you want available, not the
+        delta from the current budget.
+        """
+        # ~40 ops per iteration (sha256 costs 35, plus loop overhead),
+        # plus a 100-op allowance for method routing and returning
+        ensure_budget(rounds * 40 + 100)
+
+        digest = seed
+        for _i in urange(rounds):
+            digest = op.sha256(digest)
+        return digest
+
+    # example: ENSURE_BUDGET_BASIC
+
+    # example: ENSURE_BUDGET_FEE_SOURCE
+    @arc4.abimethod
+    def many_hashes_group_credit(self, seed: Bytes, rounds: UInt64) -> Bytes:
+        """
+        `OpUpFeeSource.GroupCredit` (the default): the inner OpUp call sets
+        `fee=0` and relies on the outer transaction group having paid extra
+        fees in advance. Callers must include enough excess fee on some other
+        txn in the group to cover the inner OpUp calls. Cheapest when the
+        caller is already paying group fees anyway.
+        """
+        ensure_budget(rounds * 40 + 100, fee_source=OpUpFeeSource.GroupCredit)
+        digest = seed
+        for _i in urange(rounds):
+            digest = op.sha256(digest)
+        return digest
+
+    @arc4.abimethod
+    def many_hashes_app_pays(self, seed: Bytes, rounds: UInt64) -> Bytes:
+        """
+        `OpUpFeeSource.AppAccount`: the application's own account pays for
+        the inner OpUp calls (their `fee` is set to `Global.min_txn_fee`).
+        Use this when the caller cannot or should not over-pay the group
+        fees. Requires the app account to hold enough algos.
+        """
+        ensure_budget(rounds * 40 + 100, fee_source=OpUpFeeSource.AppAccount)
+        digest = seed
+        for _i in urange(rounds):
+            digest = op.sha256(digest)
+        return digest
+
+    @arc4.abimethod
+    def many_hashes_any(self, seed: Bytes, rounds: UInt64) -> Bytes:
+        """
+        `OpUpFeeSource.Any`: spend the group's excess fee credit first, then
+        fall back to the app account if more is needed. Most flexible; the
+        right default for contracts that want to be "polite" about fees.
+        """
+        ensure_budget(rounds * 40 + 100, fee_source=OpUpFeeSource.Any)
+        digest = seed
+        for _i in urange(rounds):
+            digest = op.sha256(digest)
+        return digest
+
+    # example: ENSURE_BUDGET_FEE_SOURCE

--- a/examples/devportal/reference_account/contract.py
+++ b/examples/devportal/reference_account/contract.py
@@ -1,0 +1,27 @@
+from algopy import Account, ARC4Contract, TemplateVar, UInt64, arc4
+
+
+# example: ACCOUNT_REFERENCE_EXAMPLE
+class ReferenceAccount(ARC4Contract):
+    """
+    Demonstrates accessing properties of an external account. The account is
+    either baked into the program via a template variable or supplied as a
+    method argument. Either way, it must be present in the transaction's
+    reference array at call time (the AlgoKit client typically handles this
+    automatically).
+    """
+
+    @arc4.abimethod
+    def get_account_balance(self) -> UInt64:
+        """Read the balance of a well-known account, baked into the program
+        when it is compiled/deployed (`TMPL_KNOWN_ACCOUNT`)."""
+        account = TemplateVar[Account]("KNOWN_ACCOUNT")
+        return account.balance
+
+    @arc4.abimethod
+    def get_account_balance_with_arg(self, account: Account) -> UInt64:
+        """Same lookup, but with a caller-supplied account reference."""
+        return account.balance
+
+
+# example: ACCOUNT_REFERENCE_EXAMPLE

--- a/examples/devportal/reference_account_app/contract.py
+++ b/examples/devportal/reference_account_app/contract.py
@@ -1,0 +1,71 @@
+from algopy import (
+    Account,
+    Application,
+    ARC4Contract,
+    Global,
+    LocalState,
+    TemplateVar,
+    Txn,
+    UInt64,
+    arc4,
+    op,
+)
+
+
+class MyCounter(ARC4Contract):
+    """
+    A reusable counter app held in each opted-in account's local state.
+    Accounts must opt in before the counter is readable or writable.
+    """
+
+    def __init__(self) -> None:
+        self.my_counter = LocalState(UInt64)
+
+    @arc4.abimethod(allow_actions=["OptIn"])
+    def opt_in(self) -> None:
+        self.my_counter[Txn.sender] = UInt64(0)
+
+    @arc4.abimethod
+    def increment_my_counter(self) -> UInt64:
+        assert Txn.sender.is_opted_in(
+            Global.current_application_id
+        ), "Account is not opted in to the app"
+        self.my_counter[Txn.sender] += 1
+        return self.my_counter[Txn.sender]
+
+
+# example: REFERENCE_ACCOUNT_APP_EXAMPLE
+class ReferenceAccountApp(ARC4Contract):
+    """
+    Demonstrates reading another application's per-account local state.
+    The referenced account and application must both appear in the
+    transaction's reference arrays at call time (the AlgoKit client
+    typically handles this automatically).
+    """
+
+    @arc4.abimethod
+    def get_my_counter(self) -> UInt64:
+        """Read a counter from a well-known account/app pair, baked into the
+        program when it is compiled/deployed (`TMPL_KNOWN_ACCOUNT`,
+        `TMPL_KNOWN_APP`)."""
+        account = TemplateVar[Account]("KNOWN_ACCOUNT")
+        app = TemplateVar[Application]("KNOWN_APP")
+
+        # reading another app's local state requires the low-level AppLocal.get_ex_* ops;
+        # the high-level LocalState type only covers the current application's state.
+        # note: if the account is not opted in to the app at all, the opcode itself
+        # fails the program — `exists` is False only when the account *is* opted in
+        # but the key has not been set
+        my_count, exists = op.AppLocal.get_ex_uint64(account, app, b"my_counter")
+        assert exists, "my_counter is not set for this account"
+        return my_count
+
+    @arc4.abimethod
+    def get_my_counter_with_arg(self, account: Account, app: Application) -> UInt64:
+        """Same lookup, but with caller-supplied account and app references."""
+        my_count, exists = op.AppLocal.get_ex_uint64(account, app, b"my_counter")
+        assert exists, "my_counter is not set for this account"
+        return my_count
+
+
+# example: REFERENCE_ACCOUNT_APP_EXAMPLE

--- a/examples/devportal/reference_account_asset/contract.py
+++ b/examples/devportal/reference_account_asset/contract.py
@@ -1,0 +1,30 @@
+from algopy import Account, ARC4Contract, Asset, TemplateVar, UInt64, arc4
+
+
+# example: REFERENCE_ACCOUNT_ASSET_EXAMPLE
+class ReferenceAccountAsset(ARC4Contract):
+    """
+    Demonstrates how to reference both an account and an asset to read an
+    account's holding of a specific asset. Both references must be present
+    in the transaction's reference arrays at call time (the AlgoKit client
+    typically handles this automatically).
+    """
+
+    @arc4.abimethod
+    def get_asset_balance(self) -> UInt64:
+        """Read the asset balance for a well-known account/asset pair, baked
+        into the program when it is compiled/deployed (`TMPL_KNOWN_ACCOUNT`,
+        `TMPL_KNOWN_ASSET`)."""
+        account = TemplateVar[Account]("KNOWN_ACCOUNT")
+        asset = TemplateVar[Asset]("KNOWN_ASSET")
+        assert account.is_opted_in(asset), "Account is not opted in to the asset"
+        return asset.balance(account)
+
+    @arc4.abimethod
+    def get_asset_balance_with_arg(self, account: Account, asset: Asset) -> UInt64:
+        """Same lookup, but with caller-supplied account and asset references."""
+        assert account.is_opted_in(asset), "Account is not opted in to the asset"
+        return asset.balance(account)
+
+
+# example: REFERENCE_ACCOUNT_ASSET_EXAMPLE

--- a/examples/devportal/reference_app/contract.py
+++ b/examples/devportal/reference_app/contract.py
@@ -1,0 +1,41 @@
+from algopy import Application, ARC4Contract, TemplateVar, UInt64, arc4
+
+
+# example: APP_REFERENCE_EXAMPLE
+class Counter(ARC4Contract):
+    """A trivial callee whose state is incremented by inner app calls."""
+
+    def __init__(self) -> None:
+        self.counter = UInt64(0)
+
+    @arc4.abimethod
+    def increment(self) -> UInt64:
+        self.counter += 1
+        return self.counter
+
+
+class ReferenceApp(ARC4Contract):
+    """
+    Demonstrates referencing another application by id and invoking one of its
+    methods via `arc4.abi_call`. The referenced app must be present in the
+    transaction's reference arrays at call time (the AlgoKit client typically
+    handles this automatically).
+    """
+
+    @arc4.abimethod
+    def increment_via_inner(self) -> UInt64:
+        """Call into a well-known `Counter` application, baked into the
+        program when it is compiled/deployed (`TMPL_KNOWN_APP`)."""
+        app = TemplateVar[Application]("KNOWN_APP")
+        # fee=0 means the outer transaction's fee must also cover the inner call
+        counter_result, _txn = arc4.abi_call(Counter.increment, fee=0, app_id=app)
+        return counter_result
+
+    @arc4.abimethod
+    def increment_via_inner_with_arg(self, app: Application) -> UInt64:
+        """Same call, but the target app is supplied by the caller."""
+        counter_result, _txn = arc4.abi_call(Counter.increment, fee=0, app_id=app)
+        return counter_result
+
+
+# example: APP_REFERENCE_EXAMPLE

--- a/examples/devportal/reference_asset/contract.py
+++ b/examples/devportal/reference_asset/contract.py
@@ -1,0 +1,27 @@
+from algopy import ARC4Contract, Asset, TemplateVar, UInt64, arc4
+
+
+# example: GET_ASSET_REFERENCE_EXAMPLE
+class ReferenceAsset(ARC4Contract):
+    """
+    Demonstrates accessing properties of an external asset. The asset is
+    either baked into the program via a template variable or supplied as a
+    method argument. Either way, it must be present in the transaction's
+    reference array at call time (the AlgoKit client typically handles this
+    automatically).
+    """
+
+    @arc4.abimethod
+    def get_asset_total_supply(self) -> UInt64:
+        """Read the total supply of a well-known asset, baked into the program
+        when it is compiled/deployed (`TMPL_KNOWN_ASSET`)."""
+        asset = TemplateVar[Asset]("KNOWN_ASSET")
+        return asset.total
+
+    @arc4.abimethod
+    def get_asset_total_supply_with_arg(self, asset: Asset) -> UInt64:
+        """Same lookup, but with a caller-supplied asset reference."""
+        return asset.total
+
+
+# example: GET_ASSET_REFERENCE_EXAMPLE

--- a/examples/devportal/reference_box/contract.py
+++ b/examples/devportal/reference_box/contract.py
@@ -1,0 +1,71 @@
+from algopy import (
+    Account,
+    ARC4Contract,
+    BoxMap,
+    Global,
+    Txn,
+    UInt64,
+    arc4,
+    gtxn,
+)
+
+# example: REFERENCE_BOX_EXAMPLE
+# Box MBR (minimum balance requirement) is a protocol-defined function of
+# key + value size, so for a fixed box layout it is a compile-time constant.
+BOX_MBR_BASE = 2_500  # microAlgo flat cost per box
+BOX_MBR_PER_BYTE = 400  # microAlgo per byte of key + value
+COUNTER_BOX_KEY_LENGTH = 7 + 32  # len(b"counter") key prefix + 32-byte account address
+COUNTER_BOX_VALUE_LENGTH = 8  # one UInt64
+COUNTER_BOX_MBR = (
+    BOX_MBR_BASE + (COUNTER_BOX_KEY_LENGTH + COUNTER_BOX_VALUE_LENGTH) * BOX_MBR_PER_BYTE
+)
+
+
+class ReferenceBox(ARC4Contract):
+    """
+    Per-account counters held in box storage. The first increment for an
+    account is funded by a grouped payment covering the box MBR; the contract
+    then creates or increments the box on the caller's behalf. Every box an
+    app call touches must be declared in the transaction's box reference
+    array at call time (the AlgoKit client typically handles this
+    automatically).
+    """
+
+    def __init__(self) -> None:
+        self.account_box_counter = BoxMap(Account, UInt64, key_prefix="counter")
+
+    @arc4.abimethod
+    def increment_box_counter(self, pay_mbr: gtxn.PaymentTransaction) -> UInt64:
+        """Increment the sender's counter, creating their box on first use.
+        The grouped payment must fund the box MBR when the box is first
+        created; later increments may pass a zero-amount payment."""
+        counter, exists = self.account_box_counter.maybe(Txn.sender)
+        if not exists:
+            assert pay_mbr.amount >= COUNTER_BOX_MBR, "Payment must cover the box MBR"
+            assert (
+                pay_mbr.receiver == Global.current_application_address
+            ), "Payment must be to the contract"
+            counter = UInt64(0)
+
+        new_count = counter + 1
+        self.account_box_counter[Txn.sender] = new_count
+        return new_count
+
+    @arc4.abimethod(readonly=True)
+    def get_box_counter(self) -> UInt64:
+        """The sender's counter, or 0 if not yet set."""
+        return self.account_box_counter.get(Txn.sender, default=UInt64(0))
+
+    @arc4.abimethod(readonly=True)
+    def get_box_counter_for_account(self, account: Account) -> UInt64:
+        """The given account's counter, or 0 if not yet set."""
+        return self.account_box_counter.get(account, default=UInt64(0))
+
+    @arc4.abimethod(readonly=True)
+    def get_box_mbr(self) -> UInt64:
+        """The MBR a caller must fund before their first increment — a
+        compile-time constant clients can quote without hard-coding it."""
+        return UInt64(COUNTER_BOX_MBR)
+
+
+# example: REFERENCE_BOX_EXAMPLE

--- a/examples/devportal/reject_version/contract.py
+++ b/examples/devportal/reject_version/contract.py
@@ -1,0 +1,71 @@
+from algopy import (
+    Application,
+    ARC4Contract,
+    String,
+    UInt64,
+    arc4,
+)
+
+
+class RejectVersion(ARC4Contract, avm_version=12):
+    """
+    Demonstrates `reject_version`: an AVM v12 field on every application call
+    transaction that pins the caller to a maximum acceptable callee version.
+
+    The callee's app version is incremented every time its approval or clear
+    program is updated. If `reject_version > 0` and the callee's current
+    version is **>=** `reject_version`, the AVM rejects the call before any
+    bytecode executes. Setting `reject_version = N + 1` means "I accept
+    versions 0..N inclusive; refuse if newer".
+
+    Some use cases:
+      * Defend against silent upgrades of an integrated dependency.
+      * Lock a one-time interaction to a specific audited version.
+      * Check (or make sure that) a contract has been properly updated.
+    """
+
+    # example: REJECT_VERSION_INNER_CALL
+    @arc4.abimethod
+    def call_pinned(self, target: Application, max_version: UInt64) -> String:
+        """
+        Send an inner ApplicationCall that refuses to execute if `target`
+        has been upgraded past `max_version`.
+
+        `reject_version = max_version + 1` means "fail unless the callee's
+        version is <= max_version". This is the canonical pattern for
+        pinning to "the version I audited", forward-compatible with whatever
+        version number the caller has actually audited.
+        """
+        result, _txn = arc4.abi_call[String](
+            "hello(string)string",
+            "World",
+            app_id=target,
+            reject_version=max_version + 1,
+            fee=0,
+        )
+        return result
+
+    # example: REJECT_VERSION_INNER_CALL
+
+    # example: REJECT_VERSION_CHECK_BEFORE_CALL
+    @arc4.abimethod
+    def call_checked(self, target: Application, unsafe_version: UInt64) -> String:
+        """
+        Check `target.version` explicitly, then call. It reads the same
+        counter that `reject_version` is compared against (`target` must be
+        an available resource; fails if the app does not exist).
+
+        We use it here to enforce a `min_version`, i.e. make sure a
+        contract was actually updated.
+        """
+        assert target.version > unsafe_version, "target bug has not been patched yet"
+
+        result, _txn = arc4.abi_call[String](
+            "hello(string)string",
+            "World",
+            app_id=target,
+            fee=0,
+        )
+        return result
+
+    # example: REJECT_VERSION_CHECK_BEFORE_CALL

--- a/examples/devportal/self_payment/contract.py
+++ b/examples/devportal/self_payment/contract.py
@@ -1,0 +1,36 @@
+from algopy import (
+    Bytes,
+    Global,
+    TemplateVar,
+    Txn,
+    UInt64,
+    gtxn,
+    logicsig,
+    op,
+)
+
+
+# example: LSIG_SELFPAYMENT
+@logicsig
+def self_payment() -> bool:
+    """
+    This Delegated Account will authorize a single empty self payment,
+    valid no later than a round known ahead of time.
+    """
+
+    current_txn = gtxn.PaymentTransaction(Txn.group_index)
+    return (
+        current_txn.receiver == current_txn.sender
+        and current_txn.amount == 0
+        and current_txn.rekey_to == Global.zero_address
+        and current_txn.close_remainder_to == Global.zero_address
+        and current_txn.fee == Global.min_txn_fee
+        and Global.genesis_hash == TemplateVar[Bytes]("TARGET_NETWORK_GENESIS")
+        # Pinning last_valid and requiring a non-empty lease prevents replay attacks:
+        # once confirmed, the (sender, lease) pair is locked until LAST_ROUND passes.
+        and current_txn.last_valid == TemplateVar[UInt64]("LAST_ROUND")
+        and current_txn.lease == op.sha256(b"self-payment")
+    )
+
+
+# example: LSIG_SELFPAYMENT

--- a/examples/devportal/subsidize_app_call/contract.py
+++ b/examples/devportal/subsidize_app_call/contract.py
@@ -1,0 +1,46 @@
+from algopy import (
+    Application,
+    Bytes,
+    Global,
+    TemplateVar,
+    Txn,
+    UInt64,
+    gtxn,
+    logicsig,
+)
+
+
+# example: LSIG_SUBSIDIZEAPPCALL
+@logicsig
+def subsidize_app_call(prev_call: gtxn.ApplicationCallTransaction) -> bool:
+    """
+    This Contract Account will subsidize the fees for any AppCall transaction directed to a known
+    application.
+
+    Transaction-typed logicsig parameters bind positionally to the transactions
+    immediately *preceding* the signed transaction in the group (they are not
+    passed via the args array): `prev_call` here is the transaction at
+    `Txn.group_index - 1`, and the compiler asserts its type is ApplicationCall.
+    """
+
+    # this will assert the current transaction is a payment
+    # it's exactly equivalent to using the `Txn` object,
+    # just a bit more explicit
+    current_txn = gtxn.PaymentTransaction(Txn.group_index)
+    return (
+        # is it safe to pay for the fees of the previous transaction?
+        current_txn.receiver == current_txn.sender
+        and current_txn.amount == 0
+        and current_txn.rekey_to == Global.zero_address
+        and current_txn.close_remainder_to == Global.zero_address
+        and current_txn.fee == 2 * Global.min_txn_fee
+        and current_txn.last_valid <= TemplateVar[UInt64]("EXPIRATION_ROUND")
+        and Global.genesis_hash == TemplateVar[Bytes]("TARGET_NETWORK_GENESIS")
+        # does the previous transaction (already asserted to be an app call by
+        # the typed parameter) target the known app, paying no fee itself?
+        and prev_call.app_id == TemplateVar[Application]("KNOWN_APP")
+        and prev_call.fee == 0
+    )
+
+
+# example: LSIG_SUBSIDIZEAPPCALL

--- a/tests/onchain/devportal/test_abimethod_options.py
+++ b/tests/onchain/devportal/test_abimethod_options.py
@@ -1,0 +1,269 @@
+import random
+
+import algokit_utils as au
+import pytest
+from algokit_utils.transactions.transaction_composer import TransactionComposerError
+
+from tests import EXAMPLES_DIR
+from tests.utils.deployer import Deployer
+
+_ABIMETHOD_OPTIONS = EXAMPLES_DIR / "devportal" / "abimethod_options"
+
+
+def _create(deployer: Deployer, governor: str, fee_asset: int) -> au.AppClient:
+    return deployer.create(_ABIMETHOD_OPTIONS, method="create", args=[governor, fee_asset]).client
+
+
+def _params(method: str, *args: object) -> au.AppClientMethodCallParams:
+    # a random note keeps otherwise-identical txns unique within the ledger
+    return au.AppClientMethodCallParams(method=method, args=list(args), note=random.randbytes(8))
+
+
+def _funded_account(deployer: Deployer) -> au.AddressWithSigners:
+    """A second account (distinct from the deployer) that holds no assets."""
+    other = deployer.localnet.account.random()
+    deployer.localnet.account.ensure_funded(
+        account_to_fund=other.addr,
+        dispenser_account=deployer.account,
+        min_spending_balance=au.AlgoAmount.from_algo(1),
+    )
+    return other
+
+
+# --- create="require" ---------------------------------------------------------
+
+
+def test_create_initializes_governor_and_fee_asset(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    assert client.app_id
+
+
+def test_bare_create_is_rejected(deployer: Deployer) -> None:
+    # `create="require"` on `create` means a bare app create must fail
+    with pytest.raises((au.LogicError, TransactionComposerError)):
+        deployer.create_bare(_ABIMETHOD_OPTIONS)
+
+
+# --- @public --------------------------------------------------------------------
+
+
+def test_public_governor_getter_returns_governor(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    result = client.send.call(_params("public_governor_getter"))
+    assert result.abi_return == account.addr
+
+
+# --- name= ----------------------------------------------------------------------
+
+
+def test_ping_uses_renamed_abi_method(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    # `name="ping"` decouples the ABI name from the python name long_internal_name
+    result = client.send.call(_params("ping"))
+    assert result.abi_return == "ping"
+
+
+# --- readonly= --------------------------------------------------------------------
+
+
+def test_get_join_event_count_readonly(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    result = client.send.call(_params("get_join_event_count"))
+    assert result.abi_return == 0
+
+
+# --- default_args= ----------------------------------------------------------------
+
+
+def test_admin_action_with_explicit_args(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    # explicitly passing the values the defaults would resolve to
+    result = client.send.call(_params("admin_action", asset_a, 0))
+    assert result.confirmation.confirmed_round
+
+
+def test_admin_action_defaults_resolved_by_client(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    # passing None makes the client resolve each default from the ARC-56
+    # metadata: fee_asset from global state, expected_join_event_count by
+    # simulating the readonly get_join_event_count method
+    result = client.send.call(_params("admin_action", None, None))
+    assert result.confirmation.confirmed_round
+
+
+def test_admin_action_rejects_non_governor(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    other = _funded_account(deployer)
+    other_client = client.clone(default_sender=other.addr, default_signer=other.signer)
+    # a non-governor sender is rejected even when passing the correct
+    # state values for every argument (auth checks stored state, not args)
+    with pytest.raises(au.LogicError, match="only governor"):
+        other_client.send.call(_params("admin_action", asset_a, 0))
+
+
+def test_admin_action_tolerates_wrong_fee_asset(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int, asset_b: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    # a mismatched asset takes the early-return branch instead of failing —
+    # even the stale count (999) is never checked, since the branch returns first
+    result = client.send.call(_params("admin_action", asset_b, 999))
+    assert result.confirmation.confirmed_round
+
+
+def test_admin_action_rejects_stale_join_event_count(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    with pytest.raises(au.LogicError, match="stale join event count"):
+        client.send.call(_params("admin_action", asset_a, 5))
+
+
+# --- resource_encoding= -------------------------------------------------------------
+
+
+def test_eligible_balance(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    # the deployer account created asset_a (so holds it) and opts in to the app
+    client.send.opt_in(_params("join"))
+    result = client.send.call(_params("eligible_balance", asset_a, client.app_id, account.addr))
+    assert isinstance(result.abi_return, int)
+    assert result.abi_return > 0
+
+
+def test_eligible_balance_requires_app_opt_in(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    # no opt-in to the app has happened
+    with pytest.raises(au.LogicError, match="account not opted in to app"):
+        client.send.call(_params("eligible_balance", asset_a, client.app_id, account.addr))
+
+
+def test_eligible_balance_requires_asset_holding(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    localnet = deployer.localnet
+    other = _funded_account(deployer)
+    other_client = client.clone(default_sender=other.addr, default_signer=other.signer)
+
+    # `other` opts in to the fee asset (with zero balance) so it can join the app
+    localnet.send.asset_opt_in(au.AssetOptInParams(sender=other.addr, asset_id=asset_a))
+    other_client.send.opt_in(_params("join"))
+    # ...then opts back out of the asset, remaining opted in to the app only
+    localnet.send.asset_opt_out(
+        au.AssetOptOutParams(sender=other.addr, asset_id=asset_a, creator=account.addr)
+    )
+
+    with pytest.raises(au.LogicError, match="account is not opted in to the asset"):
+        other_client.send.call(_params("eligible_balance", asset_a, client.app_id, other.addr))
+
+
+# --- allow_actions= -----------------------------------------------------------------
+
+
+def test_join_lifecycle_noop_optin_closeout(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+
+    # NoOp join: allowed, but does not count as a new member
+    client.send.call(_params("join"))
+    assert client.send.call(_params("get_join_event_count")).abi_return == 0
+
+    # OptIn join: allocates local state and increments the member count
+    client.send.opt_in(_params("join"))
+    assert client.send.call(_params("get_join_event_count")).abi_return == 1
+    local_state = client.get_local_state(account.addr)
+    joined_round = local_state["joined_round"].value
+    assert isinstance(joined_round, int)
+    assert joined_round > 0
+
+    # NoOp join after opting in: still a member, count unchanged
+    client.send.call(_params("join"))
+    assert client.send.call(_params("get_join_event_count")).abi_return == 1
+
+    # CloseOut via opt_out releases local state and counts the leave event;
+    # the join event counter is never decremented
+    client.send.close_out(_params("opt_out"))
+    assert client.send.call(_params("get_join_event_count")).abi_return == 1
+    global_state = client.get_global_state()
+    assert global_state["leave_event_count"].value == 1
+
+
+def test_join_second_opt_in_rejected_by_network(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    client.send.opt_in(_params("join"))
+    # an already-opted-in account cannot opt in again — the node rejects the
+    # transaction before any contract logic runs, so `join_event_count` cannot be
+    # inflated by repeating OptIn
+    with pytest.raises(
+        (au.LogicError, TransactionComposerError, ValueError), match="already opted in"
+    ):
+        client.send.opt_in(_params("join"))
+    assert client.send.call(_params("get_join_event_count")).abi_return == 1
+
+
+def test_join_event_count_drifts_after_clear_state(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    client.send.opt_in(_params("join"))
+    assert client.send.call(_params("get_join_event_count")).abi_return == 1
+
+    # ClearState wipes local state but cannot be blocked and bypasses the
+    # CloseOut handler, so the leave is never recorded...
+    client.send.bare.clear_state(au.AppClientBareCallParams(note=random.randbytes(8)))
+    assert client.get_global_state()["leave_event_count"].value == 0
+
+    # ...and rejoining records a second join event for the same account, so
+    # join - leave now overcounts active members: the "best-effort" drift the
+    # opt_out docstring warns about
+    client.send.opt_in(_params("join"))
+    assert client.send.call(_params("get_join_event_count")).abi_return == 2
+    assert client.get_global_state()["leave_event_count"].value == 0
+
+
+def test_join_requires_fee_asset(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    other = _funded_account(deployer)
+    other_client = client.clone(default_sender=other.addr, default_signer=other.signer)
+    # `other` is not opted in to the fee asset, so joining is rejected
+    with pytest.raises(au.LogicError, match="must be opted in to fee asset"):
+        other_client.send.opt_in(_params("join"))
+
+
+def test_shut_down_only_governor(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _create(deployer, account.addr, asset_a)
+    other = _funded_account(deployer)
+    other_client = client.clone(default_sender=other.addr, default_signer=other.signer)
+
+    with pytest.raises(au.LogicError, match="only governor can delete"):
+        other_client.send.delete(_params("shut_down"))
+
+    # the governor can delete the app
+    result = client.send.delete(_params("shut_down"))
+    assert result.confirmation.confirmed_round

--- a/tests/onchain/devportal/test_arc4_client.py
+++ b/tests/onchain/devportal/test_arc4_client.py
@@ -1,0 +1,116 @@
+import algokit_utils as au
+import pytest
+
+from tests import EXAMPLES_DIR
+from tests.utils.compile import compile_arc56_from_closure
+from tests.utils.deployer import Deployer
+
+_ARC4_CLIENT = EXAMPLES_DIR / "devportal" / "arc4_client"
+
+# call_hello / call_add each issue one inner ApplicationCall with fee=0,
+# so the outer call must cover both transaction fees.
+_INNER_FEE = au.AlgoAmount.from_micro_algo(2000)
+
+
+def _target_contract() -> None:
+    """An external ARC-4 contract matching the HelloWorldClient protocol:
+    `hello(string)string` and `add(uint64,uint64)uint64`."""
+    from algopy import String, UInt64, arc4
+
+    class HelloWorld(arc4.ARC4Contract):
+        @arc4.abimethod
+        def hello(self, name: String) -> String:
+            return "Hello, " + name
+
+        @arc4.abimethod
+        def add(self, a: UInt64, b: UInt64) -> UInt64:
+            return a + b
+
+
+def test_call_hello_routes_to_target(deployer: Deployer) -> None:
+    target = deployer.create(compile_arc56_from_closure(_target_contract)).client
+    consumer = deployer.create((_ARC4_CLIENT, "ClientConsumer")).client
+
+    result = consumer.send.call(
+        au.AppClientMethodCallParams(
+            method="call_hello",
+            args=[target.app_id, "Algorand"],
+            static_fee=_INNER_FEE,
+        )
+    )
+    assert result.abi_return == "Hello, Algorand"
+
+
+def test_call_add_routes_to_target_and_checks_logs(deployer: Deployer) -> None:
+    target = deployer.create(compile_arc56_from_closure(_target_contract)).client
+    consumer = deployer.create((_ARC4_CLIENT, "ClientConsumer")).client
+
+    result = consumer.send.call(
+        au.AppClientMethodCallParams(
+            method="call_add",
+            args=[target.app_id, 7, 35],
+            static_fee=_INNER_FEE,
+        )
+    )
+    # add(7, 35) == 42; the contract also asserts the inner txn emitted
+    # exactly one log (the ABI return log).
+    assert result.abi_return == 42
+
+
+def test_call_add_with_zero_operands(deployer: Deployer) -> None:
+    target = deployer.create(compile_arc56_from_closure(_target_contract)).client
+    consumer = deployer.create((_ARC4_CLIENT, "ClientConsumer")).client
+
+    result = consumer.send.call(
+        au.AppClientMethodCallParams(
+            method="call_add",
+            args=[target.app_id, 0, 0],
+            static_fee=_INNER_FEE,
+        )
+    )
+    assert result.abi_return == 0
+
+
+def _chatty_target_contract() -> None:
+    """A target whose `add` emits an extra log besides the ABI return log,
+    violating ClientConsumer's `num_logs == 1` expectation."""
+    from algopy import String, UInt64, arc4, log
+
+    class HelloWorld(arc4.ARC4Contract):
+        @arc4.abimethod
+        def hello(self, name: String) -> String:
+            return "Hello, " + name
+
+        @arc4.abimethod
+        def add(self, a: UInt64, b: UInt64) -> UInt64:
+            log("extra log entry")
+            return a + b
+
+
+def test_call_add_rejects_target_with_extra_logs(deployer: Deployer) -> None:
+    target = deployer.create(compile_arc56_from_closure(_chatty_target_contract)).client
+    consumer = deployer.create((_ARC4_CLIENT, "ClientConsumer")).client
+
+    # the target emits 2 logs, so the consumer's num_logs assertion fails
+    with pytest.raises(au.LogicError, match="only the return log was emitted"):
+        consumer.send.call(
+            au.AppClientMethodCallParams(
+                method="call_add",
+                args=[target.app_id, 1, 2],
+                static_fee=_INNER_FEE,
+            )
+        )
+
+
+def test_call_hello_against_missing_app_fails(deployer: Deployer) -> None:
+    consumer = deployer.create((_ARC4_CLIENT, "ClientConsumer")).client
+
+    # An app id that does not exist on chain cannot be invoked.
+    with pytest.raises(au.LogicError):
+        consumer.send.call(
+            au.AppClientMethodCallParams(
+                method="call_hello",
+                args=[99_999_999, "nobody"],
+                static_fee=_INNER_FEE,
+            )
+        )

--- a/tests/onchain/devportal/test_arc4_types.py
+++ b/tests/onchain/devportal/test_arc4_types.py
@@ -1,0 +1,178 @@
+import algokit_utils as au
+import pytest
+
+from tests import EXAMPLES_DIR
+from tests.utils.deployer import Deployer
+
+_ARC4_TYPES = EXAMPLES_DIR / "devportal" / "arc4_types"
+
+
+def _client(deployer: Deployer, class_name: str) -> au.AppClient:
+    return deployer.create((_ARC4_TYPES, class_name)).client
+
+
+def _call(client: au.AppClient, method: str, args: list[object] | None = None) -> object:
+    return client.send.call(
+        au.AppClientMethodCallParams(method=method, args=args or [])
+    ).abi_return
+
+
+# --- Arc4Types ---------------------------------------------------------------
+
+
+def test_add_arc4_uint64(deployer: Deployer) -> None:
+    client = _client(deployer, "Arc4Types")
+    assert _call(client, "add_arc4_uint64", [10, 32]) == 42
+
+
+def test_add_arc4_uint_n(deployer: Deployer) -> None:
+    client = _client(deployer, "Arc4Types")
+    # uint8 + uint16 + uint32 + uint64
+    assert _call(client, "add_arc4_uint_n", [1, 2, 3, 4]) == 10
+
+
+def test_add_arc4_biguint_n(deployer: Deployer) -> None:
+    client = _client(deployer, "Arc4Types")
+    assert _call(client, "add_arc4_biguint_n", [100, 200, 300]) == 600
+
+
+def test_arc4_byte_increments(deployer: Deployer) -> None:
+    client = _client(deployer, "Arc4Types")
+    # arc4.Byte decodes to a single raw byte
+    assert _call(client, "arc4_byte", [41]) == (42).to_bytes(1, "big")
+
+
+def test_arc4_address_balance(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _client(deployer, "Arc4Types")
+    balance = _call(client, "arc4_address_balance", [account.addr])
+    assert isinstance(balance, int)
+    assert balance > 0
+
+
+def test_arc4_address_roundtrip(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _client(deployer, "Arc4Types")
+    result = _call(client, "arc4_address_roundtrip", [account.addr])
+    assert result == account.addr
+
+
+# --- Arc4StaticArray ---------------------------------------------------------
+
+
+def test_arc4_static_array(deployer: Deployer) -> None:
+    client = _client(deployer, "Arc4StaticArray")
+    # method asserts internally and returns None; success means assertions held
+    assert _call(client, "arc4_static_array") is None
+
+
+# --- Arc4DynamicArray --------------------------------------------------------
+
+
+def test_goodbye(deployer: Deployer) -> None:
+    client = _client(deployer, "Arc4DynamicArray")
+    goodbye = _call(client, "goodbye", ["Alice"])
+    assert isinstance(goodbye, list)
+    assert list(goodbye) == ["Good bye ", "Alice"]
+
+
+def test_hello_concatenates(deployer: Deployer) -> None:
+    client = _client(deployer, "Arc4DynamicArray")
+    # dynamic_string_array = ["Hello "] then extended with [name, "!"]
+    assert _call(client, "hello", ["world"]) == "Hello world!"
+
+
+def test_arc4_dynamic_bytes(deployer: Deployer) -> None:
+    client = _client(deployer, "Arc4DynamicArray")
+    # start b"\xff\xff\xff" -> set [0]=0 -> b"\x00\xff\xff"
+    # extend b"\xaa\xbb\xcc" -> b"\x00\xff\xff\xaa\xbb\xcc"
+    # pop -> b"\x00\xff\xff\xaa\xbb" ; append 255 -> b"\x00\xff\xff\xaa\xbb\xff"
+    result = _call(client, "arc4_dynamic_bytes")
+    assert result == b"\x00\xff\xff\xaa\xbb\xff"
+
+
+# --- Arc4Struct --------------------------------------------------------------
+
+
+def test_add_and_complete_todo(deployer: Deployer) -> None:
+    client = _client(deployer, "Arc4Struct")
+
+    todos = _call(client, "add_todo", ["buy milk"])
+    assert isinstance(todos, list)
+    assert [tuple(t) for t in todos] == [("buy milk", False)]
+
+    todos = _call(client, "add_todo", ["walk dog"])
+    assert isinstance(todos, list)
+    assert [tuple(t) for t in todos] == [("buy milk", False), ("walk dog", False)]
+
+    assert _call(client, "complete_todo", ["buy milk"]) is None
+
+    completed = _call(client, "return_todo", ["buy milk"])
+    # a returned arc4.Struct decodes as a mapping of field name -> value
+    assert isinstance(completed, dict)
+    assert dict(completed) == {"task": "buy milk", "completed": True}
+
+    # untouched todo stays incomplete
+    walk_dog = _call(client, "return_todo", ["walk dog"])
+    assert isinstance(walk_dog, dict)
+    assert dict(walk_dog) == {
+        "task": "walk dog",
+        "completed": False,
+    }
+
+
+def test_return_todo_missing_errors(deployer: Deployer) -> None:
+    client = _client(deployer, "Arc4Struct")
+    with pytest.raises(au.LogicError, match="todo not found"):
+        _call(client, "return_todo", ["nonexistent"])
+
+
+def test_complete_todo_missing_is_noop(deployer: Deployer) -> None:
+    client = _client(deployer, "Arc4Struct")
+    _call(client, "add_todo", ["buy milk"])
+
+    # completing a task that is not in the list succeeds without changes
+    assert _call(client, "complete_todo", ["nonexistent"]) is None
+
+    existing = _call(client, "return_todo", ["buy milk"])
+    assert isinstance(existing, dict)
+    assert dict(existing) == {"task": "buy milk", "completed": False}
+
+
+# --- Arc4Tuple ---------------------------------------------------------------
+
+
+def test_add_and_return_contact_info(deployer: Deployer) -> None:
+    client = _client(deployer, "Arc4Tuple")
+
+    contact = ("Alice", "alice@something.com", 555_555_555)
+    phone = _call(client, "add_contact_info", [contact])
+    assert phone == 555_555_555
+
+    returned_contact = _call(client, "return_contact")
+    assert isinstance(returned_contact, list | tuple)
+    assert tuple(returned_contact) == contact
+
+
+def test_add_contact_info_rejects_wrong_values(deployer: Deployer) -> None:
+    client = _client(deployer, "Arc4Tuple")
+    # method asserts name == "Alice"
+    with pytest.raises(au.LogicError):
+        _call(
+            client,
+            "add_contact_info",
+            [("Bob", "alice@something.com", 555_555_555)],
+        )
+
+
+# --- Arc4Codec ---------------------------------------------------------------
+
+
+def test_encode_decode_roundtrip(deployer: Deployer) -> None:
+    client = _client(deployer, "Arc4Codec")
+    assert _call(client, "encode_decode", [123456789]) == 123456789
+
+
+def test_decode_unvalidated(deployer: Deployer) -> None:
+    client = _client(deployer, "Arc4Codec")
+    # arc4.UInt64 encodes as 8 big-endian bytes
+    raw = (42).to_bytes(8, "big")
+    assert _call(client, "decode_unvalidated", [raw]) == 42

--- a/tests/onchain/devportal/test_box_storage.py
+++ b/tests/onchain/devportal/test_box_storage.py
@@ -1,0 +1,317 @@
+import random
+
+import algokit_utils as au
+import pytest
+
+from tests import EXAMPLES_DIR
+from tests.utils.deployer import Deployer
+
+_BOX_STORAGE = EXAMPLES_DIR / "devportal" / "box_storage"
+
+_BoxRefs = list[au.BoxReference | au.BoxIdentifier]
+
+# static box keys declared on the contract
+_BOX_INT = b"box_int"
+_BOX_DYNAMIC_BYTES = b"b"
+_BOX_STRING = b"BOX_STRING"
+_BOX_BYTES = b"BOX_BYTES"
+_BOX_NESTED = b"box_nested"
+
+
+def _int_key(value: int) -> bytes:
+    """BoxMap[UInt64, ...] keys are 8-byte big-endian (key_prefix='')."""
+    return value.to_bytes(8, "big")
+
+
+def _struct_key(value: int) -> bytes:
+    """BoxMap[arc4.UInt64, UserStruct] keys are 'users' + 8-byte big-endian."""
+    return b"users" + value.to_bytes(8, "big")
+
+
+def _empty(n: int) -> _BoxRefs:
+    # padding box references let a single txn touch additional boxes
+    return [au.BoxReference(0, b"")] * n
+
+
+def _params(
+    method: str,
+    *args: object,
+    box_refs: _BoxRefs | None = None,
+    fee: au.AlgoAmount | None = None,
+) -> au.AppClientMethodCallParams:
+    return au.AppClientMethodCallParams(
+        method=method,
+        args=list(args),
+        box_references=box_refs,
+        static_fee=fee,
+        note=random.randbytes(8),
+    )
+
+
+@pytest.fixture
+def client(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> au.AppClient:
+    client = deployer.create(_BOX_STORAGE).client
+    # boxes raise the app's minimum balance, so the app account must be funded
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=client.app_address,
+            amount=au.AlgoAmount.from_algo(2),
+        )
+    )
+    return client
+
+
+# --- Box[UInt64] ----------------------------------------------------------
+
+
+def test_set_and_get_box(client: au.AppClient) -> None:
+    refs: _BoxRefs = [_BOX_INT]
+    client.send.call(_params("set_box", 99, box_refs=refs))
+    result = client.send.call(_params("get_box", box_refs=refs))
+    assert result.abi_return == 99
+
+
+def test_get_box_missing_fails(client: au.AppClient) -> None:
+    # reading `.value` of a box that was never created fails on-chain
+    with pytest.raises(au.LogicError):
+        client.send.call(_params("get_box", box_refs=[_BOX_INT]))
+
+
+def test_maybe_box(client: au.AppClient) -> None:
+    refs: _BoxRefs = [_BOX_INT]
+    absent = client.send.call(_params("maybe_box", box_refs=refs))
+    # (value, exists) -> value undefined, exists False
+    assert absent.abi_return == (0, False)
+
+    client.send.call(_params("set_box", 7, box_refs=refs))
+    present = client.send.call(_params("maybe_box", box_refs=refs))
+    assert present.abi_return == (7, True)
+
+
+def test_box_int_length(client: au.AppClient) -> None:
+    refs: _BoxRefs = [_BOX_INT]
+    client.send.call(_params("set_box", 1, box_refs=refs))
+    # a UInt64 is 8 bytes
+    result = client.send.call(_params("box_int_length", box_refs=refs))
+    assert result.abi_return == 8
+
+
+def test_key_box(client: au.AppClient) -> None:
+    result = client.send.call(_params("key_box", box_refs=[_BOX_INT]))
+    assert result.abi_return == _BOX_INT
+
+
+def test_exist_box(client: au.AppClient) -> None:
+    refs: _BoxRefs = [_BOX_INT, _BOX_DYNAMIC_BYTES, _BOX_STRING, _BOX_BYTES]
+    absent = client.send.call(_params("exist_box", box_refs=refs))
+    assert absent.abi_return == (False, False, False, False)
+
+    client.send.call(_params("set_box_example", 10, b"\x01\x02", "hi", box_refs=refs))
+    present = client.send.call(_params("exist_box", box_refs=refs))
+    assert present.abi_return == (True, True, True, True)
+
+
+# --- explicit-key boxes ---------------------------------------------------
+
+
+def test_set_and_get_box_example(client: au.AppClient) -> None:
+    refs: _BoxRefs = [_BOX_INT, _BOX_DYNAMIC_BYTES, _BOX_STRING, _BOX_BYTES]
+    client.send.call(_params("set_box_example", 40, b"\xaa\xbb", "World", box_refs=refs))
+    result = client.send.call(_params("get_box_example", box_refs=refs))
+    # set_box_example does `box_int += 3` after assigning 40 -> 43
+    assert result.abi_return == (43, b"\xaa\xbb", "World")
+
+
+def test_key_box_example(client: au.AppClient) -> None:
+    # asserts the explicit keys b, BOX_STRING, BOX_BYTES internally
+    refs: _BoxRefs = [_BOX_DYNAMIC_BYTES, _BOX_STRING, _BOX_BYTES]
+    client.send.call(_params("key_box_example", box_refs=refs))
+
+
+def test_delete_box(client: au.AppClient) -> None:
+    refs: _BoxRefs = [_BOX_INT, _BOX_DYNAMIC_BYTES, _BOX_STRING, _BOX_BYTES]
+    client.send.call(_params("set_box_example", 5, b"\x09", "x", box_refs=refs))
+    # delete_box removes box_int / box_dynamic_bytes / box_string and asserts
+    # the .get defaults internally
+    client.send.call(_params("delete_box", box_refs=refs))
+    exists = client.send.call(_params("exist_box", box_refs=refs))
+    assert exists.abi_return == (False, False, False, True)
+
+
+# --- BoxMap[UInt64, String] -----------------------------------------------
+
+
+def test_set_and_get_item_box_map(client: au.AppClient) -> None:
+    refs: _BoxRefs = [_int_key(5)]
+    client.send.call(_params("set_box_map", 5, "five", box_refs=refs))
+    result = client.send.call(_params("get_item_box_map", 5, box_refs=refs))
+    assert result.abi_return == "five"
+
+
+def test_get_box_map_default(client: au.AppClient) -> None:
+    # get_box_map reads key 1 with default "default"
+    refs: _BoxRefs = [_int_key(1)]
+    absent = client.send.call(_params("get_box_map", box_refs=refs))
+    assert absent.abi_return == "default"
+
+    client.send.call(_params("set_box_map", 1, "one", box_refs=refs))
+    present = client.send.call(_params("get_box_map", box_refs=refs))
+    assert present.abi_return == "one"
+
+
+def test_maybe_box_map(client: au.AppClient) -> None:
+    refs: _BoxRefs = [_int_key(1)]
+    absent = client.send.call(_params("maybe_box_map", box_refs=refs))
+    assert absent.abi_return == ("", False)
+
+    client.send.call(_params("set_box_map", 1, "hello", box_refs=refs))
+    present = client.send.call(_params("maybe_box_map", box_refs=refs))
+    assert present.abi_return == ("hello", True)
+
+
+def test_box_map_exists(client: au.AppClient) -> None:
+    refs: _BoxRefs = [_int_key(3)]
+    absent = client.send.call(_params("box_map_exists", 3, box_refs=refs))
+    assert absent.abi_return is False
+
+    client.send.call(_params("set_box_map", 3, "v", box_refs=refs))
+    present = client.send.call(_params("box_map_exists", 3, box_refs=refs))
+    assert present.abi_return is True
+
+
+def test_box_map_length(client: au.AppClient) -> None:
+    refs: _BoxRefs = [_int_key(8)]
+    # length is 0 for a missing key
+    absent = client.send.call(_params("box_map_length", 8, box_refs=refs))
+    assert absent.abi_return == 0
+
+    client.send.call(_params("set_box_map", 8, "abcd", box_refs=refs))
+    # box_map values are the native algopy String, stored as raw UTF-8 bytes
+    # with no length prefix -> "abcd" is 4 bytes
+    present = client.send.call(_params("box_map_length", 8, box_refs=refs))
+    assert present.abi_return == 4
+
+
+def test_delete_box_map(client: au.AppClient) -> None:
+    refs: _BoxRefs = [_int_key(2)]
+    client.send.call(_params("set_box_map", 2, "two", box_refs=refs))
+    client.send.call(_params("delete_box_map", 2, box_refs=refs))
+    result = client.send.call(_params("box_map_exists", 2, box_refs=refs))
+    assert result.abi_return is False
+
+
+def test_get_item_box_map_missing_fails(client: au.AppClient) -> None:
+    # indexing a missing BoxMap key fails on-chain
+    with pytest.raises(au.LogicError):
+        client.send.call(_params("get_item_box_map", 404, box_refs=[_int_key(404)]))
+
+
+def test_key_prefix_box_map(client: au.AppClient) -> None:
+    # box_map was declared with key_prefix=""
+    result = client.send.call(_params("key_prefix_box_map"))
+    assert result.abi_return == b""
+
+
+def test_read_box_passed_to_subroutine(client: au.AppClient) -> None:
+    # subroutine reads box_map[key + 1]
+    refs: _BoxRefs = [_int_key(10), _int_key(11)]
+    client.send.call(_params("set_box_map", 11, "eleven", box_refs=[_int_key(11)]))
+    result = client.send.call(_params("read_box_passed_to_subroutine", 10, box_refs=refs))
+    assert result.abi_return == "eleven"
+
+
+def test_read_box_passed_to_subroutine_missing_fails(client: au.AppClient) -> None:
+    # the subroutine indexes box_map[key + 1], which was never written
+    with pytest.raises(au.LogicError):
+        client.send.call(
+            _params(
+                "read_box_passed_to_subroutine",
+                500,
+                box_refs=[_int_key(500), _int_key(501)],
+            )
+        )
+
+
+# --- BoxMap[arc4.UInt64, UserStruct] --------------------------------------
+
+
+def test_set_and_get_box_map_struct(client: au.AppClient) -> None:
+    refs: _BoxRefs = [_struct_key(1)]
+    user = ("alice", 1, 2)  # UserStruct(name, id, asset)
+    set_result = client.send.call(_params("set_box_map_struct", 1, user, box_refs=refs))
+    assert set_result.abi_return is True
+
+    get_result = client.send.call(_params("get_box_map_struct", 1, box_refs=refs))
+    # UserStruct is an arc4.Struct, so the return decodes to a field dict
+    assert get_result.abi_return == {"name": "alice", "id": 1, "asset": 2}
+
+
+def test_get_box_map_struct_missing_fails(client: au.AppClient) -> None:
+    # indexing a missing BoxMap struct key fails on-chain
+    with pytest.raises(au.LogicError):
+        client.send.call(_params("get_box_map_struct", 404, box_refs=[_struct_key(404)]))
+
+
+def test_box_map_struct_exists(client: au.AppClient) -> None:
+    refs: _BoxRefs = [_struct_key(2)]
+    absent = client.send.call(_params("box_map_struct_exists", 2, box_refs=refs))
+    assert absent.abi_return is False
+
+    client.send.call(_params("set_box_map_struct", 2, ("bob", 9, 3), box_refs=refs))
+    present = client.send.call(_params("box_map_struct_exists", 2, box_refs=refs))
+    assert present.abi_return is True
+
+
+def test_box_map_struct_length(client: au.AppClient) -> None:
+    # method writes key 0 internally and asserts the on-chain length
+    result = client.send.call(_params("box_map_struct_length", box_refs=[_struct_key(0)]))
+    assert result.abi_return is True
+
+
+# --- ad-hoc boxes ---------------------------------------------------------
+
+
+def test_extract_box(client: au.AppClient) -> None:
+    # uses an ad-hoc Box[Bytes] keyed "blob"; splice grows the box so add fee
+    client.send.call(
+        _params(
+            "extract_box",
+            box_refs=[b"blob", *_empty(1)],
+            fee=au.AlgoAmount.from_micro_algo(4_000),
+        )
+    )
+
+
+def test_slice_box(client: au.AppClient) -> None:
+    # ad-hoc Box[Bytes] keyed "scratch" plus the BOX_STRING box
+    client.send.call(_params("slice_box", box_refs=[b"scratch", _BOX_STRING]))
+
+
+def test_arc4_box(client: au.AppClient) -> None:
+    # ad-hoc Box[StaticArray] keyed "d"
+    client.send.call(_params("arc4_box", box_refs=[b"d"]))
+
+
+# --- nested struct box ----------------------------------------------------
+
+
+def test_nested_struct_write_and_sum(client: au.AppClient) -> None:
+    refs: _BoxRefs = [_BOX_NESTED, *_empty(2)]
+    fee = au.AlgoAmount.from_micro_algo(4_000)
+    # nested_struct_write(value): a=value, inner.c=value+1, inner.d=value+2,
+    # b=value+3, and appends 0,1,2 to inner.arr
+    client.send.call(_params("nested_struct_write", 10, box_refs=refs, fee=fee))
+
+    result = client.send.call(_params("nested_struct_sum", box_refs=refs, fee=fee))
+    # a + b + inner.c + inner.d + sum(arr)
+    #   = 10 + 13 + 11 + 12 + (0 + 1 + 2) = 49
+    assert result.abi_return == 49
+
+
+def test_nested_struct_sum_missing_fails(client: au.AppClient) -> None:
+    # reading box_nested.value before any write fails on-chain
+    with pytest.raises(au.LogicError):
+        client.send.call(_params("nested_struct_sum", box_refs=[_BOX_NESTED]))

--- a/tests/onchain/devportal/test_contract_options.py
+++ b/tests/onchain/devportal/test_contract_options.py
@@ -1,0 +1,98 @@
+import random
+
+import algokit_transact as at
+import algokit_utils as au
+
+from puya.utils import sha512_256_hash
+from tests import EXAMPLES_DIR
+from tests.utils.deployer import Deployer
+
+_CONTRACT_OPTIONS = EXAMPLES_DIR / "devportal" / "contract_options"
+
+
+def test_contract_with_custom_name_hello(deployer: Deployer) -> None:
+    # the contract compiles (and deploys) under its overridden name,
+    # not the python class name ContractWithCustomName
+    client = deployer.create((_CONTRACT_OPTIONS, "OnChainName")).client
+    assert client.app_spec.name == "OnChainName"
+    result = client.send.call(au.AppClientMethodCallParams(method="hello"))
+    assert result.abi_return == "hello"
+
+
+def test_contract_with_state_reservation_increment(deployer: Deployer) -> None:
+    client = deployer.create((_CONTRACT_OPTIONS, "ContractWithStateReservation")).client
+    # a random note keeps the two otherwise-identical increment txns unique
+    assert (
+        client.send.call(
+            au.AppClientMethodCallParams(method="increment", note=random.randbytes(8))
+        ).abi_return
+        == 1
+    )
+    assert (
+        client.send.call(
+            au.AppClientMethodCallParams(method="increment", note=random.randbytes(8))
+        ).abi_return
+        == 2
+    )
+
+
+def test_contract_with_state_reservation_schema(
+    deployer: Deployer, localnet: au.AlgorandClient
+) -> None:
+    client = deployer.create((_CONTRACT_OPTIONS, "ContractWithStateReservation")).client
+    # the created app reserves the explicit state_totals, not the two slots
+    # that would be auto-computed from the `self.` assignments in __init__
+    params = localnet.client.algod.application_by_id(client.app_id).params
+    assert params.global_state_schema is not None
+    assert params.global_state_schema.num_uints == 16
+    assert params.global_state_schema.num_byte_slices == 8
+    assert params.local_state_schema is not None
+    assert params.local_state_schema.num_uints == 4
+    assert params.local_state_schema.num_byte_slices == 0
+
+
+def test_contract_with_scratch_reservation_echo(deployer: Deployer) -> None:
+    client = deployer.create((_CONTRACT_OPTIONS, "ContractWithScratchReservation")).client
+    assert client.send.call(au.AppClientMethodCallParams(method="echo", args=[7])).abi_return == 7
+
+
+def test_caller_pin_reads_reject_version_field(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = deployer.create((_CONTRACT_OPTIONS, "ContractWithAvmVersion")).client
+
+    # an unpinned call reads reject_version == 0
+    result = client.send.call(au.AppClientMethodCallParams(method="caller_pin"))
+    assert result.abi_return == 0
+
+    # algokit_utils does not expose reject_version on outer app-call params
+    # yet, so a pinned call is built at the raw algokit_transact layer
+    sp = localnet.get_suggested_params()
+    txn = at.Transaction(
+        transaction_type=at.TransactionType.AppCall,
+        sender=account.addr,
+        first_valid=sp.first_valid,
+        last_valid=sp.last_valid,
+        fee=1000,
+        genesis_hash=sp.genesis_hash,
+        note=random.randbytes(8),
+        application_call=at.AppCallTransactionFields(
+            app_id=client.app_id,
+            reject_version=3,
+            args=[sha512_256_hash(b"caller_pin()uint64")[:4]],
+        ),
+    )
+    sent = localnet.new_group().add_transaction(txn).send()
+    # decode the ARC-4 return log: 4-byte return prefix + uint64
+    (log,) = sent.confirmations[0].logs or []
+    assert log[:4] == b"\x15\x1f\x7c\x75"
+    assert int.from_bytes(log[4:], "big") == 3
+
+
+def test_contract_with_avm_version_bytecode_declares_v12(
+    deployer: Deployer, localnet: au.AlgorandClient
+) -> None:
+    client = deployer.create((_CONTRACT_OPTIONS, "ContractWithAvmVersion")).client
+    params = localnet.client.algod.application_by_id(client.app_id).params
+    # the first byte of compiled AVM bytecode is the version declaration
+    assert params.approval_program[0] == 12

--- a/tests/onchain/devportal/test_control_flow.py
+++ b/tests/onchain/devportal/test_control_flow.py
@@ -1,0 +1,80 @@
+import algokit_utils as au
+
+from tests import EXAMPLES_DIR
+from tests.utils.deployer import Deployer
+
+_CONTROL_FLOW = EXAMPLES_DIR / "devportal" / "control_flow"
+
+
+def test_if_else_is_rich(deployer: Deployer) -> None:
+    client = deployer.create((_CONTROL_FLOW, "IfElseExample")).client
+
+    def is_rich(balance: int) -> object:
+        return client.send.call(
+            au.AppClientMethodCallParams(method="is_rich", args=[balance])
+        ).abi_return
+
+    assert is_rich(5000) == "This account is rich!"
+    assert is_rich(1001) == "This account is rich!"
+    assert is_rich(1000) == "This account is doing well."
+    assert is_rich(500) == "This account is doing well."
+    assert is_rich(101) == "This account is doing well."
+    assert is_rich(100) == "This account is poor :("
+    assert is_rich(0) == "This account is poor :("
+
+
+def test_ternary_is_even(deployer: Deployer) -> None:
+    client = deployer.create((_CONTROL_FLOW, "IfElseExample")).client
+
+    def is_even(number: int) -> object:
+        return client.send.call(
+            au.AppClientMethodCallParams(method="is_even", args=[number])
+        ).abi_return
+
+    assert is_even(0) == "Even"
+    assert is_even(2) == "Even"
+    assert is_even(10) == "Even"
+    assert is_even(1) == "Odd"
+    assert is_even(7) == "Odd"
+
+
+def test_for_loop(deployer: Deployer) -> None:
+    client = deployer.create((_CONTROL_FLOW, "ForLoopsExample")).client
+
+    # urange(4) reversed -> [3, 2, 1, 0] assigned at forward index 0..3
+    result = client.send.call(au.AppClientMethodCallParams(method="for_loop"))
+    assert result.abi_return == [3, 2, 1, 0]
+
+
+def test_match_get_day(deployer: Deployer) -> None:
+    client = deployer.create((_CONTROL_FLOW, "MatchStatements")).client
+
+    def get_day(date: int) -> object:
+        return client.send.call(
+            au.AppClientMethodCallParams(method="get_day", args=[date])
+        ).abi_return
+
+    expected = [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+    ]
+    for day, name in enumerate(expected):
+        assert get_day(day) == name
+
+    # any value outside 0..6 falls through to the wildcard case
+    assert get_day(7) == "Invalid day"
+    assert get_day(100) == "Invalid day"
+
+
+def test_while_loop(deployer: Deployer) -> None:
+    client = deployer.create((_CONTROL_FLOW, "WhileLoopExample")).client
+
+    # num=10: while num>5 (10->6) takes 5 iters, then num=6>5 once more -> num=5,
+    # then num<=5 branch: num-=2 (5->3) iter 6, 3-=2 ->1 iter 7, num==1 breaks.
+    result = client.send.call(au.AppClientMethodCallParams(method="loop"))
+    assert result.abi_return == 7

--- a/tests/onchain/devportal/test_crypto_ops.py
+++ b/tests/onchain/devportal/test_crypto_ops.py
@@ -1,0 +1,294 @@
+import hashlib
+from random import randbytes
+
+import algokit_utils as au
+import pytest
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec, utils
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from nacl.signing import SigningKey
+
+from tests import EXAMPLES_DIR
+from tests.utils.deployer import Deployer
+
+_CRYPTO_OPS = EXAMPLES_DIR / "devportal" / "crypto_ops"
+
+# crypto opcodes are budget-hungry; pad the group with op-up app calls. Each
+# app call in the group pools 700 opcode units, so _OP_UPS + 1 (the method
+# call) covers the most expensive opcode here (vrf_verify, ~5700).
+_OP_UPS = 10
+# enough fee on the method call to cover itself + each op-up create/delete pair
+_FEE = au.AlgoAmount.from_micro_algo(1000 * (2 * _OP_UPS + 1))
+
+
+def _call(deployer: Deployer, client: au.AppClient, method: str, args: list[object]) -> object:
+    """Call an abimethod inside a group padded with op-up txns for extra budget."""
+    group = deployer.localnet.new_group()
+    for _idx in range(_OP_UPS):
+        # unique note so repeated calls with the same args don't collide as
+        # "transaction already in ledger" duplicates
+        group.add_transaction(deployer.create_op_up(randbytes(8)))
+    group.add_app_call_method_call(
+        client.params.call(au.AppClientMethodCallParams(method=method, args=args, static_fee=_FEE))
+    )
+    return group.send().returns[-1].value
+
+
+# curve group orders; AVM ecdsa_verify requires canonical low-S signatures
+_SECP256K1_N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+_SECP256R1_N = 0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
+
+
+def _ecdsa_low_s(curve_order: int, r: int, s: int) -> tuple[int, int]:
+    if s > curve_order // 2:
+        s = curve_order - s
+    return r, s
+
+
+# -- hashes -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("data", [b"", b"hello world", b"\x00\xff" * 32])
+def test_hashes_match_python_reference(deployer: Deployer, data: bytes) -> None:
+    client = deployer.create(_CRYPTO_OPS).client
+    result = _call(deployer, client, "hashes", [data])
+    assert isinstance(result, list | tuple)
+    assert len(result) == 4
+    sha256, sha3_256, sha512_256, keccak256 = result
+
+    assert bytes(sha256) == hashlib.sha256(data).digest()
+    assert bytes(sha3_256) == hashlib.sha3_256(data).digest()
+    assert bytes(sha512_256) == hashlib.new("sha512_256", data).digest()
+    # keccak256 (legacy padding) differs from sha3_256 (NIST padding)
+    assert bytes(keccak256) != bytes(sha3_256)
+
+
+def test_keccak256_matches_reference(deployer: Deployer) -> None:
+    # legacy Keccak-256 (pre-NIST padding), distinct from SHA3-256
+    try:
+        from Cryptodome.Hash import keccak as _keccak
+    except ImportError:  # pragma: no cover
+        pytest.skip("pycryptodomex not available for keccak reference")
+
+    client = deployer.create(_CRYPTO_OPS).client
+    data = b"keccak test vector"
+    result = _call(deployer, client, "hashes", [data])
+    assert isinstance(result, list | tuple)
+    keccak256 = bytes(result[3])
+
+    expected = _keccak.new(digest_bits=256, data=data).digest()
+    assert keccak256 == expected
+
+
+def test_hashes_are_deterministic(deployer: Deployer) -> None:
+    client = deployer.create(_CRYPTO_OPS).client
+    data = b"determinism check"
+    first = _call(deployer, client, "hashes", [data])
+    second = _call(deployer, client, "hashes", [data])
+    assert isinstance(first, list | tuple)
+    assert isinstance(second, list | tuple)
+    assert [bytes(h) for h in first] == [bytes(h) for h in second]
+
+
+# -- ed25519 ----------------------------------------------------------------
+
+
+def test_ed25519_bare_verifies_valid_signature(deployer: Deployer) -> None:
+    client = deployer.create(_CRYPTO_OPS).client
+    key = SigningKey.generate()
+    data = b"signed message"
+    signature = key.sign(data).signature
+    public_key = key.verify_key.encode()
+
+    ed_result = _call(deployer, client, "ed25519", [data, signature, public_key])
+    assert isinstance(ed_result, list | tuple)
+    bound, bare = ed_result
+    # ed25519verify_bare checks the raw data and must succeed
+    assert bare is True
+    # ed25519verify (bound) signs over "ProgData"||program_hash||data, which the
+    # bare signature does not satisfy, so it is False
+    assert bound is False
+
+
+def test_ed25519_bound_verifies_program_bound_signature(deployer: Deployer) -> None:
+    client = deployer.create(_CRYPTO_OPS).client
+    # ed25519verify binds the signature to the executing program: the signed
+    # message is "ProgData" || program_address || data, where the program
+    # address is sha512_256("Program" || approval_program)
+    app = deployer.localnet.client.algod.application_by_id(client.app_id)
+    approval_program = app.params.approval_program
+    assert isinstance(approval_program, bytes)
+    program_hash = hashlib.new("sha512_256", b"Program" + approval_program).digest()
+
+    key = SigningKey.generate()
+    data = b"program bound message"
+    signature = key.sign(b"ProgData" + program_hash + data).signature
+    public_key = key.verify_key.encode()
+
+    ed_result = _call(deployer, client, "ed25519", [data, signature, public_key])
+    assert isinstance(ed_result, list | tuple)
+    bound, bare = ed_result
+    assert bound is True
+    # the bare variant sees only `data`, not the domain-separated message
+    assert bare is False
+
+
+def test_ed25519_rejects_tampered_data(deployer: Deployer) -> None:
+    client = deployer.create(_CRYPTO_OPS).client
+    key = SigningKey.generate()
+    signature = key.sign(b"original").signature
+    public_key = key.verify_key.encode()
+
+    ed_result = _call(deployer, client, "ed25519", [b"tampered", signature, public_key])
+    assert isinstance(ed_result, list | tuple)
+    bound, bare = ed_result
+    assert bare is False
+    assert bound is False
+
+
+def test_ed25519_rejects_wrong_public_key(deployer: Deployer) -> None:
+    client = deployer.create(_CRYPTO_OPS).client
+    key = SigningKey.generate()
+    data = b"signed message"
+    signature = key.sign(data).signature
+    wrong_public_key = SigningKey.generate().verify_key.encode()
+
+    ed_result = _call(deployer, client, "ed25519", [data, signature, wrong_public_key])
+    assert isinstance(ed_result, list | tuple)
+    bound, bare = ed_result
+    assert bare is False
+    assert bound is False
+
+
+# -- ecdsa ------------------------------------------------------------------
+
+
+def _ec_keypair(
+    curve: ec.EllipticCurve,
+) -> tuple[ec.EllipticCurvePrivateKey, bytes, bytes]:
+    priv = ec.generate_private_key(curve)
+    nums = priv.public_key().public_numbers()
+    return priv, nums.x.to_bytes(32, "big"), nums.y.to_bytes(32, "big")
+
+
+def _ec_sign(
+    priv: ec.EllipticCurvePrivateKey, digest: bytes, curve_order: int
+) -> tuple[bytes, bytes]:
+    der = priv.sign(digest, ec.ECDSA(utils.Prehashed(hashes.SHA256())))
+    r, s = utils.decode_dss_signature(der)
+    r, s = _ecdsa_low_s(curve_order, r, s)
+    return r.to_bytes(32, "big"), s.to_bytes(32, "big")
+
+
+def test_ecdsa_secp256k1_verifies_valid_signature(deployer: Deployer) -> None:
+    client = deployer.create(_CRYPTO_OPS).client
+    priv, pub_x, pub_y = _ec_keypair(ec.SECP256K1())
+    digest = hashlib.sha256(b"ecdsa secp256k1 message").digest()
+    sig_r, sig_s = _ec_sign(priv, digest, _SECP256K1_N)
+
+    ecdsa_result = _call(deployer, client, "ecdsa", [digest, sig_r, sig_s, pub_x, pub_y])
+    assert isinstance(ecdsa_result, list | tuple)
+    k1, r1 = ecdsa_result
+    # signature was produced on Secp256k1, so only the k1 result is True
+    assert k1 is True
+    assert r1 is False
+
+
+def test_ecdsa_secp256r1_verifies_valid_signature(deployer: Deployer) -> None:
+    client = deployer.create(_CRYPTO_OPS).client
+    priv, pub_x, pub_y = _ec_keypair(ec.SECP256R1())
+    digest = hashlib.sha256(b"ecdsa secp256r1 message").digest()
+    sig_r, sig_s = _ec_sign(priv, digest, _SECP256R1_N)
+
+    ecdsa_result = _call(deployer, client, "ecdsa", [digest, sig_r, sig_s, pub_x, pub_y])
+    assert isinstance(ecdsa_result, list | tuple)
+    k1, r1 = ecdsa_result
+    # signature was produced on Secp256r1, so only the r1 result is True
+    assert k1 is False
+    assert r1 is True
+
+
+def test_ecdsa_secp256k1_rejects_tampered_data(deployer: Deployer) -> None:
+    client = deployer.create(_CRYPTO_OPS).client
+    priv, pub_x, pub_y = _ec_keypair(ec.SECP256K1())
+    digest = hashlib.sha256(b"original ecdsa message").digest()
+    sig_r, sig_s = _ec_sign(priv, digest, _SECP256K1_N)
+    wrong_digest = hashlib.sha256(b"different ecdsa message").digest()
+
+    ecdsa_result = _call(deployer, client, "ecdsa", [wrong_digest, sig_r, sig_s, pub_x, pub_y])
+    assert isinstance(ecdsa_result, list | tuple)
+    k1, r1 = ecdsa_result
+    assert k1 is False
+    assert r1 is False
+
+
+def test_ecdsa_decompress_expands_pubkey(deployer: Deployer) -> None:
+    client = deployer.create(_CRYPTO_OPS).client
+    priv, pub_x, pub_y = _ec_keypair(ec.SECP256K1())
+    compressed = priv.public_key().public_bytes(Encoding.X962, PublicFormat.CompressedPoint)
+    assert len(compressed) == 33
+
+    decompress_result = _call(deployer, client, "ecdsa_decompress", [compressed])
+    assert isinstance(decompress_result, list | tuple)
+    x, y = decompress_result
+    # decompressing the compressed key yields the original (X, Y) components
+    assert bytes(x) == pub_x
+    assert bytes(y) == pub_y
+
+
+def test_ecdsa_recover_returns_signer_pubkey(deployer: Deployer) -> None:
+    client = deployer.create(_CRYPTO_OPS).client
+    priv, pub_x, pub_y = _ec_keypair(ec.SECP256K1())
+    digest = hashlib.sha256(b"ecdsa recover message").digest()
+    sig_r, sig_s = _ec_sign(priv, digest, _SECP256K1_N)
+
+    # the recovery id is not knowable from (r, s) alone; one of the two
+    # candidate ids must recover the signer's public key
+    recovered = []
+    for recovery_id in (0, 1):
+        result = _call(deployer, client, "ecdsa_recover", [digest, recovery_id, sig_r, sig_s])
+        assert isinstance(result, list | tuple)
+        x, y = result
+        recovered.append((bytes(x), bytes(y)))
+    assert (pub_x, pub_y) in recovered
+
+
+# -- vrf --------------------------------------------------------------------
+
+# ECVRF-ED25519-SHA512-Elligator2 test vector from draft-irtf-cfrg-vrf-03
+# (appendix A.4, example 10: alpha is the empty string)
+_VRF_PUBLIC_KEY = bytes.fromhex("d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a")
+_VRF_PROOF = bytes.fromhex(
+    "b6b4699f87d56126c9117a7da55bd0085246f4c56dbc95d20172612e9d38e8d7"
+    "ca65e573a126ed88d4e30a46f80a666854d675cf3ba81de0de043c3774f06156"
+    "0f55edc256a787afe701677c0f602900"
+)
+_VRF_OUTPUT = bytes.fromhex(
+    "5b49b554d05c0cd5a5325376b3387de59d924fd1e13ded44648ab33c21349a60"
+    "3f25b84ec5ed887995b33da5e3bfcb87cd2f64521c4c62cf825cffabbe5d31cc"
+)
+
+
+def test_vrf_verifies_known_test_vector(deployer: Deployer) -> None:
+    client = deployer.create(_CRYPTO_OPS).client
+
+    vrf_result = _call(deployer, client, "vrf", [b"", _VRF_PROOF, _VRF_PUBLIC_KEY])
+    assert isinstance(vrf_result, list | tuple)
+    output, verified = vrf_result
+    assert verified is True
+    assert bytes(output) == _VRF_OUTPUT
+
+
+def test_vrf_rejects_invalid_proof(deployer: Deployer) -> None:
+    client = deployer.create(_CRYPTO_OPS).client
+    # an all-zero proof / public key cannot verify against a random message
+    message = b"vrf message"
+    proof = b"\x00" * 80
+    public_key = b"\x00" * 32
+
+    vrf_result = _call(deployer, client, "vrf", [message, proof, public_key])
+    assert isinstance(vrf_result, list | tuple)
+    output, verified = vrf_result
+    assert verified is False
+    # output is only meaningful when verified is True
+    assert len(bytes(output)) == 64

--- a/tests/onchain/devportal/test_events.py
+++ b/tests/onchain/devportal/test_events.py
@@ -1,0 +1,61 @@
+import algokit_utils as au
+from algokit_common import public_key_from_address
+
+from puya.utils import sha512_256_hash
+from tests import EXAMPLES_DIR
+from tests.utils import arc4_encode
+from tests.utils.deployer import Deployer
+
+_EVENTS = EXAMPLES_DIR / "devportal" / "events"
+
+
+def _event_log(signature: str, *values: object) -> bytes:
+    """Expected ARC-28 log: 4-byte selector (SHA-512/256 of the event
+    signature) followed by the ARC-4 tuple encoding of the values."""
+    selector = sha512_256_hash(signature.encode("utf8"))[:4]
+    arg_types = signature[signature.index("(") :]
+    return selector + arc4_encode(arg_types, values)
+
+
+def test_swap_emit_struct_emits_arc28_events(
+    deployer: Deployer, account: au.AddressWithSigners
+) -> None:
+    client = deployer.create((_EVENTS, "SwapContract")).client
+    result = client.send.call(
+        au.AppClientMethodCallParams(
+            method="swap_emit_struct",
+            args=[account.addr, account.addr, 100, 90],
+        )
+    )
+    # two arc4.emit calls -> two ARC-28 event logs
+    pk = public_key_from_address(account.addr)
+    assert result.confirmation.logs == [
+        _event_log("Swapped(address,address,uint64,uint64)", pk, pk, 100, 90),
+        # the native struct is emitted using the equivalent ARC-4 types
+        _event_log("NativeStruct(uint64,string)", 100, "payment received"),
+    ]
+
+
+def test_transfer_emit_signature(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = deployer.create((_EVENTS, "TransferContract")).client
+    result = client.send.call(
+        au.AppClientMethodCallParams(
+            method="transfer_emit_signature",
+            args=[account.addr, account.addr, 50],
+        )
+    )
+    pk = public_key_from_address(account.addr)
+    assert result.confirmation.logs == [_event_log("Transfer(address,address,uint64)", pk, pk, 50)]
+
+
+def test_mint_emit_by_name(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = deployer.create((_EVENTS, "MintContract")).client
+    result = client.send.call(
+        au.AppClientMethodCallParams(
+            method="mint_emit_by_name",
+            args=[account.addr, 25],
+        )
+    )
+    # the signature (and thus the selector) is inferred from the arg types
+    pk = public_key_from_address(account.addr)
+    assert result.confirmation.logs == [_event_log("Mint(address,uint64)", pk, 25)]

--- a/tests/onchain/devportal/test_global_state.py
+++ b/tests/onchain/devportal/test_global_state.py
@@ -1,0 +1,221 @@
+import random
+
+import algokit_utils as au
+import pytest
+from algokit_common import public_key_from_address
+
+from tests import EXAMPLES_DIR
+from tests.utils.deployer import Deployer
+
+_GLOBAL_STATE = EXAMPLES_DIR / "devportal" / "global_state"
+
+
+def _params(method: str, *args: object) -> au.AppClientMethodCallParams:
+    # a random note keeps otherwise-identical txns unique within the ledger
+    return au.AppClientMethodCallParams(method=method, args=list(args), note=random.randbytes(8))
+
+
+def _storage(deployer: Deployer) -> au.AppClient:
+    return deployer.create((_GLOBAL_STATE, "GlobalStorage")).client
+
+
+def _storage_map(deployer: Deployer) -> au.AppClient:
+    return deployer.create((_GLOBAL_STATE, "GlobalStorageMap")).client
+
+
+# --- GlobalStorage --------------------------------------------------------
+
+
+def test_get_global_state_default_when_empty(deployer: Deployer) -> None:
+    client = _storage(deployer)
+    # global_int_no_default starts empty -> .get(default=0) returns 0
+    result = client.send.call(_params("get_global_state"))
+    assert result.abi_return == 0
+
+
+def test_maybe_global_state_when_empty(deployer: Deployer) -> None:
+    client = _storage(deployer)
+    result = client.send.call(_params("maybe_global_state"))
+    # (value, exists): empty slot -> (0, False)
+    assert result.abi_return == (0, False)
+
+
+def test_get_global_state_example(deployer: Deployer) -> None:
+    client = _storage(deployer)
+    result = client.send.call(_params("get_global_state_example"))
+    assert result.abi_return is True
+
+
+def test_maybe_global_state_example(deployer: Deployer) -> None:
+    client = _storage(deployer)
+    result = client.send.call(_params("maybe_global_state_example"))
+    assert result.abi_return is True
+
+
+def test_check_global_state_example(deployer: Deployer) -> None:
+    client = _storage(deployer)
+    result = client.send.call(_params("check_global_state_example"))
+    assert result.abi_return is True
+
+
+def test_set_global_state(deployer: Deployer) -> None:
+    client = _storage(deployer)
+    client.send.call(_params("set_global_state", b"updated"))
+    # global_bytes_full now holds the written value
+    state = client.get_global_state()
+    assert state["global_bytes_full"].value_raw == b"updated"
+
+
+def test_set_global_state_example(deployer: Deployer, asset_a: int) -> None:
+    client = _storage(deployer)
+    value_bool = True
+    client.send.call(
+        # value_bytes, value_asset, value_app, value_account, value_bool
+        _params(
+            "set_global_state_example",
+            b"world",
+            asset_a,
+            client.app_id,
+            client.app_address,
+            value_bool,
+        )
+    )
+    state = client.get_global_state()
+    assert state["global_bytes_no_default"].value_raw == b"world"
+    assert state["global_int_simplified"].value == 99
+    assert state["global_asset"].value == asset_a
+    assert state["global_application"].value == client.app_id
+    assert state["global_account"].value_raw == public_key_from_address(client.app_address)
+
+
+def test_set_global_state_example_bool_false(deployer: Deployer, asset_a: int) -> None:
+    client = _storage(deployer)
+    value_bool = False
+    # the method stores and verifies the written bool, so False also works
+    client.send.call(
+        _params(
+            "set_global_state_example",
+            b"world",
+            asset_a,
+            client.app_id,
+            client.app_address,
+            value_bool,
+        )
+    )
+    state = client.get_global_state()
+    assert state["global_bool_no_default"].value == 0
+
+
+def test_del_global_state(deployer: Deployer) -> None:
+    client = _storage(deployer)
+    result = client.send.call(_params("del_global_state"))
+    assert result.abi_return is True
+
+
+def test_del_global_state_example(deployer: Deployer, asset_a: int) -> None:
+    client = _storage(deployer)
+    value_bool = True
+    # populate the no_default slots first so deletion has something to remove
+    client.send.call(
+        _params(
+            "set_global_state_example",
+            b"world",
+            asset_a,
+            client.app_id,
+            client.app_address,
+            value_bool,
+        )
+    )
+    result = client.send.call(_params("del_global_state_example"))
+    assert result.abi_return is True
+
+
+def test_del_global_state_example_when_empty(deployer: Deployer) -> None:
+    client = _storage(deployer)
+    # deleting global state keys that were never written still succeeds
+    result = client.send.call(_params("del_global_state_example"))
+    assert result.abi_return is True
+
+
+def test_pass_proxy_to_subroutine(deployer: Deployer) -> None:
+    client = _storage(deployer)
+    # method sets global_int_no_default = 44, subroutine returns value + 1
+    result = client.send.call(_params("pass_proxy_to_subroutine"))
+    assert result.abi_return == 45
+
+
+def test_dynamic_key_access(deployer: Deployer) -> None:
+    client = _storage(deployer)
+    result = client.send.call(_params("dynamic_key_access"))
+    # re-reads the same slots via dynamically constructed proxies
+    assert result.abi_return == (7, b"hi")
+
+
+# --- GlobalStorageMap -----------------------------------------------------
+
+
+def test_global_map_set_and_get_score(deployer: Deployer) -> None:
+    client = _storage_map(deployer)
+    client.send.call(_params("set_score", "alice", 42))
+    result = client.send.call(_params("get_score", "alice"))
+    assert result.abi_return == 42
+
+
+def test_global_map_get_score_or_default(deployer: Deployer) -> None:
+    client = _storage_map(deployer)
+    # missing key -> default 0
+    missing = client.send.call(_params("get_score_or_default", "bob"))
+    assert missing.abi_return == 0
+
+    client.send.call(_params("set_score", "bob", 7))
+    present = client.send.call(_params("get_score_or_default", "bob"))
+    assert present.abi_return == 7
+
+
+def test_global_map_maybe_score(deployer: Deployer) -> None:
+    client = _storage_map(deployer)
+    absent = client.send.call(_params("maybe_score", "carol"))
+    assert absent.abi_return == (0, False)
+
+    client.send.call(_params("set_score", "carol", 9))
+    present = client.send.call(_params("maybe_score", "carol"))
+    assert present.abi_return == (9, True)
+
+
+def test_global_map_get_missing_score_fails(deployer: Deployer) -> None:
+    client = _storage_map(deployer)
+    # indexing a missing key fails on-chain
+    with pytest.raises(au.LogicError):
+        client.send.call(_params("get_score", "nobody"))
+
+
+def test_global_map_delete_score(deployer: Deployer) -> None:
+    client = _storage_map(deployer)
+    client.send.call(_params("set_score", "dave", 5))
+    client.send.call(_params("delete_score", "dave"))
+    result = client.send.call(_params("maybe_score", "dave"))
+    assert result.abi_return == (0, False)
+
+
+def test_global_map_profiles(deployer: Deployer) -> None:
+    client = _storage_map(deployer)
+    absent = client.send.call(_params("has_profile", 1))
+    assert absent.abi_return is False
+
+    client.send.call(_params("set_profile", 1, ("alice", 100)))
+    present = client.send.call(_params("has_profile", 1))
+    assert present.abi_return is True
+
+
+def test_global_map_get_slot_proxy(deployer: Deployer) -> None:
+    client = _storage_map(deployer)
+    client.send.call(_params("set_score", "eve", 88))
+    result = client.send.call(_params("get_slot_proxy", "eve"))
+    assert result.abi_return == 88
+
+
+def test_global_map_get_slot_proxy_missing_key_fails(deployer: Deployer) -> None:
+    client = _storage_map(deployer)
+    # `.value` on the proxy of a missing key fails on-chain
+    with pytest.raises(au.LogicError):
+        client.send.call(_params("get_slot_proxy", "nobody"))

--- a/tests/onchain/devportal/test_group_transactions.py
+++ b/tests/onchain/devportal/test_group_transactions.py
@@ -1,0 +1,437 @@
+import random
+
+import algokit_utils as au
+import pytest
+from algokit_utils.transactions.transaction_composer import TransactionComposerError
+
+from tests import EXAMPLES_DIR
+from tests.utils.deployer import Deployer
+
+# A group that is expected to fail must skip algokit's simulate-based resource
+# population, otherwise the rejection surfaces as a generic ValueError from the
+# pre-flight simulate rather than from the actual send.
+_NO_POPULATE = au.SendParams(populate_app_call_resources=False)
+_REJECTED = (au.LogicError, TransactionComposerError)
+
+_GROUP_TRANSACTIONS = EXAMPLES_DIR / "devportal" / "group_transactions"
+
+
+def _deploy(deployer: Deployer) -> au.AppClient:
+    """Deploy GroupTransactions and fund the app account so payments sent to
+    it during a test group keep the app above its minimum balance."""
+    client = deployer.create(_GROUP_TRANSACTIONS).client
+    deployer.localnet.send.payment(
+        au.PaymentParams(
+            sender=deployer.account.addr,
+            receiver=client.app_address,
+            amount=au.AlgoAmount.from_micro_algo(200_000),
+        )
+    )
+    return client
+
+
+def test_expect_payment_validates_preceding_payment(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy(deployer)
+
+    # [Payment -> AppCall]: expect_payment reads the txn at group_index - 1
+    result = (
+        localnet.new_group()
+        .add_payment(
+            au.PaymentParams(
+                sender=account.addr,
+                receiver=client.app_address,
+                amount=au.AlgoAmount.from_micro_algo(12345),
+            )
+        )
+        .add_app_call_method_call(
+            client.params.call(au.AppClientMethodCallParams(method="expect_payment", args=[12345]))
+        )
+        .send()
+    )
+    assert result.returns[-1].value == 12345
+
+
+def test_expect_payment_wrong_amount_is_rejected(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy(deployer)
+
+    with pytest.raises(_REJECTED):
+        (
+            localnet.new_group()
+            .add_payment(
+                au.PaymentParams(
+                    sender=account.addr,
+                    receiver=client.app_address,
+                    amount=au.AlgoAmount.from_micro_algo(1000),
+                )
+            )
+            .add_app_call_method_call(
+                client.params.call(
+                    au.AppClientMethodCallParams(method="expect_payment", args=[9999])
+                )
+            )
+            .send(_NO_POPULATE)
+        )
+
+
+def test_expect_payment_missing_preceding_txn_is_rejected(deployer: Deployer) -> None:
+    client = _deploy(deployer)
+
+    with pytest.raises(au.LogicError):
+        client.send.call(au.AppClientMethodCallParams(method="expect_payment", args=[1]))
+
+
+def test_receive_funding_typed_args(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    asset = _create_asset(localnet, account)
+    client = _deploy_for_asset(deployer, localnet, asset)
+
+    # two transaction args bind positionally: the group is [pay, axfer, call],
+    # exactly the parameter declaration order, ending at the app call
+    pay = au.PaymentParams(
+        sender=account.addr,
+        receiver=client.app_address,
+        amount=au.AlgoAmount.from_micro_algo(54321),
+    )
+    axfer = au.AssetTransferParams(
+        sender=account.addr,
+        receiver=client.app_address,
+        asset_id=asset,
+        amount=1000,
+    )
+    result = client.send.call(
+        au.AppClientMethodCallParams(method="receive_funding", args=[pay, axfer, asset, 54321])
+    )
+    assert result.abi_return == 54321 + 1000
+
+
+def test_receive_funding_wrong_amount_is_rejected(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    asset = _create_asset(localnet, account)
+    client = _deploy_for_asset(deployer, localnet, asset)
+
+    pay = au.PaymentParams(
+        sender=account.addr,
+        receiver=client.app_address,
+        amount=au.AlgoAmount.from_micro_algo(100),
+    )
+    axfer = au.AssetTransferParams(
+        sender=account.addr,
+        receiver=client.app_address,
+        asset_id=asset,
+        amount=1000,
+    )
+    with pytest.raises(au.LogicError, match="wrong payment amount"):
+        client.send.call(
+            au.AppClientMethodCallParams(method="receive_funding", args=[pay, axfer, asset, 200])
+        )
+
+
+def test_receive_funding_swapped_txn_order_is_rejected(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    asset = _create_asset(localnet, account)
+    client = _deploy_for_asset(deployer, localnet, asset)
+
+    pay = au.PaymentParams(
+        sender=account.addr,
+        receiver=client.app_address,
+        amount=au.AlgoAmount.from_micro_algo(100),
+    )
+    axfer = au.AssetTransferParams(
+        sender=account.addr,
+        receiver=client.app_address,
+        asset_id=asset,
+        amount=1000,
+    )
+    # supplying the transactions in the wrong order puts a Payment where the
+    # router asserts an AssetTransfer (and vice versa); the failure may
+    # surface client-side (arg type validation) or on-chain (type assert)
+    with pytest.raises((au.LogicError, ValueError, TransactionComposerError)):
+        client.send.call(
+            au.AppClientMethodCallParams(method="receive_funding", args=[axfer, pay, asset, 100])
+        )
+
+
+def test_chained_app_call_decodes_previous_log(
+    deployer: Deployer, localnet: au.AlgorandClient
+) -> None:
+    chained = _deploy(deployer)
+    observer = _deploy(deployer)
+
+    pay = au.PaymentParams(
+        sender=deployer.account.addr,
+        receiver=chained.app_address,
+        amount=au.AlgoAmount.from_micro_algo(777),
+    )
+    # group: [payment, expect_payment call, chained_app_call call]
+    result = (
+        localnet.new_group()
+        .add_payment(pay)
+        .add_app_call_method_call(
+            chained.params.call(au.AppClientMethodCallParams(method="expect_payment", args=[777]))
+        )
+        .add_app_call_method_call(
+            observer.params.call(au.AppClientMethodCallParams(method="chained_app_call", args=[]))
+        )
+        .send()
+    )
+    assert result.returns[-1].value == 777
+
+
+def test_observe_app_call_typed_arg(deployer: Deployer, localnet: au.AlgorandClient) -> None:
+    chained = _deploy(deployer)
+    observer = _deploy(deployer)
+
+    pay = au.PaymentParams(
+        sender=deployer.account.addr,
+        receiver=chained.app_address,
+        amount=au.AlgoAmount.from_micro_algo(321),
+    )
+    prior = chained.params.call(au.AppClientMethodCallParams(method="expect_payment", args=[321]))
+    # `prior` is supplied as the typed txn arg, so algokit places it
+    # immediately before the observe call; its own preceding payment is
+    # added to the group explicitly, giving [payment, prior, observe]
+    result = (
+        localnet.new_group()
+        .add_payment(pay)
+        .add_app_call_method_call(
+            observer.params.call(
+                au.AppClientMethodCallParams(method="observe_app_call", args=[prior])
+            )
+        )
+        .send()
+    )
+    assert result.returns[-1].value == 321
+
+
+def test_strict_position_accepts_fixed_shape(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy(deployer)
+
+    asset_id = localnet.send.asset_create(
+        au.AssetCreateParams(
+            sender=account.addr,
+            total=1_000,
+            decimals=0,
+            default_frozen=False,
+            asset_name="strict",
+            unit_name="STR",
+        )
+    ).asset_id
+
+    # [Payment(0), AppCall(1), AssetTransfer(2)]; pay.sender == axfer.asset_receiver
+    result = (
+        localnet.new_group()
+        .add_payment(
+            au.PaymentParams(
+                sender=account.addr,
+                receiver=client.app_address,
+                amount=au.AlgoAmount.from_micro_algo(0),
+            )
+        )
+        .add_app_call_method_call(
+            client.params.call(au.AppClientMethodCallParams(method="strict_position", args=[3]))
+        )
+        .add_asset_transfer(
+            au.AssetTransferParams(
+                sender=account.addr,
+                receiver=account.addr,
+                asset_id=asset_id,
+                amount=0,
+            )
+        )
+        .send()
+    )
+    assert result.returns[-1].value is None
+
+
+def test_strict_position_wrong_size_is_rejected(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy(deployer)
+
+    with pytest.raises(_REJECTED, match="wrong group size"):
+        (
+            localnet.new_group()
+            .add_payment(
+                au.PaymentParams(
+                    sender=account.addr,
+                    receiver=client.app_address,
+                    amount=au.AlgoAmount.from_micro_algo(0),
+                )
+            )
+            .add_app_call_method_call(
+                client.params.call(
+                    au.AppClientMethodCallParams(method="strict_position", args=[3])
+                )
+            )
+            .send(_NO_POPULATE)
+        )
+
+
+def test_strict_position_wrong_index_is_rejected(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy(deployer)
+
+    asset_id = localnet.send.asset_create(
+        au.AssetCreateParams(
+            sender=account.addr,
+            total=1_000,
+            decimals=0,
+            default_frozen=False,
+            asset_name="strict2",
+            unit_name="ST2",
+        )
+    ).asset_id
+
+    with pytest.raises(_REJECTED, match="must be index 1"):
+        (
+            localnet.new_group()
+            .add_app_call_method_call(
+                client.params.call(
+                    au.AppClientMethodCallParams(method="strict_position", args=[3])
+                )
+            )
+            .add_payment(
+                au.PaymentParams(
+                    sender=account.addr,
+                    receiver=client.app_address,
+                    amount=au.AlgoAmount.from_micro_algo(0),
+                )
+            )
+            .add_asset_transfer(
+                au.AssetTransferParams(
+                    sender=account.addr,
+                    receiver=account.addr,
+                    asset_id=asset_id,
+                    amount=0,
+                )
+            )
+            .send(_NO_POPULATE)
+        )
+
+
+def test_expect_asset_transfer_missing_preceding_txn_is_rejected(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy(deployer)
+
+    asset_id = localnet.send.asset_create(
+        au.AssetCreateParams(
+            sender=account.addr,
+            total=1_000,
+            decimals=0,
+            default_frozen=False,
+            asset_name="axfer",
+            unit_name="AXF",
+        )
+    ).asset_id
+
+    with pytest.raises(au.LogicError):
+        client.send.call(
+            au.AppClientMethodCallParams(method="expect_asset_transfer", args=[asset_id])
+        )
+
+
+def test_expect_asset_transfer_wrong_txn_type_is_rejected(
+    deployer: Deployer,
+    localnet: au.AlgorandClient,
+    account: au.AddressWithSigners,
+    asset_a: int,
+) -> None:
+    client = _deploy(deployer)
+
+    # a Payment precedes the call where an AssetTransfer is expected, so the
+    # gtxn.AssetTransferTransaction(...) typed lookup itself fails
+    with pytest.raises(_REJECTED):
+        (
+            localnet.new_group()
+            .add_payment(
+                au.PaymentParams(
+                    sender=account.addr,
+                    receiver=client.app_address,
+                    amount=au.AlgoAmount.from_micro_algo(1000),
+                )
+            )
+            .add_app_call_method_call(
+                client.params.call(
+                    au.AppClientMethodCallParams(
+                        method="expect_asset_transfer",
+                        args=[asset_a],
+                        asset_references=[asset_a],
+                    )
+                )
+            )
+            .send(_NO_POPULATE)
+        )
+
+
+def _create_asset(localnet: au.AlgorandClient, account: au.AddressWithSigners) -> int:
+    """A fresh asset for tests that transfer units away: the shared session
+    `asset_a` fixture must stay untouched — other tests (e.g. test_amm) assert
+    the session account still holds its full supply."""
+    return localnet.send.asset_create(
+        au.AssetCreateParams(sender=account.addr, total=10_000_000, note=random.randbytes(8))
+    ).asset_id
+
+
+def _deploy_for_asset(
+    deployer: Deployer, localnet: au.AlgorandClient, asset_id: int
+) -> au.AppClient:
+    """Deploy GroupTransactions, fund the app account so it can hold an asset,
+    and opt the app account into `asset_id` via the contract's inner transfer."""
+    client = deployer.create(_GROUP_TRANSACTIONS).client
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=deployer.account.addr,
+            receiver=client.app_address,
+            amount=au.AlgoAmount.from_algo(1),
+        )
+    )
+    # opt_in_to_asset issues an inner zero-amount AssetTransfer; the static fee
+    # must cover both the outer app call and that inner txn.
+    client.send.call(
+        au.AppClientMethodCallParams(
+            method="opt_in_to_asset",
+            args=[asset_id],
+            static_fee=au.AlgoAmount.from_micro_algo(2000),
+        )
+    )
+    return client
+
+
+def test_expect_asset_transfer_validates_preceding_transfer(
+    deployer: Deployer,
+    localnet: au.AlgorandClient,
+    account: au.AddressWithSigners,
+) -> None:
+    asset = _create_asset(localnet, account)
+    client = _deploy_for_asset(deployer, localnet, asset)
+
+    # [AssetTransfer -> AppCall]: expect_asset_transfer reads group_index - 1
+    result = (
+        localnet.new_group()
+        .add_asset_transfer(
+            au.AssetTransferParams(
+                sender=account.addr,
+                receiver=client.app_address,
+                asset_id=asset,
+                amount=750,
+            )
+        )
+        .add_app_call_method_call(
+            client.params.call(
+                au.AppClientMethodCallParams(method="expect_asset_transfer", args=[asset])
+            )
+        )
+        .send()
+    )
+    assert result.returns[-1].value == 750

--- a/tests/onchain/devportal/test_inner_transactions.py
+++ b/tests/onchain/devportal/test_inner_transactions.py
@@ -1,0 +1,279 @@
+import algokit_utils as au
+import pytest
+
+from tests import EXAMPLES_DIR
+from tests.utils.deployer import Deployer
+
+_INNER_TRANSACTIONS = EXAMPLES_DIR / "devportal" / "inner_transactions"
+
+
+def _deploy_funded(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> au.AppClient:
+    """Deploy InnerTransactions and fund its app account so it can issue
+    inner transactions and meet minimum balance for created assets/apps."""
+    client = deployer.create((_INNER_TRANSACTIONS / "contract.py", "InnerTransactions")).client
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=client.app_address,
+            amount=au.AlgoAmount.from_algo(2),
+        )
+    )
+    return client
+
+
+def test_payment(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy_funded(deployer, localnet, account)
+
+    # one inner payment txn of 5000 microAlgo; outer fee covers inner fee=0
+    result = client.send.call(
+        au.AppClientMethodCallParams(
+            method="payment",
+            static_fee=au.AlgoAmount.from_micro_algo(2000),
+        )
+    )
+    assert result.abi_return == 5000
+
+
+def test_fungible_asset_create(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy_funded(deployer, localnet, account)
+
+    result = client.send.call(
+        au.AppClientMethodCallParams(
+            method="fungible_asset_create",
+            static_fee=au.AlgoAmount.from_micro_algo(2000),
+        )
+    )
+    asset_id = result.abi_return
+    assert isinstance(asset_id, int)
+    assert asset_id > 0
+
+    info = localnet.asset.get_by_id(asset_id)
+    assert info.total == 100_000_000_000
+    assert info.decimals == 2
+    assert info.unit_name == "RP"
+    assert info.asset_name == "Royalty Points"
+
+
+def test_non_fungible_asset_create(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy_funded(deployer, localnet, account)
+
+    result = client.send.call(
+        au.AppClientMethodCallParams(
+            method="non_fungible_asset_create",
+            static_fee=au.AlgoAmount.from_micro_algo(2000),
+        )
+    )
+    asset_id = result.abi_return
+    assert isinstance(asset_id, int)
+    assert asset_id > 0
+
+    info = localnet.asset.get_by_id(asset_id)
+    assert info.total == 100
+    assert info.asset_name == "Mona Lisa"
+    assert info.unit_name == "ML"
+
+
+def test_asset_lifecycle(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy_funded(deployer, localnet, account)
+
+    def call(method: str, args: list[object], fee: int = 2000) -> object:
+        return client.send.call(
+            au.AppClientMethodCallParams(
+                method=method,
+                args=args,
+                static_fee=au.AlgoAmount.from_micro_algo(fee),
+            )
+        ).abi_return
+
+    # create an asset the app fully controls (manager/reserve/freeze/clawback)
+    asset_id = call("non_fungible_asset_create", [])
+    assert isinstance(asset_id, int)
+
+    # opt the app account into its own asset
+    call("asset_opt_in", [asset_id])
+
+    # freeze the app account's holding while the app still holds freeze authority
+    call("asset_freeze", [client.app_address, asset_id])
+    holding = localnet.asset.get_account_information(client.app_address, asset_id)
+    assert holding.frozen is True
+
+    # reconfigure: the app keeps manager/reserve, hands freeze/clawback to caller
+    call("asset_config", [asset_id])
+    info = localnet.asset.get_by_id(asset_id)
+    assert info.manager == client.app_address
+
+    # delete the asset (only possible while the manager holds the full supply)
+    call("asset_delete", [asset_id])
+
+    # the asset no longer exists
+    with pytest.raises(Exception):  # noqa: B017, PT011
+        localnet.asset.get_by_id(asset_id)
+
+
+def test_asset_config_of_immutable_asset_is_rejected(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy_funded(deployer, localnet, account)
+
+    # fungible_asset_create leaves manager/reserve/freeze/clawback unset,
+    # making the asset immutable
+    asset_id = client.send.call(
+        au.AppClientMethodCallParams(
+            method="fungible_asset_create",
+            static_fee=au.AlgoAmount.from_micro_algo(2000),
+        )
+    ).abi_return
+    assert isinstance(asset_id, int)
+
+    # the inner AssetConfig fails because there is no manager to authorize it
+    with pytest.raises(au.LogicError):
+        client.send.call(
+            au.AppClientMethodCallParams(
+                method="asset_config",
+                args=[asset_id],
+                static_fee=au.AlgoAmount.from_micro_algo(2000),
+            )
+        )
+
+
+def test_asset_transfer_and_revoke(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy_funded(deployer, localnet, account)
+
+    def call(method: str, args: list[object]) -> object:
+        return client.send.call(
+            au.AppClientMethodCallParams(
+                method=method,
+                args=args,
+                static_fee=au.AlgoAmount.from_micro_algo(2000),
+            )
+        ).abi_return
+
+    # non_fungible_asset_create sets clawback to the app, so the app can revoke;
+    # the app holds the full supply (total=100) and is the creator (auto opted-in).
+    asset_id = call("non_fungible_asset_create", [])
+    assert isinstance(asset_id, int)
+
+    # a fresh account opts in so it can receive a transfer
+    receiver = localnet.account.random()
+    localnet.account.ensure_funded(
+        account_to_fund=receiver.addr,
+        dispenser_account=account,
+        min_spending_balance=au.AlgoAmount.from_algo(1),
+    )
+    localnet.send.asset_opt_in(
+        au.AssetOptInParams(sender=receiver.addr, asset_id=asset_id, signer=receiver.signer)
+    )
+
+    # app transfers 50 units to the receiver
+    call("asset_transfer", [asset_id, receiver.addr, 50])
+    holding = localnet.asset.get_account_information(receiver.addr, asset_id)
+    assert holding.balance == 50
+
+    # app revokes (claws back) 20 units from the receiver
+    call("asset_revoke", [asset_id, receiver.addr, 20])
+    holding = localnet.asset.get_account_information(receiver.addr, asset_id)
+    assert holding.balance == 30
+
+
+def test_multi_inner_txns(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy_funded(deployer, localnet, account)
+
+    # deploy a HelloWorldContract target via the contract's own deploy method
+    target_id = client.send.call(
+        au.AppClientMethodCallParams(
+            method="arc4_deploy_app",
+            static_fee=au.AlgoAmount.from_micro_algo(2000),
+        )
+    ).abi_return
+    assert isinstance(target_id, int)
+
+    # multi_inner_txns issues a grouped Payment + ApplicationCall (2 inner txns)
+    result = client.send.call(
+        au.AppClientMethodCallParams(
+            method="multi_inner_txns",
+            args=[target_id],
+            static_fee=au.AlgoAmount.from_micro_algo(3000),
+            app_references=[target_id],
+        )
+    )
+    multi_result = result.abi_return
+    assert isinstance(multi_result, list | tuple)
+    pay_amount, hello = multi_result
+    assert pay_amount == 5000
+    assert hello == "Hello, World"
+
+
+def test_deploy_app(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy_funded(deployer, localnet, account)
+
+    result = client.send.call(
+        au.AppClientMethodCallParams(
+            method="deploy_app",
+            static_fee=au.AlgoAmount.from_micro_algo(2000),
+        )
+    )
+    app_id = result.abi_return
+    assert isinstance(app_id, int)
+    assert app_id > 0
+
+
+def test_arc4_deploy_app(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy_funded(deployer, localnet, account)
+
+    result = client.send.call(
+        au.AppClientMethodCallParams(
+            method="arc4_deploy_app",
+            static_fee=au.AlgoAmount.from_micro_algo(2000),
+        )
+    )
+    app_id = result.abi_return
+    assert isinstance(app_id, int)
+    assert app_id > 0
+
+
+def test_noop_app_call(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy_funded(deployer, localnet, account)
+
+    # deploy a HelloWorldContract to call into
+    target_id = client.send.call(
+        au.AppClientMethodCallParams(
+            method="deploy_app",
+            static_fee=au.AlgoAmount.from_micro_algo(2000),
+        )
+    ).abi_return
+    assert isinstance(target_id, int)
+
+    # noop_app_call issues two inner ApplicationCalls (manual + abi_call)
+    result = client.send.call(
+        au.AppClientMethodCallParams(
+            method="noop_app_call",
+            args=[target_id],
+            static_fee=au.AlgoAmount.from_micro_algo(3000),
+            app_references=[target_id],
+        )
+    )
+    noop_result = result.abi_return
+    assert isinstance(noop_result, list | tuple)
+    first, second = noop_result
+    assert first == "Hello, World"
+    assert second == "Hello, again"

--- a/tests/onchain/devportal/test_local_state.py
+++ b/tests/onchain/devportal/test_local_state.py
@@ -1,0 +1,237 @@
+import random
+
+import algokit_utils as au
+import pytest
+
+from tests import EXAMPLES_DIR
+from tests.utils.deployer import Deployer
+
+_LOCAL_STATE = EXAMPLES_DIR / "devportal" / "local_state"
+
+
+def _params(method: str, *args: object) -> au.AppClientMethodCallParams:
+    # a random note keeps otherwise-identical txns unique within the ledger
+    return au.AppClientMethodCallParams(method=method, args=list(args), note=random.randbytes(8))
+
+
+def _storage(deployer: Deployer) -> au.AppClient:
+    """Deploy LocalStorage and opt the sender account in."""
+    client = deployer.create((_LOCAL_STATE, "LocalStorage")).client
+    client.send.opt_in(_params("opt_in"))
+    return client
+
+
+def _storage_map(deployer: Deployer) -> au.AppClient:
+    """Deploy LocalStorageMap and opt the sender account in."""
+    client = deployer.create((_LOCAL_STATE, "LocalStorageMap")).client
+    client.send.opt_in(_params("opt_in"))
+    return client
+
+
+# --- LocalStorage ---------------------------------------------------------
+
+
+def test_contains_local_data(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage(deployer)
+    # opt_in wrote local_int for the sender
+    result = client.send.call(_params("contains_local_data", account.addr))
+    assert result.abi_return is True
+
+
+def test_contains_local_data_example(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage(deployer)
+    result = client.send.call(_params("contains_local_data_example", account.addr))
+    assert result.abi_return is True
+
+
+def test_get_item_local_data(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage(deployer)
+    # opt_in set local_int = 10
+    result = client.send.call(_params("get_item_local_data", account.addr))
+    assert result.abi_return == 10
+
+
+def test_get_item_local_data_example(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage(deployer)
+    result = client.send.call(_params("get_item_local_data_example", account.addr))
+    assert result.abi_return is True
+
+
+def test_get_local_data_with_default(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage(deployer)
+    result = client.send.call(_params("get_local_data_with_default", account.addr))
+    assert result.abi_return is True
+
+
+def test_get_local_data_with_default_int_when_absent(
+    deployer: Deployer, account: au.AddressWithSigners
+) -> None:
+    # opt_in sets local_int=10; delete it so the slot is absent for an
+    # opted-in account, then `.get(default=0)` returns the default 0
+    client = _storage(deployer)
+    client.send.call(_params("delete_local_data", account.addr))
+    result = client.send.call(_params("get_local_data_with_default_int", account.addr))
+    assert result.abi_return == 0
+
+
+def test_maybe_local_data(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage(deployer)
+    result = client.send.call(_params("maybe_local_data", account.addr))
+    assert result.abi_return == (10, True)
+
+
+def test_maybe_local_data_example(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage(deployer)
+    result = client.send.call(_params("maybe_local_data_example", account.addr))
+    assert result.abi_return is True
+
+
+def test_set_local_int(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage(deployer)
+    client.send.call(_params("set_local_int", account.addr, 123))
+    result = client.send.call(_params("get_item_local_data", account.addr))
+    assert result.abi_return == 123
+
+
+def test_set_local_data_example(
+    deployer: Deployer, account: au.AddressWithSigners, asset_a: int
+) -> None:
+    client = _storage(deployer)
+    value_bool = True
+    result = client.send.call(
+        # for_account, value_asset, value_account, value_app, value_bytes, value_bool
+        _params(
+            "set_local_data_example",
+            account.addr,
+            asset_a,
+            account.addr,
+            client.app_id,
+            b"data",
+            value_bool,
+        )
+    )
+    assert result.abi_return is True
+
+
+def test_delete_local_data(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage(deployer)
+    client.send.call(_params("delete_local_data", account.addr))
+    contains = client.send.call(_params("contains_local_data", account.addr))
+    assert contains.abi_return is False
+
+
+def test_delete_local_data_example(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage(deployer)
+    result = client.send.call(_params("delete_local_data_example", account.addr))
+    assert result.abi_return is True
+
+
+def test_pass_proxy_to_subroutine(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage(deployer)
+    # local_int is 10, subroutine returns value + 1
+    result = client.send.call(_params("pass_proxy_to_subroutine", account.addr))
+    assert result.abi_return == 11
+
+
+def test_get_item_local_data_missing_account_fails(
+    deployer: Deployer, account: au.AddressWithSigners
+) -> None:
+    # on a fresh app the account has not opted in, so indexing local_int fails
+    client = deployer.create((_LOCAL_STATE, "LocalStorage")).client
+    with pytest.raises(au.LogicError):
+        client.send.call(_params("get_item_local_data", account.addr))
+
+
+def test_set_local_int_not_opted_in_fails(
+    deployer: Deployer, account: au.AddressWithSigners
+) -> None:
+    # writing local state also requires the account to be opted in
+    client = deployer.create((_LOCAL_STATE, "LocalStorage")).client
+    with pytest.raises(au.LogicError):
+        client.send.call(_params("set_local_int", account.addr, 123))
+
+
+# --- LocalStorageMap ------------------------------------------------------
+
+
+def test_local_map_get_balance(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage_map(deployer)
+    # opt_in set balances[(sender, "USD")] = 100
+    result = client.send.call(_params("get_balance", account.addr, "USD"))
+    assert result.abi_return == 100
+
+
+def test_local_map_get_balance_missing_key_fails(
+    deployer: Deployer, account: au.AddressWithSigners
+) -> None:
+    client = _storage_map(deployer)
+    # indexing a (account, key) pair with no stored value fails on-chain
+    with pytest.raises(au.LogicError):
+        client.send.call(_params("get_balance", account.addr, "EUR"))
+
+
+def test_local_map_get_balance_or_default(
+    deployer: Deployer, account: au.AddressWithSigners
+) -> None:
+    client = _storage_map(deployer)
+    # "EUR" was never set -> default 0
+    missing = client.send.call(_params("get_balance_or_default", account.addr, "EUR"))
+    assert missing.abi_return == 0
+    present = client.send.call(_params("get_balance_or_default", account.addr, "USD"))
+    assert present.abi_return == 100
+
+
+def test_local_map_maybe_balance(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage_map(deployer)
+    absent = client.send.call(_params("maybe_balance", account.addr, "GBP"))
+    assert absent.abi_return == (0, False)
+    present = client.send.call(_params("maybe_balance", account.addr, "USD"))
+    assert present.abi_return == (100, True)
+
+
+def test_local_map_has_flag(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage_map(deployer)
+    # opt_in set flags[(sender, 0)] = True
+    has = client.send.call(_params("has_flag", account.addr, 0))
+    assert has.abi_return is True
+    missing = client.send.call(_params("has_flag", account.addr, 99))
+    assert missing.abi_return is False
+
+
+def test_local_map_set_balance(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage_map(deployer)
+    client.send.call(_params("set_balance", account.addr, "USD", 500))
+    result = client.send.call(_params("get_balance", account.addr, "USD"))
+    assert result.abi_return == 500
+
+
+def test_local_map_set_flag(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage_map(deployer)
+    flag_value = True
+    client.send.call(_params("set_flag", account.addr, 7, flag_value))
+    result = client.send.call(_params("has_flag", account.addr, 7))
+    assert result.abi_return is True
+
+
+def test_local_map_set_flag_false_still_exists(
+    deployer: Deployer, account: au.AddressWithSigners
+) -> None:
+    client = _storage_map(deployer)
+    flag_value = False
+    client.send.call(_params("set_flag", account.addr, 8, flag_value))
+    # `in` reports key existence regardless of the truthiness of the value
+    result = client.send.call(_params("has_flag", account.addr, 8))
+    assert result.abi_return is True
+
+
+def test_local_map_delete_balance(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage_map(deployer)
+    client.send.call(_params("delete_balance", account.addr, "USD"))
+    result = client.send.call(_params("maybe_balance", account.addr, "USD"))
+    assert result.abi_return == (0, False)
+
+
+def test_local_map_get_slot_proxy(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    client = _storage_map(deployer)
+    result = client.send.call(_params("get_slot_proxy", account.addr, "USD"))
+    assert result.abi_return == 100

--- a/tests/onchain/devportal/test_logged_errors.py
+++ b/tests/onchain/devportal/test_logged_errors.py
@@ -1,0 +1,83 @@
+import algokit_utils as au
+import pytest
+
+from tests import EXAMPLES_DIR
+from tests.utils.deployer import Deployer
+
+_LOGGED_ERRORS = EXAMPLES_DIR / "devportal" / "logged_errors"
+
+
+def test_deposit_and_withdraw(deployer: Deployer) -> None:
+    client = deployer.create(_LOGGED_ERRORS).client
+
+    def call(method: str, amount: int) -> object:
+        return client.send.call(
+            au.AppClientMethodCallParams(method=method, args=[amount])
+        ).abi_return
+
+    # `balance` is global state, starting at 0 and updated by each call
+    assert call("deposit", 100) == 100
+    assert call("deposit", 50) == 150
+    assert call("withdraw", 30) == 120
+    assert call("withdraw", 120) == 0
+
+
+def test_withdraw_zero_is_rejected(deployer: Deployer) -> None:
+    client = deployer.create(_LOGGED_ERRORS).client
+
+    # logged_assert(amount > 0, ...) -> ERR:amountError01:amount must be positive
+    with pytest.raises(au.LogicError, match="ERR:amountError01:amount must be positive"):
+        client.send.call(au.AppClientMethodCallParams(method="withdraw", args=[0]))
+
+
+def test_withdraw_insufficient_balance_is_rejected(deployer: Deployer) -> None:
+    client = deployer.create(_LOGGED_ERRORS).client
+    client.send.call(au.AppClientMethodCallParams(method="deposit", args=[10]))
+
+    # logged_assert(amount <= balance, ...) -> ERR:amountError02:insufficient balance
+    with pytest.raises(au.LogicError, match="ERR:amountError02:insufficient balance"):
+        client.send.call(au.AppClientMethodCallParams(method="withdraw", args=[50]))
+
+
+def test_withdraw_desc_lands_in_arc56_source_info(deployer: Deployer) -> None:
+    client = deployer.create(_LOGGED_ERRORS).client
+
+    # `desc=` does not change the on-chain logged output (covered above), but
+    # becomes the plain-language errorMessage in the ARC-56 source info that
+    # typed clients surface for the failing program counter
+    source_info = client.app_spec.source_info
+    assert source_info is not None
+    messages = {e.error_message for e in source_info.approval.source_info if e.error_message}
+    assert "Withdrawal amount must be greater than zero" in messages
+
+
+def test_reject_returns_code_in_range(deployer: Deployer) -> None:
+    client = deployer.create(_LOGGED_ERRORS).client
+
+    assert (
+        client.send.call(au.AppClientMethodCallParams(method="reject", args=[42])).abi_return == 42
+    )
+
+
+def test_reject_out_of_range_codes_are_logged(deployer: Deployer) -> None:
+    client = deployer.create(_LOGGED_ERRORS).client
+
+    # logged_err for the reserved zero code
+    with pytest.raises(au.LogicError, match="ERR:codeRange00:code zero is reserved"):
+        client.send.call(au.AppClientMethodCallParams(method="reject", args=[0]))
+
+    # logged_err for codes above the permitted range
+    with pytest.raises(au.LogicError, match="ERR:codeRange01:code out of range"):
+        client.send.call(au.AppClientMethodCallParams(method="reject", args=[150]))
+
+
+def test_reject_boundary_code(deployer: Deployer) -> None:
+    client = deployer.create(_LOGGED_ERRORS).client
+
+    # 100 is the highest accepted code; 101 is the first rejected one
+    assert (
+        client.send.call(au.AppClientMethodCallParams(method="reject", args=[100])).abi_return
+        == 100
+    )
+    with pytest.raises(au.LogicError, match="ERR:codeRange01:code out of range"):
+        client.send.call(au.AppClientMethodCallParams(method="reject", args=[101]))

--- a/tests/onchain/devportal/test_lsig_with_args.py
+++ b/tests/onchain/devportal/test_lsig_with_args.py
@@ -1,0 +1,370 @@
+import hashlib
+import random
+
+import algokit_utils as au
+import pytest
+from algokit_common import public_key_from_address
+from algokit_utils.transactions.transaction_composer import TransactionComposerError
+
+from tests import EXAMPLES_DIR
+from tests.test_logic_sig import compile_logic_sig
+from tests.utils import arc4_encode
+
+_LSIG_SRC = EXAMPLES_DIR / "devportal" / "lsig_with_args" / "contract.py"
+_DUMMY_PK = b"\x00" * 32
+
+
+def _compile(
+    name: str,
+    *,
+    beneficiary: bytes = _DUMMY_PK,
+    payee_a: bytes = _DUMMY_PK,
+    payee_b: bytes = _DUMMY_PK,
+) -> bytes:
+    # all four logicsigs in the file compile together, so every TemplateVar in
+    # the module must be supplied on each call (unrelated ones get a dummy)
+    return compile_logic_sig(
+        _LSIG_SRC,
+        name=name,
+        template_variables={
+            "BENEFICIARY": beneficiary,
+            "PAYEE_A": payee_a,
+            "PAYEE_B": payee_b,
+        },
+    )
+
+
+def _fund(localnet: au.AlgorandClient, account: au.AddressWithSigners, lsig_addr: str) -> None:
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=lsig_addr,
+            amount=au.AlgoAmount.from_algo(2),
+        )
+    )
+
+
+def _pay_from_lsig(
+    localnet: au.AlgorandClient,
+    lsig: au.LogicSigAccount,
+    *,
+    receiver: str,
+    micro_algo: int,
+    note: bytes | None = None,
+    lease: bytes | None = None,
+    last_valid_round: int | None = None,
+) -> au.SendSingleTransactionResult:
+    localnet.account.set_signer(lsig.addr, lsig.signer)
+    return localnet.send.payment(
+        au.PaymentParams(
+            sender=lsig.addr,
+            receiver=receiver,
+            amount=au.AlgoAmount.from_micro_algo(micro_algo),
+            note=note,
+            lease=lease,
+            last_valid_round=last_valid_round,
+        )
+    )
+
+
+# --- escrow_release: contract account, single beneficiary baked in via TemplateVar
+
+
+def test_escrow_release_pays_beneficiary(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    amount = 1_000_000
+    bytecode = _compile("escrow_release", beneficiary=public_key_from_address(account.addr))
+    lsig = au.LogicSigAccount(logic=bytecode, args=[arc4_encode("uint64", amount)])
+    _fund(localnet, account, lsig.addr)
+
+    result = _pay_from_lsig(localnet, lsig, receiver=account.addr, micro_algo=amount)
+    assert result.confirmation.confirmed_round is not None
+
+
+def test_escrow_release_rejects_amount_mismatch(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    # the lsig arg pins Txn.amount; paying a different amount must fail
+    bytecode = _compile("escrow_release", beneficiary=public_key_from_address(account.addr))
+    lsig = au.LogicSigAccount(logic=bytecode, args=[arc4_encode("uint64", 1_000_000)])
+    _fund(localnet, account, lsig.addr)
+
+    with pytest.raises(TransactionComposerError, match="rejected by logic"):
+        _pay_from_lsig(localnet, lsig, receiver=account.addr, micro_algo=999_999)
+
+
+def test_escrow_release_rejects_wrong_receiver(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    # the beneficiary is baked into the program; paying anyone else must fail
+    outsider = localnet.account.random()
+    amount = 1_000_000
+    bytecode = _compile("escrow_release", beneficiary=public_key_from_address(account.addr))
+    lsig = au.LogicSigAccount(logic=bytecode, args=[arc4_encode("uint64", amount)])
+    _fund(localnet, account, lsig.addr)
+
+    with pytest.raises(TransactionComposerError, match="rejected by logic"):
+        _pay_from_lsig(localnet, lsig, receiver=outsider.addr, micro_algo=amount)
+
+
+def test_escrow_release_rejects_malformed_arg_encoding(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    # default validate_encoding="args" checks the encoded bytes against the
+    # declared type: a 7-byte arg is not a valid uint64 encoding
+    bytecode = _compile("escrow_release", beneficiary=public_key_from_address(account.addr))
+    lsig = au.LogicSigAccount(logic=bytecode, args=[b"\x00" * 7])
+    _fund(localnet, account, lsig.addr)
+
+    with pytest.raises(TransactionComposerError, match="rejected by logic"):
+        _pay_from_lsig(localnet, lsig, receiver=account.addr, micro_algo=1_000_000)
+
+
+# --- voucher_redeem: arc4.Struct argument
+
+
+def _voucher(
+    localnet: au.AlgorandClient, recipient: str, max_amount: int
+) -> tuple[bytes, bytes, int]:
+    """Voucher bytes + the lease and pinned last_valid its redemption requires.
+
+    The lsig enforces `Txn.last_valid == expires_at` and
+    `Txn.lease == sha256(voucher_bytes)` (single-use), so expires_at must sit
+    inside the node's ~1000-round max validity window.
+    """
+    expires_at = localnet.get_suggested_params().last_valid
+    voucher = arc4_encode(
+        "(address,uint64,uint64)",
+        (public_key_from_address(recipient), max_amount, expires_at),
+    )
+    return voucher, hashlib.sha256(voucher).digest(), expires_at
+
+
+def test_voucher_redeem_within_constraints(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    voucher, lease, expires_at = _voucher(localnet, account.addr, 5_000_000)
+    bytecode = _compile("voucher_redeem")
+    lsig = au.LogicSigAccount(logic=bytecode, args=[voucher])
+    _fund(localnet, account, lsig.addr)
+
+    result = _pay_from_lsig(
+        localnet,
+        lsig,
+        receiver=account.addr,
+        micro_algo=1_000_000,
+        lease=lease,
+        last_valid_round=expires_at,
+    )
+    assert result.confirmation.confirmed_round is not None
+
+
+def test_voucher_redeem_is_single_use(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    voucher, lease, expires_at = _voucher(localnet, account.addr, 5_000_000)
+    bytecode = _compile("voucher_redeem")
+    lsig = au.LogicSigAccount(logic=bytecode, args=[voucher])
+    _fund(localnet, account, lsig.addr)
+
+    result = _pay_from_lsig(
+        localnet,
+        lsig,
+        receiver=account.addr,
+        micro_algo=1_000_000,
+        note=b"first",
+        lease=lease,
+        last_valid_round=expires_at,
+    )
+    assert result.confirmation.confirmed_round is not None
+
+    # replaying the same voucher is blocked by the ledger's lease mechanism:
+    # the (sender, lease) slot is held until expires_at, and after expires_at
+    # the pinned last_valid makes any redemption impossible
+    with pytest.raises(TransactionComposerError, match="lease"):
+        _pay_from_lsig(
+            localnet,
+            lsig,
+            receiver=account.addr,
+            micro_algo=1_000_000,
+            note=b"second",
+            lease=lease,
+            last_valid_round=expires_at,
+        )
+
+
+def test_voucher_redeem_rejects_over_max_amount(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    voucher, lease, expires_at = _voucher(localnet, account.addr, 5_000_000)
+    bytecode = _compile("voucher_redeem")
+    lsig = au.LogicSigAccount(logic=bytecode, args=[voucher])
+    _fund(localnet, account, lsig.addr)
+
+    with pytest.raises(TransactionComposerError, match="rejected by logic"):
+        _pay_from_lsig(
+            localnet,
+            lsig,
+            receiver=account.addr,
+            micro_algo=5_000_001,
+            lease=lease,
+            last_valid_round=expires_at,
+        )
+
+
+def test_voucher_redeem_rejects_expired_voucher(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    # expires_at is far in the past, so the pinned `Txn.last_valid ==
+    # expires_at` check cannot hold for any currently-valid transaction
+    voucher = arc4_encode(
+        "(address,uint64,uint64)",
+        (public_key_from_address(account.addr), 5_000_000, 1),
+    )
+    bytecode = _compile("voucher_redeem")
+    lsig = au.LogicSigAccount(logic=bytecode, args=[voucher])
+    _fund(localnet, account, lsig.addr)
+
+    with pytest.raises(TransactionComposerError, match="rejected by logic"):
+        _pay_from_lsig(
+            localnet,
+            lsig,
+            receiver=account.addr,
+            micro_algo=1_000_000,
+            lease=hashlib.sha256(voucher).digest(),
+        )
+
+
+# --- mixed_args: native + arc4 args mixed, returns UInt64
+
+
+def _mixed_args(receiver_pk: bytes, note: bytes) -> list[bytes]:
+    return [
+        arc4_encode("uint64", 500_000),
+        arc4_encode("address", receiver_pk),
+        arc4_encode("byte[]", note),
+    ]
+
+
+def _mixed_args_lease(args: list[bytes]) -> bytes:
+    # the lsig requires Txn.lease == sha256(arg0 || arg1 || arg2)
+    return hashlib.sha256(b"".join(args)).digest()
+
+
+def test_mixed_args_succeeds(localnet: au.AlgorandClient, account: au.AddressWithSigners) -> None:
+    # the note feeds the lease preimage (sender is the same lsig contract account
+    # every run), so it must be unique per run or reruns within the ~1000-round
+    # lease validity window are rejected as duplicate (sender, lease) pairs
+    note = b"mixed-args-" + random.randbytes(8)
+    args = _mixed_args(public_key_from_address(account.addr), note)
+    bytecode = _compile("MixedArgsLsig")
+    lsig = au.LogicSigAccount(logic=bytecode, args=args)
+    _fund(localnet, account, lsig.addr)
+
+    result = _pay_from_lsig(
+        localnet,
+        lsig,
+        receiver=account.addr,
+        micro_algo=500_000,
+        note=note,
+        lease=_mixed_args_lease(args),
+    )
+    assert result.confirmation.confirmed_round is not None
+
+
+def test_mixed_args_rejects_wrong_note(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    args = _mixed_args(public_key_from_address(account.addr), b"expected-note")
+    bytecode = _compile("MixedArgsLsig")
+    lsig = au.LogicSigAccount(logic=bytecode, args=args)
+    _fund(localnet, account, lsig.addr)
+
+    with pytest.raises(TransactionComposerError, match="rejected by logic"):
+        _pay_from_lsig(
+            localnet,
+            lsig,
+            receiver=account.addr,
+            micro_algo=500_000,
+            note=b"wrong-note",
+            lease=_mixed_args_lease(args),
+        )
+
+
+def test_mixed_args_rejects_missing_lease(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    # without the lease committing to the encoded args, the lsig must reject
+    note = b"mixed-args-note"
+    args = _mixed_args(public_key_from_address(account.addr), note)
+    bytecode = _compile("MixedArgsLsig")
+    lsig = au.LogicSigAccount(logic=bytecode, args=args)
+    _fund(localnet, account, lsig.addr)
+
+    with pytest.raises(TransactionComposerError, match="rejected by logic"):
+        _pay_from_lsig(localnet, lsig, receiver=account.addr, micro_algo=500_000, note=note)
+
+
+# --- escrow_release_to: arc4.Address arg, validate_encoding="unsafe_disabled"
+
+
+def test_escrow_release_to_pays_approved_payee(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    payee_b = localnet.account.random()
+    bytecode = _compile(
+        "escrow_release_to",
+        payee_a=public_key_from_address(account.addr),
+        payee_b=public_key_from_address(payee_b.addr),
+    )
+    # caller selects PAYEE_A
+    lsig = au.LogicSigAccount(
+        logic=bytecode,
+        args=[arc4_encode("address", public_key_from_address(account.addr))],
+    )
+    _fund(localnet, account, lsig.addr)
+
+    result = _pay_from_lsig(localnet, lsig, receiver=account.addr, micro_algo=1_000_000)
+    assert result.confirmation.confirmed_round is not None
+
+
+def test_escrow_release_to_pays_second_payee(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    # the caller can select either baked-in payee; here PAYEE_B
+    payee_b = localnet.account.random()
+    bytecode = _compile(
+        "escrow_release_to",
+        payee_a=public_key_from_address(account.addr),
+        payee_b=public_key_from_address(payee_b.addr),
+    )
+    lsig = au.LogicSigAccount(
+        logic=bytecode,
+        args=[arc4_encode("address", public_key_from_address(payee_b.addr))],
+    )
+    _fund(localnet, account, lsig.addr)
+
+    result = _pay_from_lsig(localnet, lsig, receiver=payee_b.addr, micro_algo=1_000_000)
+    assert result.confirmation.confirmed_round is not None
+
+
+def test_escrow_release_to_rejects_unapproved_payee(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    payee_b = localnet.account.random()
+    outsider = localnet.account.random()
+    bytecode = _compile(
+        "escrow_release_to",
+        payee_a=public_key_from_address(account.addr),
+        payee_b=public_key_from_address(payee_b.addr),
+    )
+    # caller passes an address that is not on the allow-list
+    lsig = au.LogicSigAccount(
+        logic=bytecode,
+        args=[arc4_encode("address", public_key_from_address(outsider.addr))],
+    )
+    _fund(localnet, account, lsig.addr)
+
+    with pytest.raises(TransactionComposerError, match="rejected by logic"):
+        _pay_from_lsig(localnet, lsig, receiver=outsider.addr, micro_algo=1_000_000)

--- a/tests/onchain/devportal/test_op_budget.py
+++ b/tests/onchain/devportal/test_op_budget.py
@@ -1,0 +1,131 @@
+import hashlib
+import random
+
+import algokit_utils as au
+import pytest
+
+from tests import EXAMPLES_DIR
+from tests.utils.deployer import Deployer
+
+_OP_BUDGET = EXAMPLES_DIR / "devportal" / "op_budget"
+
+# generous flat fee to cover the chain of inner OpUp application calls
+_FEE = au.AlgoAmount.from_micro_algo(20_000)
+
+
+def _params(method: str, *args: object, fee: au.AlgoAmount = _FEE) -> au.AppClientMethodCallParams:
+    return au.AppClientMethodCallParams(
+        method=method, args=list(args), static_fee=fee, note=random.randbytes(8)
+    )
+
+
+def _expected_digest(seed: bytes, rounds: int) -> bytes:
+    """Mirror of the contract: chained sha256 applied `rounds` times."""
+    digest = seed
+    for _ in range(rounds):
+        digest = hashlib.sha256(digest).digest()
+    return digest
+
+
+def test_many_hashes_group_credit(deployer: Deployer) -> None:
+    client = deployer.create(_OP_BUDGET).client
+    seed = b"seed"
+    rounds = 20
+    # ensure_budget covers the extra ops; the static fee pays the inner OpUps
+    result = client.send.call(_params("many_hashes_group_credit", seed, rounds))
+    assert result.abi_return == _expected_digest(seed, rounds)
+
+
+def test_many_hashes_default_fee_source(deployer: Deployer) -> None:
+    # `many_hashes` uses the default GroupCredit fee source
+    client = deployer.create(_OP_BUDGET).client
+    seed = b"hello world"
+    rounds = 20
+    result = client.send.call(_params("many_hashes", seed, rounds))
+    assert result.abi_return == _expected_digest(seed, rounds)
+
+
+def test_many_hashes_any_fee_source(deployer: Deployer) -> None:
+    client = deployer.create(_OP_BUDGET).client
+    seed = b"abc"
+    rounds = 25
+    result = client.send.call(_params("many_hashes_any", seed, rounds))
+    assert result.abi_return == _expected_digest(seed, rounds)
+
+
+def test_many_hashes_app_pays(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = deployer.create(_OP_BUDGET).client
+
+    # AppAccount fee source: the application account itself pays inner OpUp fees,
+    # so it must hold algos.
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=client.app_address,
+            amount=au.AlgoAmount.from_algo(1),
+        )
+    )
+
+    seed = b"app pays"
+    rounds = 20
+    # the app account pays the inner fees, so the outer txn only needs the
+    # standard min fee
+    result = client.send.call(
+        _params(
+            "many_hashes_app_pays",
+            seed,
+            rounds,
+            fee=au.AlgoAmount.from_micro_algo(1_000),
+        )
+    )
+    assert result.abi_return == _expected_digest(seed, rounds)
+
+
+def test_many_hashes_multiple_op_ups(deployer: Deployer) -> None:
+    # rounds=100 requires ~4100 ops of budget, i.e. several chained OpUp
+    # inner calls on top of the base 700
+    client = deployer.create(_OP_BUDGET).client
+    seed = b"lots of hashing"
+    rounds = 100
+    result = client.send.call(_params("many_hashes", seed, rounds))
+    assert result.abi_return == _expected_digest(seed, rounds)
+
+
+def test_many_hashes_zero_rounds(deployer: Deployer) -> None:
+    # with rounds=0 the loop never runs and the seed is returned unchanged
+    client = deployer.create(_OP_BUDGET).client
+    seed = b"unchanged"
+    result = client.send.call(_params("many_hashes", seed, 0))
+    assert result.abi_return == seed
+
+
+def test_many_hashes_group_credit_without_credit_fails(deployer: Deployer) -> None:
+    # GroupCredit inner OpUp calls carry fee=0 and rely on excess fee paid by
+    # the group; with only the min fee on the outer txn there is no credit
+    client = deployer.create(_OP_BUDGET).client
+    with pytest.raises((au.LogicError, ValueError)):
+        client.send.call(
+            _params(
+                "many_hashes",
+                b"seed",
+                20,
+                fee=au.AlgoAmount.from_micro_algo(1_000),
+            )
+        )
+
+
+def test_many_hashes_app_pays_unfunded_fails(deployer: Deployer) -> None:
+    # AppAccount fee source with no algos in the app account cannot pay the
+    # inner OpUp fees, so the call fails
+    client = deployer.create(_OP_BUDGET).client
+    with pytest.raises(au.LogicError):
+        client.send.call(
+            _params(
+                "many_hashes_app_pays",
+                b"seed",
+                20,
+                fee=au.AlgoAmount.from_micro_algo(1_000),
+            )
+        )

--- a/tests/onchain/devportal/test_reference_account.py
+++ b/tests/onchain/devportal/test_reference_account.py
@@ -1,0 +1,135 @@
+import random
+
+import algokit_utils as au
+import pytest
+from algokit_common import public_key_from_address
+
+from tests import EXAMPLES_DIR
+from tests.utils.compile import compile_arc56
+from tests.utils.deployer import Deployer
+
+_REFERENCE_ACCOUNT = EXAMPLES_DIR / "devportal" / "reference_account"
+
+
+def _deploy(deployer: Deployer, known_account: str) -> au.AppClient:
+    """Deploy ReferenceAccount with the TMPL_KNOWN_ACCOUNT template variable filled."""
+    spec = compile_arc56(_REFERENCE_ACCOUNT)
+    factory = au.AppFactory(
+        au.AppFactoryParams(
+            algorand=deployer.localnet,
+            app_spec=spec,
+            default_sender=deployer.account.addr,
+        )
+    )
+    client, _ = factory.send.bare.create(
+        au.AppFactoryCreateParams(note=random.randbytes(8)),
+        compilation_params=au.AppClientCompilationParams(
+            deploy_time_params={"TMPL_KNOWN_ACCOUNT": public_key_from_address(known_account)}
+        ),
+    )
+    return client
+
+
+def test_known_account_balance(
+    deployer: Deployer, account: au.AddressWithSigners, localnet: au.AlgorandClient
+) -> None:
+    """The template-provided account's balance is read by the no-arg variant."""
+    funded = localnet.account.random()
+    fund_amount = au.AlgoAmount.from_algo(5)
+    localnet.send.payment(
+        au.PaymentParams(sender=account.addr, receiver=funded.addr, amount=fund_amount)
+    )
+    client = _deploy(deployer, funded.addr)
+
+    result = client.send.call(au.AppClientMethodCallParams(method="get_account_balance"))
+    assert result.abi_return == fund_amount.micro_algo
+
+
+def test_known_account_unfunded_fails(deployer: Deployer, localnet: au.AlgorandClient) -> None:
+    """Reading `.balance` of an unfunded account triggers the AVM
+    `acct_params_get AcctBalance` funded assertion, so the call fails."""
+    client = _deploy(deployer, localnet.account.random().addr)
+
+    with pytest.raises(au.LogicError, match="account funded"):
+        client.send.call(au.AppClientMethodCallParams(method="get_account_balance"))
+
+
+def test_with_argument_reads_funded_account_balance(
+    deployer: Deployer, account: au.AddressWithSigners, localnet: au.AlgorandClient
+) -> None:
+    """A funded account's real balance is read via the with-argument variant."""
+    client = _deploy(deployer, deployer.account.addr)
+
+    funded = localnet.account.random()
+    fund_amount = au.AlgoAmount.from_algo(7)
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=funded.addr,
+            amount=fund_amount,
+        )
+    )
+
+    result = client.send.call(
+        au.AppClientMethodCallParams(
+            method="get_account_balance_with_arg",
+            args=[funded.addr],
+        )
+    )
+    assert result.abi_return == fund_amount.micro_algo
+
+
+def test_with_argument_unfunded_account_fails(
+    deployer: Deployer, localnet: au.AlgorandClient
+) -> None:
+    """An unfunded account has no balance entry, so `.balance` asserts."""
+    client = _deploy(deployer, deployer.account.addr)
+
+    fresh = localnet.account.random()
+    with pytest.raises(au.LogicError, match="account funded"):
+        client.send.call(
+            au.AppClientMethodCallParams(
+                method="get_account_balance_with_arg",
+                args=[fresh.addr],
+            )
+        )
+
+
+def test_balance_tracks_repeated_funding(
+    deployer: Deployer, account: au.AddressWithSigners, localnet: au.AlgorandClient
+) -> None:
+    """The reported balance grows as the account receives more payments."""
+    client = _deploy(deployer, deployer.account.addr)
+
+    target = localnet.account.random()
+
+    def balance() -> object:
+        return client.send.call(
+            au.AppClientMethodCallParams(
+                method="get_account_balance_with_arg",
+                args=[target.addr],
+                note=random.randbytes(8),
+            )
+        ).abi_return
+
+    first = au.AlgoAmount.from_algo(3)
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=target.addr,
+            amount=first,
+            note=random.randbytes(8),
+        )
+    )
+    assert balance() == first.micro_algo
+
+    second = au.AlgoAmount.from_algo(2)
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=target.addr,
+            amount=second,
+            note=random.randbytes(8),
+        )
+    )
+    assert balance() == first.micro_algo + second.micro_algo

--- a/tests/onchain/devportal/test_reference_account_app.py
+++ b/tests/onchain/devportal/test_reference_account_app.py
@@ -1,0 +1,202 @@
+import random
+
+import algokit_utils as au
+import pytest
+from algokit_common import public_key_from_address
+
+from tests import EXAMPLES_DIR
+from tests.utils.compile import compile_arc56
+from tests.utils.deployer import Deployer
+
+_REFERENCE_ACCOUNT_APP = EXAMPLES_DIR / "devportal" / "reference_account_app"
+
+
+def _deploy_ref(deployer: Deployer, known_account: str, known_app_id: int) -> au.AppClient:
+    """Deploy ReferenceAccountApp with both template variables filled."""
+    spec = compile_arc56(_REFERENCE_ACCOUNT_APP, contract_name="ReferenceAccountApp")
+    factory = au.AppFactory(
+        au.AppFactoryParams(
+            algorand=deployer.localnet,
+            app_spec=spec,
+            default_sender=deployer.account.addr,
+        )
+    )
+    client, _ = factory.send.bare.create(
+        au.AppFactoryCreateParams(note=random.randbytes(8)),
+        compilation_params=au.AppClientCompilationParams(
+            deploy_time_params={
+                "TMPL_KNOWN_ACCOUNT": public_key_from_address(known_account),
+                "TMPL_KNOWN_APP": known_app_id,
+            }
+        ),
+    )
+    return client
+
+
+def _opt_in(client: au.AppClient, signer: au.AddressWithSigners) -> None:
+    """Opt the given account into the MyCounter app via its OptIn ABI method."""
+    client.send.call(
+        au.AppClientMethodCallParams(
+            method="opt_in",
+            on_complete=au.OnApplicationComplete.OptIn,
+            sender=signer.addr,
+            signer=signer.signer,
+            note=random.randbytes(8),
+        )
+    )
+
+
+def _increment(client: au.AppClient, signer: au.AddressWithSigners) -> object:
+    return client.send.call(
+        au.AppClientMethodCallParams(
+            method="increment_my_counter",
+            sender=signer.addr,
+            signer=signer.signer,
+            note=random.randbytes(8),
+        )
+    ).abi_return
+
+
+def test_increment_my_counter_tracks_per_account(
+    deployer: Deployer, account: au.AddressWithSigners
+) -> None:
+    """MyCounter increments the opted-in caller's local counter on each call."""
+    counter = deployer.create((_REFERENCE_ACCOUNT_APP, "MyCounter")).client
+
+    _opt_in(counter, account)
+    assert _increment(counter, account) == 1
+    assert _increment(counter, account) == 2
+    assert _increment(counter, account) == 3
+
+
+def test_increment_without_opt_in_fails(
+    deployer: Deployer, account: au.AddressWithSigners
+) -> None:
+    """Calling increment without opting in trips the is_opted_in assertion."""
+    counter = deployer.create((_REFERENCE_ACCOUNT_APP, "MyCounter")).client
+
+    with pytest.raises(au.LogicError, match="Account is not opted in to the app"):
+        _increment(counter, account)
+
+
+def test_get_my_counter_with_arg_reads_other_apps_local_state(
+    deployer: Deployer, account: au.AddressWithSigners
+) -> None:
+    """ReferenceAccountApp reads the per-account counter from a separate app."""
+    counter = deployer.create((_REFERENCE_ACCOUNT_APP, "MyCounter")).client
+    ref = _deploy_ref(deployer, account.addr, counter.app_id)
+
+    _opt_in(counter, account)
+    _increment(counter, account)
+    _increment(counter, account)
+
+    result = ref.send.call(
+        au.AppClientMethodCallParams(
+            method="get_my_counter_with_arg",
+            args=[account.addr, counter.app_id],
+        )
+    )
+    assert result.abi_return == 2
+
+
+def test_get_my_counter_with_arg_not_opted_in_fails(
+    deployer: Deployer, account: au.AddressWithSigners, localnet: au.AlgorandClient
+) -> None:
+    """Reading a counter for an account that never opted in fails inside the
+    `app_local_get_ex` opcode itself, *before* the contract's `exists` assert
+    is ever reached. Note: algokit maps the failing PC to the nearest ARC-56
+    error message, so the *reported text* is still the assert's message — the
+    trace line (`app_local_get_ex <-- Error`) is what identifies the real
+    failure point."""
+    counter = deployer.create((_REFERENCE_ACCOUNT_APP, "MyCounter")).client
+    ref = _deploy_ref(deployer, account.addr, counter.app_id)
+
+    not_opted = localnet.account.random()
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=not_opted.addr,
+            amount=au.AlgoAmount.from_algo(1),
+            note=random.randbytes(8),
+        )
+    )
+
+    with pytest.raises(au.LogicError, match="app_local_get_ex"):
+        ref.send.call(
+            au.AppClientMethodCallParams(
+                method="get_my_counter_with_arg",
+                args=[not_opted.addr, counter.app_id],
+            )
+        )
+
+
+def test_get_my_counter_with_arg_key_missing_fails(
+    deployer: Deployer, account: au.AddressWithSigners, localnet: au.AlgorandClient
+) -> None:
+    """`exists` is False only when the account IS opted in but the key was
+    never written — that is the case the contract's assert actually guards."""
+    ref = _deploy_ref(deployer, account.addr, 0)
+
+    # a raw app with a local-state schema whose opt-in writes nothing, so the
+    # opted-in account has no "my_counter" key
+    raw = localnet.send.app_create(
+        au.AppCreateParams(
+            sender=account.addr,
+            approval_program="#pragma version 10\nint 1",
+            clear_state_program="#pragma version 10\nint 1",
+            schema=au.AppCreateSchema(
+                global_ints=0, global_byte_slices=0, local_ints=1, local_byte_slices=0
+            ),
+            note=random.randbytes(8),
+        )
+    )
+    assert raw.app_id
+    localnet.send.app_call(
+        au.AppCallParams(
+            sender=account.addr,
+            app_id=raw.app_id,
+            on_complete=au.OnApplicationComplete.OptIn,
+            note=random.randbytes(8),
+        )
+    )
+
+    with pytest.raises(au.LogicError, match="my_counter is not set for this account"):
+        ref.send.call(
+            au.AppClientMethodCallParams(
+                method="get_my_counter_with_arg",
+                args=[account.addr, raw.app_id],
+            )
+        )
+
+
+def test_get_my_counter_known_pair(deployer: Deployer, account: au.AddressWithSigners) -> None:
+    """The template-provided account/app pair's counter is read by the no-arg variant."""
+    counter = deployer.create((_REFERENCE_ACCOUNT_APP, "MyCounter")).client
+    _opt_in(counter, account)
+    _increment(counter, account)
+    ref = _deploy_ref(deployer, account.addr, counter.app_id)
+
+    result = ref.send.call(au.AppClientMethodCallParams(method="get_my_counter"))
+    assert result.abi_return == 1
+
+
+def test_get_my_counter_known_pair_not_opted_in_fails(
+    deployer: Deployer, account: au.AddressWithSigners, localnet: au.AlgorandClient
+) -> None:
+    """A template-provided account that never opted in to the known app fails
+    inside the `app_local_get_ex` opcode (see the note on the with-arg variant
+    about how the error is reported)."""
+    counter = deployer.create((_REFERENCE_ACCOUNT_APP, "MyCounter")).client
+    not_opted = localnet.account.random()
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=not_opted.addr,
+            amount=au.AlgoAmount.from_algo(1),
+            note=random.randbytes(8),
+        )
+    )
+    ref = _deploy_ref(deployer, not_opted.addr, counter.app_id)
+
+    with pytest.raises(au.LogicError, match="app_local_get_ex"):
+        ref.send.call(au.AppClientMethodCallParams(method="get_my_counter"))

--- a/tests/onchain/devportal/test_reference_account_asset.py
+++ b/tests/onchain/devportal/test_reference_account_asset.py
@@ -1,0 +1,190 @@
+import random
+
+import algokit_utils as au
+import pytest
+from algokit_common import public_key_from_address
+
+from tests import EXAMPLES_DIR
+from tests.utils.compile import compile_arc56
+from tests.utils.deployer import Deployer
+
+_REFERENCE_ACCOUNT_ASSET = EXAMPLES_DIR / "devportal" / "reference_account_asset"
+
+
+def _deploy(deployer: Deployer, known_account: str, known_asset_id: int) -> au.AppClient:
+    """Deploy ReferenceAccountAsset with both template variables filled."""
+    spec = compile_arc56(_REFERENCE_ACCOUNT_ASSET)
+    factory = au.AppFactory(
+        au.AppFactoryParams(
+            algorand=deployer.localnet,
+            app_spec=spec,
+            default_sender=deployer.account.addr,
+        )
+    )
+    client, _ = factory.send.bare.create(
+        au.AppFactoryCreateParams(note=random.randbytes(8)),
+        compilation_params=au.AppClientCompilationParams(
+            deploy_time_params={
+                "TMPL_KNOWN_ACCOUNT": public_key_from_address(known_account),
+                "TMPL_KNOWN_ASSET": known_asset_id,
+            }
+        ),
+    )
+    return client
+
+
+def _create_asset(localnet: au.AlgorandClient, account: au.AddressWithSigners) -> int:
+    """A fresh asset for tests that transfer units away: the shared session
+    `asset_a` fixture must stay untouched — other tests (e.g. test_amm) assert
+    the session account still holds its full supply."""
+    return localnet.send.asset_create(
+        au.AssetCreateParams(sender=account.addr, total=10_000_000, note=random.randbytes(8))
+    ).asset_id
+
+
+def _funded_account(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> au.AddressWithSigners:
+    """Create and fund a fresh account so it can opt into / hold assets."""
+    acct = localnet.account.random()
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=acct.addr,
+            amount=au.AlgoAmount.from_algo(1),
+            note=random.randbytes(8),
+        )
+    )
+    return acct
+
+
+def test_known_pair_reads_holding(
+    deployer: Deployer,
+    account: au.AddressWithSigners,
+    localnet: au.AlgorandClient,
+) -> None:
+    """The template-provided account/asset pair's holding is read by the no-arg variant."""
+    holder = _funded_account(localnet, account)
+    asset = _create_asset(localnet, account)
+    # opt-in, then receive some units
+    localnet.send.asset_transfer(
+        au.AssetTransferParams(sender=holder.addr, receiver=holder.addr, asset_id=asset, amount=0)
+    )
+    transfer_amount = 777
+    localnet.send.asset_transfer(
+        au.AssetTransferParams(
+            sender=account.addr,
+            receiver=holder.addr,
+            asset_id=asset,
+            amount=transfer_amount,
+            note=random.randbytes(8),
+        )
+    )
+    client = _deploy(deployer, holder.addr, asset)
+
+    result = client.send.call(au.AppClientMethodCallParams(method="get_asset_balance"))
+    assert result.abi_return == transfer_amount
+
+
+def test_known_pair_account_not_opted_in(
+    deployer: Deployer,
+    account: au.AddressWithSigners,
+    localnet: au.AlgorandClient,
+    asset_a: int,
+) -> None:
+    """A template-provided account that never opted in trips the opt-in assertion."""
+    holder = _funded_account(localnet, account)
+    client = _deploy(deployer, holder.addr, asset_a)
+
+    with pytest.raises(au.LogicError, match="Account is not opted in to the asset"):
+        client.send.call(au.AppClientMethodCallParams(method="get_asset_balance"))
+
+
+def test_with_arg_reads_opted_in_account_holding(
+    deployer: Deployer,
+    account: au.AddressWithSigners,
+    localnet: au.AlgorandClient,
+    asset_a: int,
+) -> None:
+    """After opting in and receiving a transfer, the holding is read correctly."""
+    client = _deploy(deployer, account.addr, asset_a)
+
+    holder = _funded_account(localnet, account)
+    asset = _create_asset(localnet, account)
+
+    # opt-in: 0-amount transfer from the account to itself
+    localnet.send.asset_transfer(
+        au.AssetTransferParams(
+            sender=holder.addr,
+            receiver=holder.addr,
+            asset_id=asset,
+            amount=0,
+        )
+    )
+
+    # transfer some units from the asset creator to the holder
+    transfer_amount = 1234
+    localnet.send.asset_transfer(
+        au.AssetTransferParams(
+            sender=account.addr,
+            receiver=holder.addr,
+            asset_id=asset,
+            amount=transfer_amount,
+            note=random.randbytes(8),
+        )
+    )
+
+    result = client.send.call(
+        au.AppClientMethodCallParams(
+            method="get_asset_balance_with_arg",
+            args=[holder.addr, asset],
+        )
+    )
+    assert result.abi_return == transfer_amount
+
+
+def test_with_arg_opted_in_zero_balance(
+    deployer: Deployer,
+    account: au.AddressWithSigners,
+    localnet: au.AlgorandClient,
+    asset_a: int,
+) -> None:
+    """An opted-in account that received nothing has a zero holding."""
+    client = _deploy(deployer, account.addr, asset_a)
+
+    holder = _funded_account(localnet, account)
+    localnet.send.asset_transfer(
+        au.AssetTransferParams(
+            sender=holder.addr,
+            receiver=holder.addr,
+            asset_id=asset_a,
+            amount=0,
+        )
+    )
+
+    result = client.send.call(
+        au.AppClientMethodCallParams(
+            method="get_asset_balance_with_arg",
+            args=[holder.addr, asset_a],
+        )
+    )
+    assert result.abi_return == 0
+
+
+def test_with_arg_not_opted_in_fails(
+    deployer: Deployer,
+    account: au.AddressWithSigners,
+    localnet: au.AlgorandClient,
+    asset_a: int,
+) -> None:
+    """An account that never opted into the asset trips the opt-in assertion."""
+    client = _deploy(deployer, account.addr, asset_a)
+
+    holder = _funded_account(localnet, account)
+    with pytest.raises(au.LogicError, match="Account is not opted in to the asset"):
+        client.send.call(
+            au.AppClientMethodCallParams(
+                method="get_asset_balance_with_arg",
+                args=[holder.addr, asset_a],
+            )
+        )

--- a/tests/onchain/devportal/test_reference_app.py
+++ b/tests/onchain/devportal/test_reference_app.py
@@ -1,0 +1,123 @@
+import random
+
+import algokit_utils as au
+import pytest
+
+from tests import EXAMPLES_DIR
+from tests.utils.compile import compile_arc56
+from tests.utils.deployer import Deployer
+
+_REFERENCE_APP = EXAMPLES_DIR / "devportal" / "reference_app"
+
+# each call issues one inner ApplicationCall with fee=0
+_INNER_FEE = au.AlgoAmount.from_micro_algo(2000)
+
+_ALWAYS_APPROVE = "#pragma version 10\nint 1"
+
+
+def _deploy_reference(deployer: Deployer, known_app_id: int) -> au.AppClient:
+    """Deploy ReferenceApp with the TMPL_KNOWN_APP template variable filled."""
+    spec = compile_arc56(_REFERENCE_APP / "contract.py", contract_name="ReferenceApp")
+    factory = au.AppFactory(
+        au.AppFactoryParams(
+            algorand=deployer.localnet,
+            app_spec=spec,
+            default_sender=deployer.account.addr,
+        )
+    )
+    client, _ = factory.send.bare.create(
+        au.AppFactoryCreateParams(note=random.randbytes(8)),
+        compilation_params=au.AppClientCompilationParams(
+            deploy_time_params={"TMPL_KNOWN_APP": known_app_id}
+        ),
+    )
+    return client
+
+
+def test_increment_via_inner_known_app(deployer: Deployer) -> None:
+    """The template-provided Counter is incremented by the no-arg variant."""
+    counter = deployer.create((_REFERENCE_APP / "contract.py", "Counter")).client
+    reference = _deploy_reference(deployer, counter.app_id)
+
+    def increment() -> object:
+        return reference.send.call(
+            au.AppClientMethodCallParams(
+                method="increment_via_inner",
+                static_fee=_INNER_FEE,
+                app_references=[counter.app_id],
+                note=random.randbytes(8),
+            )
+        ).abi_return
+
+    assert increment() == 1
+    assert increment() == 2
+
+
+def test_increment_via_inner_known_app_deleted_fails(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    """A deleted app id no longer resolves, so the inner call fails."""
+    created = localnet.send.app_create(
+        au.AppCreateParams(
+            sender=account.addr,
+            approval_program=_ALWAYS_APPROVE,
+            clear_state_program=_ALWAYS_APPROVE,
+            note=random.randbytes(8),
+        )
+    )
+    app_id = created.app_id
+    assert app_id
+    localnet.send.app_delete(
+        au.AppDeleteParams(sender=account.addr, app_id=app_id, note=random.randbytes(8))
+    )
+    reference = _deploy_reference(deployer, app_id)
+
+    with pytest.raises(au.LogicError):
+        reference.send.call(
+            au.AppClientMethodCallParams(
+                method="increment_via_inner",
+                static_fee=_INNER_FEE,
+                app_references=[app_id],
+            )
+        )
+
+
+def test_increment_via_inner_with_arg(deployer: Deployer) -> None:
+    # deploy the Counter callee and the ReferenceApp caller; the template value
+    # is irrelevant for the with-arg variant but must be supplied to deploy
+    counter = deployer.create((_REFERENCE_APP / "contract.py", "Counter")).client
+    reference = _deploy_reference(deployer, counter.app_id)
+
+    def increment() -> object:
+        # note keeps otherwise-identical txns unique
+        return reference.send.call(
+            au.AppClientMethodCallParams(
+                method="increment_via_inner_with_arg",
+                args=[counter.app_id],
+                static_fee=_INNER_FEE,
+                app_references=[counter.app_id],
+                note=random.randbytes(8),
+            )
+        ).abi_return
+
+    # the inner call bumps Counter.counter and returns the new value
+    assert increment() == 1
+    assert increment() == 2
+    assert increment() == 3
+
+
+def test_increment_via_inner_with_arg_rejects_non_counter_app(
+    deployer: Deployer,
+) -> None:
+    # pointing at an app that is not a Counter fails the inner abi_call dispatch
+    reference = _deploy_reference(deployer, 0)
+
+    with pytest.raises(au.LogicError):
+        reference.send.call(
+            au.AppClientMethodCallParams(
+                method="increment_via_inner_with_arg",
+                args=[reference.app_id],  # not a Counter
+                static_fee=_INNER_FEE,
+                app_references=[reference.app_id],
+            )
+        )

--- a/tests/onchain/devportal/test_reference_asset.py
+++ b/tests/onchain/devportal/test_reference_asset.py
@@ -1,0 +1,91 @@
+import random
+
+import algokit_utils as au
+import pytest
+
+from tests import EXAMPLES_DIR
+from tests.utils.compile import compile_arc56
+from tests.utils.deployer import Deployer
+
+_REFERENCE_ASSET = EXAMPLES_DIR / "devportal" / "reference_asset"
+
+# the asset_a / asset_b fixtures create assets with this total supply
+_ASSET_TOTAL = 10_000_000
+
+
+def _deploy(deployer: Deployer, known_asset_id: int) -> au.AppClient:
+    """Deploy ReferenceAsset with the TMPL_KNOWN_ASSET template variable filled."""
+    spec = compile_arc56(_REFERENCE_ASSET)
+    factory = au.AppFactory(
+        au.AppFactoryParams(
+            algorand=deployer.localnet,
+            app_spec=spec,
+            default_sender=deployer.account.addr,
+        )
+    )
+    client, _ = factory.send.bare.create(
+        au.AppFactoryCreateParams(note=random.randbytes(8)),
+        compilation_params=au.AppClientCompilationParams(
+            deploy_time_params={"TMPL_KNOWN_ASSET": known_asset_id}
+        ),
+    )
+    return client
+
+
+def test_known_asset_total_supply(deployer: Deployer, asset_a: int) -> None:
+    """The template-provided asset's total supply is read by the no-arg variant."""
+    client = _deploy(deployer, asset_a)
+
+    result = client.send.call(au.AppClientMethodCallParams(method="get_asset_total_supply"))
+    assert result.abi_return == _ASSET_TOTAL
+
+
+def test_known_asset_destroyed_fails(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    """A destroyed asset id no longer resolves, so reading `.total` fails."""
+    created = localnet.send.asset_create(
+        au.AssetCreateParams(
+            sender=account.addr,
+            total=1,
+            manager=account.addr,  # required to be able to destroy the asset below
+            note=random.randbytes(8),
+        )
+    )
+    localnet.send.asset_destroy(
+        au.AssetDestroyParams(sender=account.addr, asset_id=created.asset_id)
+    )
+    client = _deploy(deployer, created.asset_id)
+
+    with pytest.raises(au.LogicError):
+        client.send.call(au.AppClientMethodCallParams(method="get_asset_total_supply"))
+
+
+def test_with_arg_returns_total_supply(deployer: Deployer, asset_a: int) -> None:
+    """The with-argument variant reads the real total supply of a created asset."""
+    client = _deploy(deployer, asset_a)
+
+    result = client.send.call(
+        au.AppClientMethodCallParams(
+            method="get_asset_total_supply_with_arg",
+            args=[asset_a],
+        )
+    )
+    assert result.abi_return == _ASSET_TOTAL
+
+
+def test_with_arg_works_for_multiple_assets(
+    deployer: Deployer, asset_a: int, asset_b: int
+) -> None:
+    """Each distinct asset reference returns its own total supply."""
+    client = _deploy(deployer, asset_a)
+
+    for asset_id in (asset_a, asset_b):
+        result = client.send.call(
+            au.AppClientMethodCallParams(
+                method="get_asset_total_supply_with_arg",
+                args=[asset_id],
+                note=random.randbytes(8),
+            )
+        )
+        assert result.abi_return == _ASSET_TOTAL

--- a/tests/onchain/devportal/test_reference_box.py
+++ b/tests/onchain/devportal/test_reference_box.py
@@ -1,0 +1,210 @@
+import random
+
+import algokit_utils as au
+import pytest
+from algokit_abi import abi
+
+from tests import EXAMPLES_DIR
+from tests.utils.deployer import Deployer
+
+_REFERENCE_BOX = EXAMPLES_DIR / "devportal" / "reference_box"
+
+# COUNTER_BOX_MBR: 2500 + (39 key + 8 value) * 400 = 21300
+_EXPECTED_BOX_MBR = 2_500 + (7 + 32 + 8) * 400
+
+_ADDRESS = abi.ABIType.from_string("address")
+
+
+def _counter_box_ref(addr: str) -> au.BoxReference:
+    """BoxMap(Account, ..., key_prefix="counter") stores under
+    b"counter" + <32-byte raw address>."""
+    return au.BoxReference(0, b"counter" + _ADDRESS.encode(addr))
+
+
+def _deploy(deployer: Deployer) -> au.AppClient:
+    """Deploy ReferenceBox and fund the app account with the base account MBR
+    so it can later hold box storage. Per-box MBR is still funded by the
+    grouped payment inside increment_box_counter."""
+    client = deployer.create(_REFERENCE_BOX).client
+    deployer.localnet.send.payment(
+        au.PaymentParams(
+            sender=deployer.account.addr,
+            receiver=client.app_address,
+            amount=au.AlgoAmount.from_micro_algo(100_000),
+        )
+    )
+    return client
+
+
+def test_get_box_mbr_quotes_constant(deployer: Deployer) -> None:
+    client = _deploy(deployer)
+
+    # the MBR is a compile-time constant of the fixed box layout; the readonly
+    # getter lets clients quote it instead of hard-coding the number
+    mbr = client.send.call(au.AppClientMethodCallParams(method="get_box_mbr", args=[])).abi_return
+    assert mbr == _EXPECTED_BOX_MBR
+
+
+def test_increment_box_counter_creates_and_increments(
+    deployer: Deployer, account: au.AddressWithSigners
+) -> None:
+    client = _deploy(deployer)
+    box_ref = _counter_box_ref(account.addr)
+
+    # counter starts unset -> reads back as 0
+    initial = client.send.call(
+        au.AppClientMethodCallParams(method="get_box_counter", args=[])
+    ).abi_return
+    assert initial == 0
+
+    def increment() -> object:
+        # grouped [Payment(MBR) -> AppCall]; the payment is the typed ABI arg
+        pay = au.PaymentParams(
+            sender=account.addr,
+            receiver=client.app_address,
+            amount=au.AlgoAmount.from_micro_algo(_EXPECTED_BOX_MBR),
+            note=random.randbytes(8),
+        )
+        result = client.send.call(
+            au.AppClientMethodCallParams(
+                method="increment_box_counter",
+                args=[pay],
+                box_references=[box_ref],
+                note=random.randbytes(8),
+            )
+        )
+        return result.abi_return
+
+    assert increment() == 1
+    assert increment() == 2
+    assert increment() == 3
+
+    # the readonly getter agrees with the latest value
+    current = client.send.call(
+        au.AppClientMethodCallParams(method="get_box_counter", args=[], box_references=[box_ref])
+    ).abi_return
+    assert current == 3
+
+
+def test_get_box_counter_for_account(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    client = _deploy(deployer)
+    box_ref = _counter_box_ref(account.addr)
+
+    pay = au.PaymentParams(
+        sender=account.addr,
+        receiver=client.app_address,
+        amount=au.AlgoAmount.from_micro_algo(_EXPECTED_BOX_MBR),
+    )
+    client.send.call(
+        au.AppClientMethodCallParams(
+            method="increment_box_counter",
+            args=[pay],
+            box_references=[box_ref],
+        )
+    )
+
+    # looked up by explicit account argument
+    value = client.send.call(
+        au.AppClientMethodCallParams(
+            method="get_box_counter_for_account",
+            args=[account.addr],
+            box_references=[box_ref],
+        )
+    ).abi_return
+    assert value == 1
+
+    # an account that never incremented reads back as 0
+    other = localnet.account.random()
+    other_value = client.send.call(
+        au.AppClientMethodCallParams(
+            method="get_box_counter_for_account",
+            args=[other.addr],
+            box_references=[_counter_box_ref(other.addr)],
+        )
+    ).abi_return
+    assert other_value == 0
+
+
+def test_increment_box_counter_mbr_only_required_on_creation(
+    deployer: Deployer, account: au.AddressWithSigners
+) -> None:
+    client = _deploy(deployer)
+    box_ref = _counter_box_ref(account.addr)
+
+    # first increment creates the box, so the payment must fund the MBR
+    pay = au.PaymentParams(
+        sender=account.addr,
+        receiver=client.app_address,
+        amount=au.AlgoAmount.from_micro_algo(_EXPECTED_BOX_MBR),
+    )
+    first = client.send.call(
+        au.AppClientMethodCallParams(
+            method="increment_box_counter",
+            args=[pay],
+            box_references=[box_ref],
+        )
+    ).abi_return
+    assert first == 1
+
+    # the box already exists, so a zero-amount payment is accepted
+    zero_pay = au.PaymentParams(
+        sender=account.addr,
+        receiver=client.app_address,
+        amount=au.AlgoAmount.from_micro_algo(0),
+        note=random.randbytes(8),
+    )
+    second = client.send.call(
+        au.AppClientMethodCallParams(
+            method="increment_box_counter",
+            args=[zero_pay],
+            box_references=[box_ref],
+            note=random.randbytes(8),
+        )
+    ).abi_return
+    assert second == 2
+
+
+def test_increment_box_counter_wrong_payment_amount_is_rejected(
+    deployer: Deployer, account: au.AddressWithSigners
+) -> None:
+    client = _deploy(deployer)
+    box_ref = _counter_box_ref(account.addr)
+
+    # payment does not cover the box MBR
+    pay = au.PaymentParams(
+        sender=account.addr,
+        receiver=client.app_address,
+        amount=au.AlgoAmount.from_micro_algo(_EXPECTED_BOX_MBR - 1),
+    )
+    with pytest.raises(au.LogicError, match="Payment must cover the box MBR"):
+        client.send.call(
+            au.AppClientMethodCallParams(
+                method="increment_box_counter",
+                args=[pay],
+                box_references=[box_ref],
+            )
+        )
+
+
+def test_increment_box_counter_wrong_receiver_is_rejected(
+    deployer: Deployer, account: au.AddressWithSigners
+) -> None:
+    client = _deploy(deployer)
+    box_ref = _counter_box_ref(account.addr)
+
+    # payment goes to the caller instead of the contract
+    pay = au.PaymentParams(
+        sender=account.addr,
+        receiver=account.addr,
+        amount=au.AlgoAmount.from_micro_algo(_EXPECTED_BOX_MBR),
+    )
+    with pytest.raises(au.LogicError, match="Payment must be to the contract"):
+        client.send.call(
+            au.AppClientMethodCallParams(
+                method="increment_box_counter",
+                args=[pay],
+                box_references=[box_ref],
+            )
+        )

--- a/tests/onchain/devportal/test_reject_version.py
+++ b/tests/onchain/devportal/test_reject_version.py
@@ -1,0 +1,192 @@
+import random
+
+import algokit_utils as au
+import pytest
+
+from tests import EXAMPLES_DIR
+from tests.utils.deployer import Deployer
+
+_REJECT_VERSION = EXAMPLES_DIR / "devportal" / "reject_version"
+_HELLO_WORLD = EXAMPLES_DIR / "hello_world_arc4"
+
+# call_pinned / call_checked each issue one inner ApplicationCall with fee=0
+_INNER_FEE = au.AlgoAmount.from_micro_algo(2000)
+
+_ALWAYS_APPROVE = "#pragma version 10\nint 1"
+# approve-all program that also logs an ARC-4 return value: the 0x151f7c75
+# ABI return prefix followed by the encoded string "Hello, Upgraded"
+_HELLO_UPGRADED = (
+    "#pragma version 10\n"
+    "pushbytes 0x151f7c75000f48656c6c6f2c205570677261646564\n"
+    "log\n"
+    "pushint 1"
+)
+
+
+def _deploy(deployer: Deployer) -> tuple[au.AppClient, au.AppClient]:
+    """Deploy the RejectVersion contract plus a freshly-created v0 hello target."""
+    target = deployer.create(_HELLO_WORLD).client
+    reject_version = deployer.create(_REJECT_VERSION).client
+    return reject_version, target
+
+
+def _create_raw_app(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners, approval: str
+) -> int:
+    result = localnet.send.app_create(
+        au.AppCreateParams(
+            sender=account.addr,
+            approval_program=approval,
+            clear_state_program=_ALWAYS_APPROVE,
+            note=random.randbytes(8),
+        )
+    )
+    app_id = result.app_id
+    assert app_id
+    return app_id
+
+
+def _create_upgraded_app(
+    localnet: au.AlgorandClient,
+    account: au.AddressWithSigners,
+    *,
+    updated_approval: str = _ALWAYS_APPROVE,
+) -> int:
+    """Create a raw approve-all app, then update it once so its version becomes 1."""
+    app_id = _create_raw_app(localnet, account, _ALWAYS_APPROVE)
+    localnet.send.app_update(
+        au.AppUpdateParams(
+            sender=account.addr,
+            app_id=app_id,
+            approval_program=updated_approval,
+            clear_state_program=_ALWAYS_APPROVE,
+            note=random.randbytes(8),
+        )
+    )
+    return app_id
+
+
+def test_call_pinned_invokes_target_within_version_pin(deployer: Deployer) -> None:
+    reject_version, target = _deploy(deployer)
+
+    # target is v0, so reject_version = max_version + 1 = 1 does not trip
+    result = reject_version.send.call(
+        au.AppClientMethodCallParams(
+            method="call_pinned",
+            args=[target.app_id, 0],
+            static_fee=_INNER_FEE,
+        )
+    )
+    assert result.abi_return == "Hello, World"
+
+
+def test_call_checked_rejects_unpatched_target(deployer: Deployer) -> None:
+    reject_version, target = _deploy(deployer)
+
+    # the freshly created target is version 0, i.e. still the version declared
+    # unsafe, so the minimum-version guard rejects the call
+    with pytest.raises((au.LogicError, ValueError), match="target bug has not been patched yet"):
+        reject_version.send.call(
+            au.AppClientMethodCallParams(
+                method="call_checked",
+                args=[target.app_id, 0],
+                static_fee=_INNER_FEE,
+            )
+        )
+
+
+def test_call_pinned_rejects_upgraded_target(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    reject_version = deployer.create(_REJECT_VERSION).client
+    # the target has been updated once, so it is now version 1
+    target_id = _create_upgraded_app(localnet, account)
+
+    # reject_version = max_version + 1 = 1 and version 1 >= 1, so the AVM
+    # rejects the inner call before the target's code runs
+    with pytest.raises((au.LogicError, ValueError)):
+        reject_version.send.call(
+            au.AppClientMethodCallParams(
+                method="call_pinned",
+                args=[target_id, 0],
+                static_fee=_INNER_FEE,
+            )
+        )
+
+
+def test_call_pinned_allows_target_at_version_pin_boundary(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    reject_version = deployer.create(_REJECT_VERSION).client
+    target_id = _create_upgraded_app(localnet, account, updated_approval=_HELLO_UPGRADED)
+
+    # target version (1) == max_version (1): reject_version = 2 does not trip
+    result = reject_version.send.call(
+        au.AppClientMethodCallParams(
+            method="call_pinned",
+            args=[target_id, 1],
+            static_fee=_INNER_FEE,
+        )
+    )
+    assert result.abi_return == "Hello, Upgraded"
+
+
+def test_call_checked_allows_patched_target(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    reject_version = deployer.create(_REJECT_VERSION).client
+    # the target has been updated once (version 0 -> 1), i.e. patched past
+    # the unsafe version 0, so the guard passes and the inner call runs
+    target_id = _create_upgraded_app(localnet, account, updated_approval=_HELLO_UPGRADED)
+
+    result = reject_version.send.call(
+        au.AppClientMethodCallParams(
+            method="call_checked",
+            args=[target_id, 0],
+            static_fee=_INNER_FEE,
+        )
+    )
+    assert result.abi_return == "Hello, Upgraded"
+
+
+def test_call_checked_rejects_target_at_unsafe_version_boundary(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    reject_version = deployer.create(_REJECT_VERSION).client
+    target_id = _create_upgraded_app(localnet, account, updated_approval=_HELLO_UPGRADED)
+
+    # target.version (1) is not strictly greater than unsafe_version (1):
+    # being AT the unsafe version is still unsafe, so the guard rejects
+    with pytest.raises((au.LogicError, ValueError), match="target bug has not been patched yet"):
+        reject_version.send.call(
+            au.AppClientMethodCallParams(
+                method="call_checked",
+                args=[target_id, 1],
+                static_fee=_INNER_FEE,
+            )
+        )
+
+
+def test_call_checked_fails_for_missing_app(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    reject_version = deployer.create(_REJECT_VERSION).client
+    # create then delete an app, leaving a dangling app id
+    target_id = _create_raw_app(localnet, account, _ALWAYS_APPROVE)
+    localnet.send.app_delete(
+        au.AppDeleteParams(
+            sender=account.addr,
+            app_id=target_id,
+            note=random.randbytes(8),
+        )
+    )
+
+    # reading target.version fails because the app no longer exists
+    with pytest.raises((au.LogicError, ValueError)):
+        reject_version.send.call(
+            au.AppClientMethodCallParams(
+                method="call_checked",
+                args=[target_id, 0],
+                static_fee=_INNER_FEE,
+            )
+        )

--- a/tests/onchain/devportal/test_self_payment.py
+++ b/tests/onchain/devportal/test_self_payment.py
@@ -1,0 +1,239 @@
+import hashlib
+
+import algokit_utils as au
+import pytest
+from algokit_utils.transactions.transaction_composer import TransactionComposerError
+
+from tests import EXAMPLES_DIR
+from tests.test_logic_sig import compile_logic_sig
+
+_SELF_PAYMENT = EXAMPLES_DIR / "devportal" / "self_payment" / "contract.py"
+
+# the lsig requires Txn.lease == op.sha256(b"self-payment")
+_LEASE = hashlib.sha256(b"self-payment").digest()
+
+
+def _compile(genesis_hash: bytes, last_round: int) -> bytes:
+    return compile_logic_sig(
+        _SELF_PAYMENT,
+        template_variables={
+            "TARGET_NETWORK_GENESIS": genesis_hash,
+            "LAST_ROUND": last_round,
+        },
+    )
+
+
+def _genesis_and_round(localnet: au.AlgorandClient) -> tuple[bytes, int]:
+    params = localnet.get_suggested_params()
+    return params.genesis_hash, params.last_valid
+
+
+def test_self_payment_authorizes_empty_self_payment(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    genesis_hash, last_round = _genesis_and_round(localnet)
+    bytecode = _compile(genesis_hash, last_round)
+
+    lsig = au.LogicSigAccount(logic=bytecode)
+    localnet.account.set_signer(lsig.addr, lsig.signer)
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=lsig.addr,
+            amount=au.AlgoAmount.from_algo(1),
+        )
+    )
+
+    # an empty self-payment with the expected lease, fee and last_valid round
+    result = localnet.send.payment(
+        au.PaymentParams(
+            sender=lsig.addr,
+            receiver=lsig.addr,
+            amount=au.AlgoAmount.from_micro_algo(0),
+            lease=_LEASE,
+            last_valid_round=last_round,
+            static_fee=au.AlgoAmount.from_micro_algo(1000),
+        )
+    )
+    assert result.confirmation.confirmed_round is not None
+
+
+def test_self_payment_rejects_nonzero_amount(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    genesis_hash, last_round = _genesis_and_round(localnet)
+    bytecode = _compile(genesis_hash, last_round)
+
+    lsig = au.LogicSigAccount(logic=bytecode)
+    localnet.account.set_signer(lsig.addr, lsig.signer)
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=lsig.addr,
+            amount=au.AlgoAmount.from_algo(2),
+        )
+    )
+
+    # Txn.amount == 0 is required by the lsig
+    with pytest.raises((au.LogicError, TransactionComposerError)):
+        localnet.send.payment(
+            au.PaymentParams(
+                sender=lsig.addr,
+                receiver=lsig.addr,
+                amount=au.AlgoAmount.from_micro_algo(1),
+                lease=_LEASE,
+                last_valid_round=last_round,
+                static_fee=au.AlgoAmount.from_micro_algo(1000),
+            )
+        )
+
+
+def test_self_payment_rejects_wrong_receiver(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    genesis_hash, last_round = _genesis_and_round(localnet)
+    bytecode = _compile(genesis_hash, last_round)
+
+    lsig = au.LogicSigAccount(logic=bytecode)
+    localnet.account.set_signer(lsig.addr, lsig.signer)
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=lsig.addr,
+            amount=au.AlgoAmount.from_algo(2),
+        )
+    )
+
+    # Txn.receiver must equal Txn.sender; paying to another account is rejected
+    with pytest.raises((au.LogicError, TransactionComposerError)):
+        localnet.send.payment(
+            au.PaymentParams(
+                sender=lsig.addr,
+                receiver=account.addr,
+                amount=au.AlgoAmount.from_micro_algo(0),
+                lease=_LEASE,
+                last_valid_round=last_round,
+                static_fee=au.AlgoAmount.from_micro_algo(1000),
+            )
+        )
+
+
+def test_self_payment_rejects_missing_lease(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    genesis_hash, last_round = _genesis_and_round(localnet)
+    bytecode = _compile(genesis_hash, last_round)
+
+    lsig = au.LogicSigAccount(logic=bytecode)
+    localnet.account.set_signer(lsig.addr, lsig.signer)
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=lsig.addr,
+            amount=au.AlgoAmount.from_algo(2),
+        )
+    )
+
+    # without the expected lease the lsig rejects the transaction
+    with pytest.raises((au.LogicError, TransactionComposerError)):
+        localnet.send.payment(
+            au.PaymentParams(
+                sender=lsig.addr,
+                receiver=lsig.addr,
+                amount=au.AlgoAmount.from_micro_algo(0),
+                last_valid_round=last_round,
+                static_fee=au.AlgoAmount.from_micro_algo(1000),
+            )
+        )
+
+
+def test_self_payment_rejects_wrong_fee(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    genesis_hash, last_round = _genesis_and_round(localnet)
+    bytecode = _compile(genesis_hash, last_round)
+
+    lsig = au.LogicSigAccount(logic=bytecode)
+    localnet.account.set_signer(lsig.addr, lsig.signer)
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=lsig.addr,
+            amount=au.AlgoAmount.from_algo(2),
+        )
+    )
+
+    # Txn.fee must be exactly Global.min_txn_fee
+    with pytest.raises((au.LogicError, TransactionComposerError)):
+        localnet.send.payment(
+            au.PaymentParams(
+                sender=lsig.addr,
+                receiver=lsig.addr,
+                amount=au.AlgoAmount.from_micro_algo(0),
+                lease=_LEASE,
+                last_valid_round=last_round,
+                static_fee=au.AlgoAmount.from_micro_algo(2000),
+            )
+        )
+
+
+def test_self_payment_rejects_rekey(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    genesis_hash, last_round = _genesis_and_round(localnet)
+    bytecode = _compile(genesis_hash, last_round)
+
+    lsig = au.LogicSigAccount(logic=bytecode)
+    localnet.account.set_signer(lsig.addr, lsig.signer)
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=lsig.addr,
+            amount=au.AlgoAmount.from_algo(2),
+        )
+    )
+
+    # Txn.rekey_to must be the zero address; rekeying away is rejected
+    with pytest.raises((au.LogicError, TransactionComposerError)):
+        localnet.send.payment(
+            au.PaymentParams(
+                sender=lsig.addr,
+                receiver=lsig.addr,
+                amount=au.AlgoAmount.from_micro_algo(0),
+                rekey_to=account.addr,
+                lease=_LEASE,
+                last_valid_round=last_round,
+                static_fee=au.AlgoAmount.from_micro_algo(1000),
+            )
+        )
+
+
+def test_self_payment_rejects_wrong_last_round(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    genesis_hash, last_round = _genesis_and_round(localnet)
+    # compile pinned to a LAST_ROUND that the actual txn will not match
+    bytecode = _compile(genesis_hash, last_round + 500)
+
+    lsig = au.LogicSigAccount(logic=bytecode)
+    localnet.account.set_signer(lsig.addr, lsig.signer)
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=lsig.addr,
+            amount=au.AlgoAmount.from_algo(2),
+        )
+    )
+
+    # Txn.last_valid must equal the pinned LAST_ROUND template var
+    with pytest.raises((au.LogicError, TransactionComposerError)):
+        localnet.send.payment(
+            au.PaymentParams(
+                sender=lsig.addr,
+                receiver=lsig.addr,
+                amount=au.AlgoAmount.from_micro_algo(0),
+                lease=_LEASE,
+                last_valid_round=last_round,
+                static_fee=au.AlgoAmount.from_micro_algo(1000),
+            )
+        )

--- a/tests/onchain/devportal/test_subsidize_app_call.py
+++ b/tests/onchain/devportal/test_subsidize_app_call.py
@@ -1,0 +1,288 @@
+import algokit_utils as au
+import pytest
+from algokit_utils.transactions.transaction_composer import TransactionComposerError
+
+from tests import EXAMPLES_DIR
+from tests.test_logic_sig import compile_logic_sig
+from tests.utils.deployer import Deployer
+
+_SUBSIDIZE = EXAMPLES_DIR / "devportal" / "subsidize_app_call" / "contract.py"
+_HELLO_WORLD = EXAMPLES_DIR / "hello_world_arc4"
+
+_MIN_FEE = 1000
+
+
+def _compile(genesis_hash: bytes, expiration_round: int, known_app: int) -> bytes:
+    return compile_logic_sig(
+        _SUBSIDIZE,
+        template_variables={
+            "TARGET_NETWORK_GENESIS": genesis_hash,
+            "EXPIRATION_ROUND": expiration_round,
+            "KNOWN_APP": known_app,
+        },
+    )
+
+
+def _genesis_and_round(localnet: au.AlgorandClient) -> tuple[bytes, int]:
+    params = localnet.get_suggested_params()
+    return params.genesis_hash, params.last_valid
+
+
+def _fund_lsig(
+    localnet: au.AlgorandClient, account: au.AddressWithSigners, lsig: au.LogicSigAccount
+) -> None:
+    localnet.account.set_signer(lsig.addr, lsig.signer)
+    localnet.send.payment(
+        au.PaymentParams(
+            sender=account.addr,
+            receiver=lsig.addr,
+            amount=au.AlgoAmount.from_algo(1),
+        )
+    )
+
+
+def test_subsidize_authorizes_fee_for_known_app_call(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    target = deployer.create(_HELLO_WORLD).client
+    genesis_hash, last_round = _genesis_and_round(localnet)
+    bytecode = _compile(genesis_hash, last_round + 1000, target.app_id)
+
+    lsig = au.LogicSigAccount(logic=bytecode)
+    _fund_lsig(localnet, account, lsig)
+
+    # group: [app call to KNOWN_APP with fee=0, self-payment from lsig with fee=2*min]
+    result = (
+        localnet.new_group()
+        .add_app_call_method_call(
+            target.params.call(
+                au.AppClientMethodCallParams(
+                    method="hello",
+                    args=["subsidized"],
+                    static_fee=au.AlgoAmount.from_micro_algo(0),
+                )
+            )
+        )
+        .add_payment(
+            au.PaymentParams(
+                sender=lsig.addr,
+                receiver=lsig.addr,
+                amount=au.AlgoAmount.from_micro_algo(0),
+                static_fee=au.AlgoAmount.from_micro_algo(2 * _MIN_FEE),
+            )
+        )
+        .send()
+    )
+    assert result.confirmations[-1].confirmed_round is not None
+    assert result.returns[0].value == "Hello, subsidized"
+
+
+def test_subsidize_rejects_unknown_app(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    target = deployer.create(_HELLO_WORLD).client
+    other = deployer.create(_HELLO_WORLD).client
+    genesis_hash, last_round = _genesis_and_round(localnet)
+    # lsig is pinned to `target`, but the group calls `other`
+    bytecode = _compile(genesis_hash, last_round + 1000, target.app_id)
+
+    lsig = au.LogicSigAccount(logic=bytecode)
+    _fund_lsig(localnet, account, lsig)
+
+    with pytest.raises((au.LogicError, TransactionComposerError)):
+        (
+            localnet.new_group()
+            .add_app_call_method_call(
+                other.params.call(
+                    au.AppClientMethodCallParams(
+                        method="hello",
+                        args=["x"],
+                        static_fee=au.AlgoAmount.from_micro_algo(0),
+                    )
+                )
+            )
+            .add_payment(
+                au.PaymentParams(
+                    sender=lsig.addr,
+                    receiver=lsig.addr,
+                    amount=au.AlgoAmount.from_micro_algo(0),
+                    static_fee=au.AlgoAmount.from_micro_algo(2 * _MIN_FEE),
+                )
+            )
+            .send()
+        )
+
+
+def test_subsidize_rejects_when_app_call_pays_own_fee(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    target = deployer.create(_HELLO_WORLD).client
+    genesis_hash, last_round = _genesis_and_round(localnet)
+    bytecode = _compile(genesis_hash, last_round + 1000, target.app_id)
+
+    lsig = au.LogicSigAccount(logic=bytecode)
+    _fund_lsig(localnet, account, lsig)
+
+    # the lsig requires the preceding app call's fee to be 0, so a self-paying
+    # app call must be rejected
+    with pytest.raises((au.LogicError, TransactionComposerError)):
+        (
+            localnet.new_group()
+            .add_app_call_method_call(
+                target.params.call(
+                    au.AppClientMethodCallParams(
+                        method="hello",
+                        args=["x"],
+                        static_fee=au.AlgoAmount.from_micro_algo(_MIN_FEE),
+                    )
+                )
+            )
+            .add_payment(
+                au.PaymentParams(
+                    sender=lsig.addr,
+                    receiver=lsig.addr,
+                    amount=au.AlgoAmount.from_micro_algo(0),
+                    static_fee=au.AlgoAmount.from_micro_algo(2 * _MIN_FEE),
+                )
+            )
+            .send()
+        )
+
+
+def test_subsidize_rejects_wrong_fee(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    target = deployer.create(_HELLO_WORLD).client
+    genesis_hash, last_round = _genesis_and_round(localnet)
+    bytecode = _compile(genesis_hash, last_round + 1000, target.app_id)
+
+    lsig = au.LogicSigAccount(logic=bytecode)
+    _fund_lsig(localnet, account, lsig)
+
+    # lsig payment fee must be exactly 2 * min_txn_fee
+    with pytest.raises((au.LogicError, TransactionComposerError)):
+        (
+            localnet.new_group()
+            .add_app_call_method_call(
+                target.params.call(
+                    au.AppClientMethodCallParams(
+                        method="hello",
+                        args=["x"],
+                        static_fee=au.AlgoAmount.from_micro_algo(0),
+                    )
+                )
+            )
+            .add_payment(
+                au.PaymentParams(
+                    sender=lsig.addr,
+                    receiver=lsig.addr,
+                    amount=au.AlgoAmount.from_micro_algo(0),
+                    static_fee=au.AlgoAmount.from_micro_algo(3 * _MIN_FEE),
+                )
+            )
+            .send()
+        )
+
+
+def test_subsidize_rejects_when_preceding_txn_not_app_call(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    target = deployer.create(_HELLO_WORLD).client
+    genesis_hash, last_round = _genesis_and_round(localnet)
+    bytecode = _compile(genesis_hash, last_round + 1000, target.app_id)
+
+    lsig = au.LogicSigAccount(logic=bytecode)
+    _fund_lsig(localnet, account, lsig)
+
+    # the typed gtxn parameter's implicit type assertion fails outright when
+    # the preceding group transaction is a Payment rather than an app call
+    with pytest.raises((au.LogicError, TransactionComposerError)):
+        (
+            localnet.new_group()
+            .add_payment(
+                au.PaymentParams(
+                    sender=account.addr,
+                    receiver=account.addr,
+                    amount=au.AlgoAmount.from_micro_algo(0),
+                )
+            )
+            .add_payment(
+                au.PaymentParams(
+                    sender=lsig.addr,
+                    receiver=lsig.addr,
+                    amount=au.AlgoAmount.from_micro_algo(0),
+                    static_fee=au.AlgoAmount.from_micro_algo(2 * _MIN_FEE),
+                )
+            )
+            .send()
+        )
+
+
+def test_subsidize_rejects_nonzero_amount(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    target = deployer.create(_HELLO_WORLD).client
+    genesis_hash, last_round = _genesis_and_round(localnet)
+    bytecode = _compile(genesis_hash, last_round + 1000, target.app_id)
+
+    lsig = au.LogicSigAccount(logic=bytecode)
+    _fund_lsig(localnet, account, lsig)
+
+    # the lsig payment must be an empty self-payment (Txn.amount == 0)
+    with pytest.raises((au.LogicError, TransactionComposerError)):
+        (
+            localnet.new_group()
+            .add_app_call_method_call(
+                target.params.call(
+                    au.AppClientMethodCallParams(
+                        method="hello",
+                        args=["x"],
+                        static_fee=au.AlgoAmount.from_micro_algo(0),
+                    )
+                )
+            )
+            .add_payment(
+                au.PaymentParams(
+                    sender=lsig.addr,
+                    receiver=lsig.addr,
+                    amount=au.AlgoAmount.from_micro_algo(1),
+                    static_fee=au.AlgoAmount.from_micro_algo(2 * _MIN_FEE),
+                )
+            )
+            .send()
+        )
+
+
+def test_subsidize_rejects_expired_lsig(
+    deployer: Deployer, localnet: au.AlgorandClient, account: au.AddressWithSigners
+) -> None:
+    target = deployer.create(_HELLO_WORLD).client
+    genesis_hash, last_round = _genesis_and_round(localnet)
+    # EXPIRATION_ROUND is far in the past, so Txn.last_valid <= EXPIRATION fails
+    bytecode = _compile(genesis_hash, 1, target.app_id)
+
+    lsig = au.LogicSigAccount(logic=bytecode)
+    _fund_lsig(localnet, account, lsig)
+
+    with pytest.raises((au.LogicError, TransactionComposerError)):
+        (
+            localnet.new_group()
+            .add_app_call_method_call(
+                target.params.call(
+                    au.AppClientMethodCallParams(
+                        method="hello",
+                        args=["x"],
+                        static_fee=au.AlgoAmount.from_micro_algo(0),
+                    )
+                )
+            )
+            .add_payment(
+                au.PaymentParams(
+                    sender=lsig.addr,
+                    receiver=lsig.addr,
+                    amount=au.AlgoAmount.from_micro_algo(0),
+                    static_fee=au.AlgoAmount.from_micro_algo(2 * _MIN_FEE),
+                )
+            )
+            .send()
+        )

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -120,6 +120,7 @@ class PuyaTestCase:
 
 
 def get_test_cases() -> list[PuyaTestCase]:
+    # non-recursive: grouped subtrees like examples/devportal/* are excluded
     return [
         PuyaTestCase(item)
         for root in (EXAMPLES_DIR, TEST_CASES_DIR, AWST_DIR)


### PR DESCRIPTION
As the title says, we are bringing all devportal examples into Puya to aid with keeping them up to date with the latest language versions.
This work also included bumping said examples, and adding some for the newest (up to AVM 12) language features.

Both examples and tests are kept intentionally separate so as to not add extra compilation artifacts for redundant patterns.